### PR TITLE
Fix deploytool typo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ git:
 jobs:
   include:
   - env: CMD="make ci"
-  - env: CMD="make e2e delpoytool=operator"
+  - env: CMD="make e2e deploytool=operator"
          RELEASE=true
   - env: CMD="make e2e deploytool=helm"
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ TARGETS := $(shell ls scripts | grep -v deploy)
 SCRIPTS_DIR ?= /opt/shipyard/scripts
 
 ifeq ($(deploytool),operator)
-DEPLOY_ARGS += --delpoytool operator --deploytool_broker_args '--service-discovery'
+DEPLOY_ARGS += --deploytool operator --deploytool_broker_args '--service-discovery'
 else
 DEPLOY_ARGS += --deploytool helm --deploytool_broker_args '--set submariner.serviceDiscovery=true' --deploytool_submariner_args '--set submariner.serviceDiscovery=true,lighthouse.image.repository=localhost:5000/lighthouse-agent,serviceAccounts.lighthouse.create=true'
 endif


### PR DESCRIPTION
It was misspelled, causing lighthouse to always deploy with helm in the
CI.