### PR TITLE
Use controller-runtime signals lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,11 +12,11 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/submariner-io/admiral v0.0.0-20190829090417-2e381e854f60
 	github.com/submariner-io/shipyard v0.0.0-20200324112155-1429f74326da
-	github.com/submariner-io/submariner v0.1.0
 	k8s.io/api v0.0.0-20190313235455-40a48860b5ab
 	k8s.io/apimachinery v0.0.0-20190629003722-e20a3a656cff
 	k8s.io/client-go v11.0.0+incompatible
 	k8s.io/klog v0.3.3
+	sigs.k8s.io/controller-runtime v0.1.12
 )
 
 replace github.com/bronze1man/goStrongswanVici => github.com/mangelajo/goStrongswanVici v0.0.0-20190701121157-9a5ae4453bda

--- a/go.sum
+++ b/go.sum
@@ -256,10 +256,6 @@ github.com/submariner-io/shipyard v0.0.0-20200322060547-ffcda8757e51 h1:9nx5T+Nf
 github.com/submariner-io/shipyard v0.0.0-20200322060547-ffcda8757e51/go.mod h1:tm9TSwLsOFQxsOgbXCC4EpPQF01K4fsxUJaV+0rn4pI=
 github.com/submariner-io/shipyard v0.0.0-20200324112155-1429f74326da h1:UdL2BuLqaFepyEI9BpSVZBYsxIF19hTxPkKbYohJtuM=
 github.com/submariner-io/shipyard v0.0.0-20200324112155-1429f74326da/go.mod h1:tm9TSwLsOFQxsOgbXCC4EpPQF01K4fsxUJaV+0rn4pI=
-github.com/submariner-io/submariner v0.0.2-0.20190828132721-a11a9a84c90d h1:IWLdQxR9mDgVNEBTyI0cjFNn8AXiLkRIPw5grQGTtzs=
-github.com/submariner-io/submariner v0.0.2-0.20190828132721-a11a9a84c90d/go.mod h1:CTCPMZnhq6v/2+iMNcyED6TI6RjU8r+m0XIkNe1PkEo=
-github.com/submariner-io/submariner v0.1.0 h1:qyaloepsAfqrSRkkCNNDUGRz2XMAke0tg5px7mfWxSU=
-github.com/submariner-io/submariner v0.1.0/go.mod h1:CUeiMmxtT5UfYynBy4NECqLy/NoTROVaxcG3SIotF94=
 github.com/tinylib/msgp v1.1.0/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=

--- a/pkg/dnsserver/main.go
+++ b/pkg/dnsserver/main.go
@@ -7,9 +7,9 @@ import (
 	"github.com/miekg/dns"
 	"github.com/submariner-io/lighthouse/pkg/dnsserver/handler"
 	"github.com/submariner-io/lighthouse/pkg/multiclusterservice"
-	"github.com/submariner-io/submariner/pkg/signals"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
 var (

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -8,10 +8,10 @@ import (
 	"github.com/submariner-io/admiral/pkg/federate/kubefed"
 	multiclusterservice "github.com/submariner-io/lighthouse/pkg/apis/lighthouse.submariner.io/v1"
 	"github.com/submariner-io/lighthouse/pkg/controller"
-	"github.com/submariner-io/submariner/pkg/signals"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
 var kubeConfig string


### PR DESCRIPTION
The signals code exists in k8s controller-runtime so use that instead
of the submariner copy which is being removed. In addition, the submariner
go.mod dependency can now be removed.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>