### PR TITLE
Add Lighthouse Agent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/caddyserver/caddy v1.0.5
 	github.com/coredns/coredns v1.5.2
 	github.com/golang/mock v1.3.1
+	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/miekg/dns v1.1.29
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,7 @@ github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod 
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115/go.mod h1:zVt7zX3K/aDCk9Tj+VM7YymsX66ERvzCJzw8rFCX2JU=
 github.com/caddyserver/caddy v1.0.1 h1:oor6ep+8NoJOabpFXhvjqjfeldtw1XSzfISVrbfqTKo=
@@ -182,6 +183,7 @@ github.com/hashicorp/golang-lru v0.0.0-20180201235237-0fb14efe8c47/go.mod h1:/m3
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.3 h1:YPkqC67at8FYaadspW/6uE0COsBxS2656RLEr8Bppgk=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -206,6 +208,7 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kelseyhightower/envconfig v1.3.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -313,6 +316,7 @@ github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
 github.com/prometheus/client_golang v1.0.0 h1:vrDKnkGzuGvhNAL56c7DBz29ZL+KxnoR0x7enabFceM=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
+github.com/prometheus/client_golang v1.1.0 h1:BQ53HtBmfOitExawJ6LokA4x8ov/z0SYYb0+HxJfRI8=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -326,6 +330,7 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2 h1:6LJUbpNm42llc4HRCuvApCSWB/WfhuNo9K98Q9sNGfs=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
+github.com/prometheus/procfs v0.0.3 h1:CTwfnzjQ+8dS6MhHHu4YswVAD99sL2wjPqP+VkURmKE=
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/rainycape/memcache v0.0.0-20150622160815-1031fa0ce2f2/go.mod h1:7tZKcyumwBO6qip7RNQ5r77yrssm9bfCowcLEBcU5IA=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
@@ -367,6 +372,7 @@ github.com/transip/gotransip v0.0.0-20190812104329-6d8d9179b66f/go.mod h1:i0f4R4
 github.com/uber-go/atomic v1.3.2/go.mod h1:/Ct5t2lcmbJ4OSe/waGBoaVvVqtO0bmtfVNex1PFV8g=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
+github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vultr/govultr v0.1.4/go.mod h1:9H008Uxr/C4vFNGLqKx232C206GL0PBHzOP0809bGNA=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
@@ -437,6 +443,7 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478 h1:l5EDrHhldLYb3ZRHDUhXF7Om7MvYXnkV9/iQNo1lX6g=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190930134127-c5a3c61f89f3/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191027093000-83d349e8ac1a h1:Yu34BogBivvmu7SAzHHaB9nZWH5D1C+z3F1jyIaYZSQ=
 golang.org/x/net v0.0.0-20191027093000-83d349e8ac1a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20170412232759-a6bd8cefa181/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -469,6 +476,7 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190618155005-516e3c20635f h1:dHNZYIYdq2QuU6w73vZ/DzesPbVlZVYZTtTZmrnsbQ8=
 golang.org/x/sys v0.0.0-20190618155005-516e3c20635f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0 h1:HyfiK1WMnHj5FXFXatD+Qs1A/xC2Run6RzeW1SyHxpc=
@@ -487,6 +495,7 @@ golang.org/x/time v0.0.0-20161028155119-f51c12702a4d/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0 h1:xQwXv67TxFo9nC1GJFyab5eq/5B590r6RlnL/G8Sz7w=
 golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -504,6 +513,7 @@ golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20191216052735-49a3e744a425/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
@@ -576,6 +586,8 @@ k8s.io/apimachinery v0.0.0-20190629003722-e20a3a656cff h1:xDwHiDiMvjKW1AJRktBdhL
 k8s.io/apimachinery v0.0.0-20190629003722-e20a3a656cff/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
 k8s.io/client-go v0.0.0-20190521190702-177766529176 h1:gI8ZMlH24D7c30GMAbiwG8hK9l80yvqiiBLaDbRS/Gc=
 k8s.io/client-go v0.0.0-20190521190702-177766529176/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
+k8s.io/client-go v11.0.0+incompatible h1:LBbX2+lOwY9flffWlJM7f1Ct8V2SRNiMRDFeiwnJo9o=
+k8s.io/client-go v11.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/klog v0.0.0-20181108234604-8139d8cb77af/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.3 h1:niceAagH1tzskmaie/icWd7ci1wbG7Bf2c6YGcQv+3c=
@@ -585,6 +597,7 @@ k8s.io/klog v0.4.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/kube-openapi v0.0.0-20181109181836-c59034cc13d5/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/kube-openapi v0.0.0-20190306001800-15615b16d372 h1:zia7dTzfEtdiSUxi9cXUDsSQH2xE6igmGKyFn2on/9A=
 k8s.io/kube-openapi v0.0.0-20190306001800-15615b16d372/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
+k8s.io/utils v0.0.0-20190529001817-6999998975a7 h1:5UOdmwfY+7XsXvo26XeCDu9GhHJPkO1z8Mcz5AHMnOE=
 k8s.io/utils v0.0.0-20190529001817-6999998975a7/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/controller-runtime v0.1.12 h1:ovDq28E64PeY1yR+6H7DthakIC09soiDCrKvfP2tPYo=

--- a/package/Dockerfile.agent
+++ b/package/Dockerfile.agent
@@ -1,0 +1,11 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+WORKDIR /var/submariner
+
+COPY lighthouse-agent.sh /usr/local/bin
+
+RUN chmod +x /usr/local/bin/lighthouse-agent.sh
+
+COPY lighthouse-agent /usr/local/bin
+
+ENTRYPOINT lighthouse-agent.sh

--- a/package/lighthouse-agent-deployment.yaml
+++ b/package/lighthouse-agent-deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: submariner-lighthouse
+  namespace: submariner-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: submariner:lighthouse
+  namespace: submariner-operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - '*'
+    resources:
+      - nodes
+    verbs:
+      - 'get'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: submariner:lighthouse
+  namespace: submariner-operator
+subjects:
+  - kind: ServiceAccount
+    name: submariner-lighthouse
+    namespace: submariner-operator
+roleRef:
+  kind: ClusterRole
+  name: submariner:lighthouse
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lighthouse-agent
+  namespace: submariner-operator
+  labels:
+    app: lighthouse-agent
+spec:
+  selector:
+    matchLabels:
+      app: lighthouse-agent
+  template:
+    metadata:
+      labels:
+        app: lighthouse-agent
+    spec:
+      containers:
+      - name: lighthouse-agent
+        image: lighthouse-agent:local
+      serviceAccount: submariner:lighthouse
+      serviceAccountName: submariner-lighthouse

--- a/package/lighthouse-agent.sh
+++ b/package/lighthouse-agent.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e -x
+
+trap "exit 1" SIGTERM SIGINT
+
+if [ "${LIGHTHOUSE_DEBUG}" == "true" ]; then
+    DEBUG="--debug -v=9"
+else
+    DEBUG="-v=4"
+fi
+
+exec lighthouse-agent ${DEBUG} -alsologtostderr

--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -1,0 +1,205 @@
+package controller
+
+import (
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+)
+
+const (
+	submarinerIpamGlobalIp = "submariner.io/globalIp"
+)
+
+var excludeSvcList = map[string]bool{"kubernetes": true, "openshift": true}
+
+func New(spec *AgentSpecification, config InformerConfigStruct) *Controller {
+	exclusionNSMap := map[string]bool{"kube-system": true, "submariner": true, "openshift": true,
+		"submariner-operator": true, "kubefed-operator": true}
+	for _, v := range spec.ExcludeNS {
+		exclusionNSMap[v] = true
+	}
+	agentController := &Controller{
+		kubeClientSet:    config.KubeClientSet,
+		serviceWorkqueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Services"),
+		servicesSynced:   config.ServiceInformer.Informer().HasSynced,
+
+		excludeNamespaces: exclusionNSMap,
+	}
+
+	klog.Info("Setting up event handlers")
+	config.ServiceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: agentController.enqueueService,
+		UpdateFunc: func(old, newObj interface{}) {
+			agentController.handleUpdateService(old, newObj)
+		},
+		DeleteFunc: agentController.handleRemovedService,
+	})
+
+	return agentController
+}
+
+func (a *Controller) Run(stopCh <-chan struct{}) error {
+	defer utilruntime.HandleCrash()
+
+	// Start the informer factories to begin populating the informer caches
+	klog.Info("Starting Agent controller")
+
+	// Wait for the caches to be synced before starting workers
+	klog.Info("Waiting for informer caches to sync")
+	if ok := cache.WaitForCacheSync(stopCh, a.servicesSynced); !ok {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+
+	go wait.Until(a.runServiceWorker, time.Second, stopCh)
+	klog.Info("Lighthouse agent workers started")
+	<-stopCh
+	klog.Info("Lighthouse Agent stopping")
+	return nil
+}
+
+func (a *Controller) enqueueService(obj interface{}) {
+	if key := a.getEnqueueKey(obj); key != "" {
+		klog.V(4).Infof("Enqueueing service %v for agent", key)
+		a.serviceWorkqueue.AddRateLimited(key)
+	}
+}
+
+func (a *Controller) getEnqueueKey(obj interface{}) string {
+	var key string
+	var err error
+	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
+		utilruntime.HandleError(err)
+		return ""
+	}
+	ns, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		utilruntime.HandleError(err)
+		return ""
+	}
+	if !a.isValidService(ns, name) {
+		return ""
+	}
+	return key
+}
+
+func (a *Controller) isValidService(namespace string, serviceName string) bool {
+	if a.excludeNamespaces[namespace] || excludeSvcList[serviceName] {
+		return false
+	}
+	return true
+}
+
+func (a *Controller) runServiceWorker() {
+	for a.processNextService() {
+
+	}
+}
+
+func (a *Controller) processNextService() bool {
+	obj, shutdown := a.serviceWorkqueue.Get()
+	if shutdown {
+		return false
+	}
+	err := func() error {
+		defer a.serviceWorkqueue.Done(obj)
+
+		key := obj.(string)
+		ns, name, err := cache.SplitMetaNamespaceKey(key)
+		if err != nil {
+			a.serviceWorkqueue.Forget(obj)
+			return fmt.Errorf("error while splitting meta namespace key %s: %v", key, err)
+		}
+
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			// Retrieve the latest version of object before attempting update
+			// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
+			service, err := a.kubeClientSet.CoreV1().Services(ns).Get(name, metav1.GetOptions{})
+
+			if err != nil {
+				if errors.IsNotFound(err) {
+					// already deleted Forget and return
+					return nil
+				}
+				return fmt.Errorf("error retrieving service %s: %v", name, err)
+			}
+
+			return a.serviceUpdater(service, key)
+		})
+
+		if retryErr != nil {
+			logAndRequeue(key, a.serviceWorkqueue)
+		}
+
+		a.serviceWorkqueue.Forget(obj)
+		return nil
+	}()
+
+	if err != nil {
+		utilruntime.HandleError(err)
+		return true
+	}
+
+	return true
+}
+
+func (a *Controller) handleUpdateService(old interface{}, newObj interface{}) {
+	// ServiceIp can't change without deleting service, so we only check for globalIp change
+	if key := a.getEnqueueKey(newObj); key != "" {
+		oldGlobalIp := getGlobalIpFromService(old.(*corev1.Service))
+		newGlobalIp := getGlobalIpFromService(newObj.(*corev1.Service))
+		if oldGlobalIp != newGlobalIp {
+			a.serviceWorkqueue.AddRateLimited(key)
+		}
+	}
+}
+
+func (a *Controller) serviceUpdater(service *corev1.Service, key string) error {
+	klog.V(2).Infof("Updating Service %s", key)
+	return nil
+}
+
+func (a *Controller) handleRemovedService(obj interface{}) {
+	var service *corev1.Service
+	var ok bool
+
+	if service, ok = obj.(*corev1.Service); !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.Errorf("Could not convert object %v to Service", obj)
+			return
+		}
+		service, ok = tombstone.Obj.(*corev1.Service)
+		if !ok {
+			klog.Errorf("Could not convert object tombstone %v to Service", tombstone.Obj)
+			return
+		}
+	}
+	if !a.isValidService(service.GetNamespace(), service.GetName()) {
+		return
+	}
+	klog.V(2).Infof("Removed service %v", service)
+}
+
+func logAndRequeue(key string, workqueue workqueue.RateLimitingInterface) {
+	klog.V(2).Infof("%s enqueued %d times", key, workqueue.NumRequeues(key))
+	workqueue.AddRateLimited(key)
+}
+
+func getGlobalIpFromService(service *corev1.Service) string {
+	if service != nil {
+		annotations := service.GetAnnotations()
+		if annotations != nil {
+			return annotations[submarinerIpamGlobalIp]
+		}
+	}
+	return ""
+}

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -1,0 +1,28 @@
+package controller
+
+import (
+	kubeInformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+type Controller struct {
+	kubeClientSet     kubernetes.Interface
+	serviceWorkqueue  workqueue.RateLimitingInterface
+	servicesSynced    cache.InformerSynced
+	excludeNamespaces map[string]bool
+}
+
+type AgentSpecification struct {
+	ClusterID string
+	Namespace string
+	Token     string
+	Broker    string
+	ExcludeNS []string
+}
+
+type InformerConfigStruct struct {
+	KubeClientSet   kubernetes.Interface
+	ServiceInformer kubeInformers.ServiceInformer
+}

--- a/pkg/agent/main.go
+++ b/pkg/agent/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"flag"
+	"time"
+
+	"github.com/kelseyhightower/envconfig"
+	"github.com/submariner-io/lighthouse/pkg/agent/controller"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+)
+
+var (
+	masterURL  string
+	kubeConfig string
+)
+
+const defaultResync = 0 * time.Minute
+
+func main() {
+	var agentSpec controller.AgentSpecification
+	klog.InitFlags(nil)
+	flag.Parse()
+
+	err := envconfig.Process("submariner", &agentSpec)
+	if err != nil {
+		klog.Fatal(err)
+	}
+
+	cfg, err := clientcmd.BuildConfigFromFlags(masterURL, kubeConfig)
+	if err != nil {
+		klog.Fatalf("Error building kubeconfig: %s", err.Error())
+	}
+	clientSet, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		klog.Fatalf("error building k8s clientset: %s", err.Error())
+	}
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(clientSet, defaultResync)
+	informerConfig := controller.InformerConfigStruct{
+		KubeClientSet:   clientSet,
+		ServiceInformer: informerFactory.Core().V1().Services(),
+	}
+	klog.Infof("Starting submariner-lighthouse-agent %v", agentSpec)
+
+	// set up signals so we handle the first shutdown signal gracefully
+	stopCh := signals.SetupSignalHandler()
+	lightHouseAgent := controller.New(&agentSpec, informerConfig)
+
+	informerFactory.Start(stopCh)
+
+	if err := lightHouseAgent.Run(stopCh); err != nil {
+		klog.Fatalf("Failed to start lighthouse agent: %v", err)
+	}
+
+	klog.Info("All controllers stopped or exited. Stopping main loop")
+}
+
+func init() {
+	flag.StringVar(&kubeConfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
+	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+}

--- a/scripts/build
+++ b/scripts/build
@@ -12,4 +12,5 @@ if [[ $1 != clean ]]; then
        ./build-coredns "$@"
     fi
     ./build-controller "$@"
+    ./build-agent "$@"
 fi

--- a/scripts/build-agent
+++ b/scripts/build-agent
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+source $(dirname $0)/../scripts/lib/version
+source $(dirname $0)/../scripts/lib/debug_functions
+
+cd $(dirname $0)/..
+mkdir -p bin
+echo Building lighthouse-agent version ${VERSION}
+go mod vendor
+GO111MODULE=on CGO_ENABLED=0 go build -ldflags "-X main.VERSION=${VERSION}" -o bin/lighthouse-agent ./pkg/agent/main.go
+
+LIGHTHOUSE_AGENT_IMAGE=lighthouse-agent:${VERSION}
+cd ./package
+cp ../bin/lighthouse-agent lighthouse-agent
+docker build -t ${LIGHTHOUSE_AGENT_IMAGE} -f Dockerfile.agent .
+
+echo "Built lighthouse-agent to image: ${LIGHTHOUSE_AGENT_IMAGE}"
+
+# clean up agent image
+rm lighthouse-agent

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -34,6 +34,12 @@ function setup_lighthouse_controller () {
     docker tag lighthouse-controller:${VERSION} lighthouse-controller:local
     kind --name cluster1 load docker-image lighthouse-controller:local
     kubectl --context=cluster1 apply -f ${PRJ_ROOT}/package/lighthouse-controller-deployment.yaml
+    for i in 2 3; do
+      echo "Installing lighthouse-agent in cluster${i}..."
+      docker tag lighthouse-agent:${VERSION} lighthouse-agent:local
+      kind --name cluster${i} load docker-image lighthouse-agent:local
+      kubectl --context=cluster${i} apply -f ${PRJ_ROOT}/package/lighthouse-agent-deployment.yaml
+    done
 }
 
 function update_coredns_deployment() {

--- a/scripts/release
+++ b/scripts/release
@@ -12,4 +12,6 @@ docker tag lighthouse-coredns:${VERSION} ${REPO}/lighthouse-coredns:${DOCKER_TAG
 docker tag lighthouse-coredns:${VERSION} ${REPO}/lighthouse-coredns:"${COMMIT:0:7}"
 docker tag lighthouse-controller:${VERSION} ${REPO}/lighthouse-controller:${DOCKER_TAG#"v"}
 docker tag lighthouse-controller:${VERSION} ${REPO}/lighthouse-controller:"${COMMIT:0:7}"
+docker tag lighthouse-agent:${VERSION} ${REPO}/lighthouse-agent:${DOCKER_TAG#"v"}
+docker tag lighthouse-agent:${VERSION} ${REPO}/lighthouse-agent:"${COMMIT:0:7}"
 for i in $(docker images --format "{{.Repository}}:{{.Tag}}" | grep -E "${REPO}/.*:(${DOCKER_TAG#v}|${COMMIT:0:7})"); do docker push $i; done


### PR DESCRIPTION
To remove kubefed dependency in lighthouse, we'll be using a different
lighthouse agents running in each cluster syncing multiclusterservices
of their clusters to central broker, similar to way we sync clusters
and endpoints in submariner.

This patch adds the initial lighthouse agent. With these changes,
we can work on deployment code while working on finalizing changes
to remove kubefed altogether.

Fixes #80