### PR TITLE
Base CI container on common submariner/dapper-base

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,59 +1,8 @@
-FROM ubuntu:16.04
+FROM quay.io/submariner/dapper-base
 
-ARG DAPPER_HOST_ARCH
-ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} DAPPER_ENV=REPO DAPPER_ENV=TAG \
+ENV DAPPER_ENV=REPO DAPPER_ENV=TAG \
     DAPPER_SOURCE=/go/src/github.com/submariner-io/lighthouse DAPPER_DOCKER_SOCKET=true \
     TRASH_CACHE=${DAPPER_SOURCE}/.trash-cache HOME=${DAPPER_SOURCE} DAPPER_OUTPUT=output
-
-RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh
-
-ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
-    GOPATH=/go GO111MODULE=on PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
-
-# Requirements:
-# Component       | Usage
-# -----------------------------------------------------------
-# gcc             | ginkgo
-# git             | find the workspace root
-# curl            | download other tools
-# docker.io       | Dapper
-# make            | coredns make
-# golang          | build
-# kubectl         | e2e tests
-# golangci-lint   | code linting
-# helm            | e2e tests
-# kubefedctl      | e2e tests
-# kind            | e2e tests
-# ginkgo          | tests
-# goimports       | code formatting
-
-RUN apt-get -q update && \
-    apt-get install -y gcc git curl docker.io make
-
-ENV GO_VERSION=1.12.6
-RUN curl https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    GOFLAGS="" go get -v github.com/onsi/ginkgo/ginkgo && \
-    GOFLAGS="" go get -v golang.org/x/tools/cmd/goimports
-
-RUN curl -Lo /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${ARCH}/kubectl && \
-    chmod a+x /usr/bin/kubectl
-
-ENV HELM_VERSION=v2.14.1
-RUN curl "https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" | tar -xzf - && \
-    cp linux-${ARCH}/helm /usr/bin/ && \
-    chmod a+x /usr/bin/helm
-
-ENV LINT_VERSION=v1.17.1
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin ${LINT_VERSION}
-
-ENV KUBEFED_VERSION=0.1.0-rc2
-RUN curl -LO "https://github.com/kubernetes-sigs/kubefed/releases/download/v${KUBEFED_VERSION}/kubefedctl-${KUBEFED_VERSION}-linux-${ARCH}.tgz" && \
-    tar -xzf kubefedctl-${KUBEFED_VERSION}-linux-${ARCH}.tgz && \
-    cp kubefedctl /usr/bin/ && \
-    chmod a+x /usr/bin/kubefedctl
-
-ENV KIND_VERSION=v0.4.0
-RUN curl -Lo /usr/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}" && chmod a+x /usr/bin/kind
 
 WORKDIR ${DAPPER_SOURCE}
 


### PR DESCRIPTION
Reuse the submariner/dapper-base image as a shared/common foundation for
CI, vs duplicating tooling install and version maintains logic here.

Will support further de-duplicating other e2e scripts, per #369.

Results in a conversion to Fedora from Ubuntu as a side-effect.

Closes: #69

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>