### PR TITLE
Deploy with Shipyard using new extended flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ branches:
 git:
   depth: false
 
+jobs:
+  include:
+  - env: CMD="make ci"
+  - env: CMD="make e2e status=keep delpoytool=operator"
+  - env: CMD="make e2e status=keep deploytool=helm"
+
 install:
   - sudo apt-get install moreutils # make ts available
 
@@ -19,13 +25,13 @@ services:
 before_script:
   - CHANGED_FILES_PR=$(git diff --name-only HEAD $(git merge-base HEAD $TRAVIS_BRANCH))
 script:
-  - set -o pipefail ;
-    make ci e2e status=keep 2>&1 | ts '[%H:%M:%.S]' -s
+  - set -o pipefail;
+    $CMD 2>&1 | ts '[%H:%M:%.S]' -s
 after_success:
   - if [[ "${CHANGED_FILES_PR[@]}" =~ "scripts/kind-e2e/e2e.sh" ]]; then
       echo "scripts/kind-e2e/e2e.sh was modified, testing recurring run on already deployed infrastructure.";
-      set -o pipefail ;
-      make e2e status=keep | ts '[%H:%M:%.S]' -s;
+      set -o pipefail;
+      $CMD 2>&1 | ts '[%H:%M:%.S]' -s;
     fi
 deploy:
   - provider: script

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,13 @@ globalnet ?= false
 TARGETS := $(shell ls scripts | grep -v deploy)
 SCRIPTS_DIR ?= /opt/shipyard/scripts
 
+ifeq ($(deploytool),operator)
+DEPLOY_ARGS += --delpoytool operator --deploytool_broker_args '--service-discovery'
+else
+DEPLOY_ARGS += --deploytool helm --deploytool_broker_args '--set submariner.serviceDiscovery=true' --deploytool_submariner_args '--set submariner.serviceDiscovery=true,lighthouse.image.repository=localhost:5000/lighthouse-agent,serviceAccounts.lighthouse.create=true'
+endif
+
+
 .dapper:
 	@echo Downloading dapper
 	@curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > .dapper.tmp
@@ -22,7 +29,7 @@ clusters:
 	./.dapper -m bind $(SCRIPTS_DIR)/clusters.sh --k8s_version $(version) --globalnet $(globalnet)
 
 deploy: build clusters
-	DAPPER_ENV="OPERATOR_IMAGE" ./.dapper -m bind $@ --globalnet $(globalnet) --deploytool $(deploytool)
+	DAPPER_ENV="OPERATOR_IMAGE" ./.dapper -m bind $@ --globalnet $(globalnet) $(DEPLOY_ARGS)
 
 e2e: deploy
 	./.dapper -m bind scripts/kind-e2e/e2e.sh --status $(status) --logging $(logging)

--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,13 @@ SCRIPTS_DIR ?= /opt/shipyard/scripts
 cleanup: .dapper
 	./.dapper -m bind $(SCRIPTS_DIR)/cleanup.sh
 
-clusters: ci
+clusters:
 	./.dapper -m bind $(SCRIPTS_DIR)/clusters.sh --k8s_version $(version) --globalnet $(globalnet)
 
-deploy: clusters
+deploy: build clusters
 	DAPPER_ENV="OPERATOR_IMAGE" ./.dapper -m bind $@ --globalnet $(globalnet) --deploytool $(deploytool)
 
-e2e: build deploy
+e2e: deploy
 	./.dapper -m bind scripts/kind-e2e/e2e.sh --status $(status) --logging $(logging)
 
 $(TARGETS): .dapper

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -3,14 +3,11 @@ set -e
 
 source ${SCRIPTS_DIR}/lib/debug_functions
 source ${SCRIPTS_DIR}/lib/version
+source ${SCRIPTS_DIR}/lib/deploy_funcs
 
-function load_image() {
-    docker pull ${1}:latest
-    docker tag ${1}:latest ${1}:$VERSION
-}
-
-load_image quay.io/submariner/submariner
-load_image quay.io/submariner/submariner-route-agent
-load_image quay.io/submariner/submariner-globalnet
+import_image quay.io/submariner/submariner
+import_image quay.io/submariner/submariner-route-agent
+import_image quay.io/submariner/submariner-globalnet
+import_image lighthouse-agent
 
 ${SCRIPTS_DIR}/deploy.sh "$@"

--- a/scripts/kind-e2e/e2e.sh
+++ b/scripts/kind-e2e/e2e.sh
@@ -20,19 +20,6 @@ source ${SCRIPTS_DIR}/lib/utils
 
 ### Functions ###
 
-function setup_lighthouse () {
-    for i in 1 2 3; do
-      echo "Installing lighthouse CRD in cluster${i}..."
-      kubectl --context=cluster${i} apply -f ${PRJ_ROOT}/package/lighthouse-crd.yaml
-    done
-    for i in 2 3; do
-      echo "Installing lighthouse-agent in cluster${i}..."
-      docker tag lighthouse-agent:${VERSION#"v"} lighthouse-agent:local
-      kind --name cluster${i} load docker-image lighthouse-agent:local
-      kubectl --context=cluster${i} apply -f ${PRJ_ROOT}/package/lighthouse-agent-deployment.yaml
-    done
-}
-
 function update_coredns_deployment() {
     uuid=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
     docker tag lighthouse-coredns:${VERSION#"v"} lighthouse-coredns:${VERSION#"v"}_${uuid}
@@ -110,7 +97,6 @@ if [[ $logging = true ]]; then
     enable_logging
 fi
 
-setup_lighthouse
 update_coredns_configmap
 update_coredns_deployment
 


### PR DESCRIPTION
Now that shipyard supports extended deployment flags [1] deploy using them.

Also modified CI to run 3 jobs: basic code tests, e2e with helm and e2e with operator (which should work AFAIK)

[1] https://github.com/submariner-io/shipyard/pull/111