### PR TITLE
Coredns custom plugin fix

### DIFF
--- a/scripts/build-coredns
+++ b/scripts/build-coredns
@@ -19,7 +19,7 @@ BUILD_DIR="build/linux/amd64"
 cd ${TOPDIR}
 git clone -b v${COREDNS_VERSION} ${COREDNS_GIT}
 cd ${TOPDIR}/coredns
-sed -i "\$alighthouse:github.com/submariner-io/lighthouse/plugin/lighthouse" plugin.cfg
+sed -i '/^kubernetes:kubernetes/a lighthouse:github.com/submariner-io/lighthouse/plugin/lighthouse' plugin.cfg
 go mod vendor
 mkdir -p ${TOPDIR}/coredns/vendor/github.com/submariner-io/lighthouse/plugin/ ${BUILD_DIR}
 cp -R ${TOPDIR}/plugin ${TOPDIR}/coredns/vendor/github.com/submariner-io/lighthouse/

--- a/scripts/validate
+++ b/scripts/validate
@@ -10,8 +10,8 @@ EXCLUDE_PKG_DIRS=".git .tmp .trash-cache vendor bin"
 PACKAGES=$(find_go_pkg_dirs --no-trailing-dots "*.go")
 
 if [[ $(goimports -l ${PACKAGES} | wc -l) -gt 0 ]]; then
+    echo "Incorrect formatting, please run goimports and check the following files:"
     goimports -l ${PACKAGES}
-    echo Incorrect formatting, please run goimports
     exit 1
 fi
 


### PR DESCRIPTION
1. Add lighthouse coredns plugin after kubernetes plugin and not in the end of the plugins.cfg file.
2. Improve make validate troubleshooting with better output.