### PR TITLE
Use ginkgo for UTs

### DIFF
--- a/plugin/plugin_suite_test.go
+++ b/plugin/plugin_suite_test.go
@@ -1,0 +1,13 @@
+package lighthouse
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestPlugin(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Plugin Suite")
+}

--- a/plugin/setup_test.go
+++ b/plugin/setup_test.go
@@ -1,21 +1,24 @@
 package lighthouse
 
 import (
-	"testing"
-
 	"github.com/mholt/caddy"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
-// TestSetup tests the various things that should be parsed by setup.
-// Make sure you also test for parse errors.
-func TestSetup(t *testing.T) {
-	c := caddy.NewTestController("dns", `lighthouse`)
-	if err := setupLighthouse(c); err != nil {
-		t.Fatalf("Expected no errors, but got: %v", err)
-	}
+var _ = Describe("[setup] Test basic bring up", func() {
 
-	c = caddy.NewTestController("dns", `lighthouse more`)
-	if err := setupLighthouse(c); err == nil {
-		t.Fatalf("Expected errors, but got: %v", err)
-	}
-}
+	It("Should come up without errors", func() {
+		c := caddy.NewTestController("dns", `lighthouse`)
+		err := setupLighthouse(c)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Should give error on setup", func() {
+		c := caddy.NewTestController("dns", `lighthouse more`)
+		err := setupLighthouse(c)
+		Expect(err).To(HaveOccurred())
+	})
+
+})


### PR DESCRIPTION
changed the setup_test.go to ginkgo. For now I have to run this from plugin root. Is this the correct way?