### PR TITLE
Move MultiClusterServiceMap and controller to common package

### DIFF
--- a/pkg/multiclusterservice/map.go
+++ b/pkg/multiclusterservice/map.go
@@ -1,4 +1,4 @@
-package lighthouse
+package multiclusterservice
 
 import (
 	"sync"
@@ -6,11 +6,11 @@ import (
 	lighthousev1 "github.com/submariner-io/lighthouse/pkg/apis/lighthouse.submariner.io/v1"
 )
 
-type multiClusterServiceMap struct {
+type Map struct {
 	syncMap sync.Map
 }
 
-func (m *multiClusterServiceMap) get(namespace, name string) (*lighthousev1.MultiClusterService, bool) {
+func (m *Map) Get(namespace, name string) (*lighthousev1.MultiClusterService, bool) {
 	value, ok := m.syncMap.Load(keyFunc(namespace, name))
 	if ok {
 		return value.(*lighthousev1.MultiClusterService), true
@@ -19,11 +19,11 @@ func (m *multiClusterServiceMap) get(namespace, name string) (*lighthousev1.Mult
 	return nil, false
 }
 
-func (m *multiClusterServiceMap) put(mcs *lighthousev1.MultiClusterService) {
+func (m *Map) Put(mcs *lighthousev1.MultiClusterService) {
 	m.syncMap.Store(keyFunc(mcs.Namespace, mcs.Name), mcs)
 }
 
-func (m *multiClusterServiceMap) remove(namespace, name string) {
+func (m *Map) Remove(namespace, name string) {
 	m.syncMap.Delete(keyFunc(namespace, name))
 }
 

--- a/pkg/multiclusterservice/suite_test.go
+++ b/pkg/multiclusterservice/suite_test.go
@@ -1,0 +1,13 @@
+package multiclusterservice
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMultiClusterService(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "MultiClusterService Suite")
+}

--- a/plugin/lighthouse/handler.go
+++ b/plugin/lighthouse/handler.go
@@ -46,7 +46,7 @@ func (lh *Lighthouse) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns
 	query := strings.Split(qname, ".")
 	svcName := query[0]
 	namespace := query[1]
-	service, found := lh.multiClusterServices.get(namespace, svcName)
+	service, found := lh.multiClusterServices.Get(namespace, svcName)
 
 	if !found || len(service.Spec.Items) == 0 {
 		// We couldn't find record for this service name

--- a/plugin/lighthouse/handler_test.go
+++ b/plugin/lighthouse/handler_test.go
@@ -10,6 +10,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
+	lighthousev1 "github.com/submariner-io/lighthouse/pkg/apis/lighthouse.submariner.io/v1"
+	v1 "github.com/submariner-io/lighthouse/pkg/apis/lighthouse.submariner.io/v1"
+	"github.com/submariner-io/lighthouse/pkg/multiclusterservice"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -63,7 +67,7 @@ func testWithoutFallback() {
 
 	When("type A DNS query for an existing service with a different namespace", func() {
 		It("should succeed and write an A record response", func() {
-			lh.multiClusterServices.put(newMultiClusterService(namespace2, service1, serviceIP, "clusterID"))
+			lh.multiClusterServices.Put(newMultiClusterService(namespace2, service1, serviceIP, "clusterID"))
 			executeTestCase(lh, rec, test.Case{
 				Qname: service1 + "." + namespace2 + ".svc.cluster.local.",
 				Qtype: dns.TypeA,
@@ -221,8 +225,25 @@ func executeTestCase(lh *Lighthouse, rec *dnstest.Recorder, tc test.Case) {
 	}
 }
 
-func setupMultiClusterServiceMap() *multiClusterServiceMap {
-	mcsMap := new(multiClusterServiceMap)
-	mcsMap.put(newMultiClusterService(namespace1, service1, serviceIP, "clusterID"))
+func setupMultiClusterServiceMap() *multiclusterservice.Map {
+	mcsMap := new(multiclusterservice.Map)
+	mcsMap.Put(newMultiClusterService(namespace1, service1, serviceIP, "clusterID"))
 	return mcsMap
+}
+
+func newMultiClusterService(namespace, name, serviceIP, clusterID string) *v1.MultiClusterService {
+	return &lighthousev1.MultiClusterService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: lighthousev1.MultiClusterServiceSpec{
+			Items: []lighthousev1.ClusterServiceInfo{
+				lighthousev1.ClusterServiceInfo{
+					ClusterID: clusterID,
+					ServiceIP: serviceIP,
+				},
+			},
+		},
+	}
 }

--- a/plugin/lighthouse/lighthouse.go
+++ b/plugin/lighthouse/lighthouse.go
@@ -6,6 +6,7 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/fall"
 	clog "github.com/coredns/coredns/plugin/pkg/log"
+	"github.com/submariner-io/lighthouse/pkg/multiclusterservice"
 )
 
 const (
@@ -25,7 +26,7 @@ type Lighthouse struct {
 	Next                 plugin.Handler
 	Fall                 fall.F
 	Zones                []string
-	multiClusterServices *multiClusterServiceMap
+	multiClusterServices *multiclusterservice.Map
 }
 
 var _ plugin.Handler = &Lighthouse{}

--- a/plugin/lighthouse/setup.go
+++ b/plugin/lighthouse/setup.go
@@ -7,6 +7,7 @@ import (
 	"github.com/caddyserver/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
+	"github.com/submariner-io/lighthouse/pkg/multiclusterservice"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -51,16 +52,16 @@ func lighthouseParse(c *caddy.Controller) (*Lighthouse, error) {
 		return nil, fmt.Errorf("error building kubeconfig: %v", err)
 	}
 
-	mcsMap := new(multiClusterServiceMap)
-	dnsController := newController(mcsMap)
+	mcsMap := new(multiclusterservice.Map)
+	mcsController := multiclusterservice.NewController(mcsMap)
 
-	err = dnsController.start(cfg)
+	err = mcsController.Start(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("error starting the controller: %v", err)
 	}
 
 	c.OnShutdown(func() error {
-		dnsController.stop()
+		mcsController.Stop()
 		return nil
 	})
 


### PR DESCRIPTION
So it can be reused by the CoreDNS plugin and new standalone DNS server.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>