### PR TITLE
Fix lighthouse-agent tagging on git tags processing

### DIFF
--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -27,7 +27,7 @@ function setup_lighthouse () {
     done
     for i in 2 3; do
       echo "Installing lighthouse-agent in cluster${i}..."
-      docker tag lighthouse-agent:${VERSION} lighthouse-agent:local
+      docker tag lighthouse-agent:${VERSION#"v"} lighthouse-agent:local
       kind --name cluster${i} load docker-image lighthouse-agent:local
       kubectl --context=cluster${i} apply -f ${PRJ_ROOT}/package/lighthouse-agent-deployment.yaml
     done


### PR DESCRIPTION
This may help us fixing this error:

[00:14:42.532740] [lighthouse]$ docker tag lighthouse-agent:v0.3.0-rc1 lighthouse-agent:local
[00:14:42.823298] Error response from daemon: No such image: lighthouse-agent:v0.3.0-rc1
[00:14:42.832165] [lighthouse]$ scripts/kind-e2e/e2e.sh --status keep --logging false
[00:14:43.201131] time="2020-04-22T14:54:48Z" level=fatal msg="exit status 1"
[00:14:43.203839] Makefile:28: recipe for target 'e2e' failed
[00:14:43.203891] make: *** [e2e] Error 1
The command "set -o pipefail ; make ci e2e status=keep 2>&1 | ts '[%H:%M:%.S]' -s" exited with 2.
