### PR TITLE
Update test and validate scripts

### DIFF
--- a/plugin/lighthouse/parse_test.go
+++ b/plugin/lighthouse/parse_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("[parse] Test parese DNS request", func() {
+var _ = Describe("[parse] Test parse DNS request", func() {
 	Context("When request is valid", testParseValid)
 	Context("When request is invalid", testParseInvalid)
 })

--- a/scripts/lib/debug_functions
+++ b/scripts/lib/debug_functions
@@ -1,18 +1,19 @@
 ### Constants ###
 
-export CYAN_COLOR='\e[36m'
-export NO_COLOR='\e[0m'
+export CYAN_COLOR=$(echo -e '\e[36m')
+export NO_COLOR=$(echo -e '\e[0m')
 
 ### Functions ###
 
 function trap_commands() {
     # Function to print each bash command before it is executed
-    trap '! [[ "$BASH_COMMAND" =~ ^(echo|read|\[\[|while|for|prompt) ]] && \
-    cmd=`eval echo -e "$BASH_COMMAND" 2>/dev/null` && \
-    echo -e "${CYAN_COLOR} $cmd ${NO_COLOR}"' DEBUG
+    trap '! [[ "$BASH_COMMAND" =~ ^(echo|read|\[|while|for) ]] && \
+          ctxt="${cluster:+[${cluster}]}" && \
+          cmd=`eval echo "[${PWD##*/}]\$ $ctxt $BASH_COMMAND" 2>/dev/null` && \
+          echo "${CYAN_COLOR}$cmd${NO_COLOR}" >&2; true' DEBUG
 }
 
 ### Main ###
 
-export -f trap_commands
+set -T
 trap_commands

--- a/scripts/lib/find_functions
+++ b/scripts/lib/find_functions
@@ -1,11 +1,10 @@
 function find_go_pkg_dirs() {
-
-    local BASE _EXCLUDED_PKG_DIRS FIND_EXCLUDE PACKAGE_DIRS
+    local BASE EXCLUDED_PKG_DIRS FIND_EXCLUDE PACKAGE_DIRS
 
     BASE=${2:-.}
-    _EXCLUDED_PKG_DIRS=${EXCLUDE_PKG_DIRS:-vendor .tmp test .git .trash-cache bin}
+    EXCLUDED_PKG_DIRS=${EXCLUDE_PKG_DIRS:-vendor test .git .trash-cache bin}
 
-    for excldir in $_EXCLUDED_PKG_DIRS; do
+    for excldir in $EXCLUDED_PKG_DIRS; do
         FIND_EXCLUDE="-path ./$excldir -prune -o $FIND_EXCLUDE"
     done
 
@@ -15,7 +14,7 @@ function find_go_pkg_dirs() {
                       sort -u)"
 
     if [[ "x$1" != "x--no-trailing-dots" ]]; then
-        PACKAGE_DIRS=$(echo $PACKAGE_DIRS | sed -e 's!.*!./&/...!')
+        PACKAGE_DIRS=$(echo "$PACKAGE_DIRS" | sed -e 's![^ ]*!./&/...!g')
     fi
 
     echo "$BASE $PACKAGE_DIRS"

--- a/scripts/test
+++ b/scripts/test
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source $(dirname $0)/lib/debug_functions
+
 cd $(dirname $0)/..
 
 source scripts/lib/find_functions
@@ -11,4 +13,4 @@ PACKAGES=$(find_go_pkg_dirs)
 
 echo Running tests in ${PACKAGES}
 [ "${ARCH}" == "amd64" ] && RACE=-race
-ginkgo ${RACE} -cover ${PACKAGES}
+ginkgo -v ${RACE} -cover ${PACKAGES}

--- a/scripts/validate
+++ b/scripts/validate
@@ -1,17 +1,21 @@
 #!/bin/bash
 set -e
 
+source $(dirname $0)/lib/debug_functions
+
 cd $(dirname $0)/..
 
 source scripts/lib/find_functions
 
-EXCLUDE_PKG_DIRS=".git .tmp .trash-cache vendor bin"
-
-PACKAGES=$(find_go_pkg_dirs --no-trailing-dots "*.go")
+EXCLUDE_PKG_DIRS=".git .trash-cache vendor bin"
+PACKAGES="$(find_go_pkg_dirs --no-trailing-dots "*.go")"
 
 if [[ $(goimports -l ${PACKAGES} | wc -l) -gt 0 ]]; then
-    echo "Incorrect formatting, please run goimports and check the following files:"
+    echo Incorrect formatting
+    echo These are the files with formatting errrors:
     goimports -l ${PACKAGES}
+    echo These are the formatting errors:
+    goimports -d ${PACKAGES}
     exit 1
 fi
 


### PR DESCRIPTION
The test script doesn't run any tests under pkg - it finds "./pkg" and
not "./pkg/...". Updating the find_functios to the latest in submariner
fixes. Also updated the debug_functions validate script and fixed a type in the parse tests.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>