### PR TITLE
E2E: Don't check for IP

### DIFF
--- a/test/e2e/dataplane/service_discovery.go
+++ b/test/e2e/dataplane/service_discovery.go
@@ -108,6 +108,7 @@ func verifyClusterIpWithDig(f *framework.Framework, cluster framework.ClusterInd
 		return stdout, nil
 	}, func(result interface{}) (bool, string, error) {
 		doesContain := strings.Contains(result.(string), serviceIP)
+		By(fmt.Sprintf("Validating dig result: %q", result))
 		if doesContain && !shouldContain {
 			return false || logOnly, fmt.Sprintf("expected execution result %q not to contain %q", result, serviceIP), nil
 		}
@@ -115,13 +116,12 @@ func verifyClusterIpWithDig(f *framework.Framework, cluster framework.ClusterInd
 		if !doesContain && shouldContain {
 			return false || logOnly, fmt.Sprintf("expected execution result %q to contain %q", result, serviceIP), nil
 		}
-		By(fmt.Sprintf("Validating dig result: %q", result))
 
 		return true, "", nil
 	})
 }
 
-func verifyCurl(f *framework.Framework, cluster framework.ClusterIndex, pod v1.Pod, target string, shouldPass bool) {
+func verifyCurl(f *framework.Framework, cluster framework.ClusterIndex, pod v1.Pod, target string, expectingSuccess bool) {
 	cmd := []string{"curl", target}
 	stdout, _, err := f.ExecWithOptions(framework.ExecOptions{
 		Command:       cmd,
@@ -131,7 +131,7 @@ func verifyCurl(f *framework.Framework, cluster framework.ClusterIndex, pod v1.P
 		CaptureStdout: true,
 		CaptureStderr: true,
 	}, framework.ClusterB)
-	if shouldPass {
+	if expectingSuccess {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(stdout).To(ContainSubstring("Welcome to nginx!"))
 	} else {

--- a/test/e2e/dataplane/service_discovery.go
+++ b/test/e2e/dataplane/service_discovery.go
@@ -41,24 +41,13 @@ func RunServiceDiscoveryTest(f *framework.Framework) {
 	nginxServiceClusterC := f.NewNginxService(framework.ClusterC)
 	By(fmt.Sprintf("Creating a Netshoot Deployment on %q", clusterBName))
 	netshootPodList := f.NewNetShootDeployment(framework.ClusterB)
-	cmd := []string{"curl", nginxServiceClusterC.Name}
-	stdout, _, err := f.ExecWithOptions(framework.ExecOptions{
-		Command:       cmd,
-		Namespace:     f.Namespace,
-		PodName:       netshootPodList.Items[0].Name,
-		ContainerName: netshootPodList.Items[0].Spec.Containers[0].Name,
-		CaptureStdout: true,
-		CaptureStderr: true,
-	}, framework.ClusterB)
 
-	Expect(err).NotTo(HaveOccurred())
-	Expect(stdout).To(ContainSubstring("Welcome to nginx!"))
-
-	verifyClusterIpWithDig(f, framework.ClusterB, nginxServiceClusterC, netshootPodList, true)
+	verifyClusterIpWithDig(f, framework.ClusterB, nginxServiceClusterC, netshootPodList, true, true)
+	verifyCurl(f, framework.ClusterB, netshootPodList.Items[0], nginxServiceClusterC.Name, true)
 
 	f.DeleteService(framework.ClusterC, nginxServiceClusterC.Name)
 
-	verifyClusterIpWithDig(f, framework.ClusterB, nginxServiceClusterC, netshootPodList, false)
+	verifyCurl(f, framework.ClusterB, netshootPodList.Items[0], nginxServiceClusterC.Name, false)
 }
 
 func RunServiceDiscoveryLocalTest(f *framework.Framework) {
@@ -80,18 +69,19 @@ func RunServiceDiscoveryLocalTest(f *framework.Framework) {
 	By(fmt.Sprintf("Creating a Netshoot Deployment on %q", clusterBName))
 	netshootPodList := f.NewNetShootDeployment(framework.ClusterB)
 
-	verifyClusterIpWithDig(f, framework.ClusterB, nginxServiceClusterB, netshootPodList, true)
+	verifyClusterIpWithDig(f, framework.ClusterB, nginxServiceClusterB, netshootPodList, true, false)
 
 	f.DeleteService(framework.ClusterB, nginxServiceClusterB.Name)
 
-	verifyClusterIpWithDig(f, framework.ClusterB, nginxServiceClusterC, netshootPodList, true)
+	verifyClusterIpWithDig(f, framework.ClusterB, nginxServiceClusterC, netshootPodList, true, true)
+	verifyCurl(f, framework.ClusterB, netshootPodList.Items[0], nginxServiceClusterC.Name, true)
 
 	f.DeleteService(framework.ClusterC, nginxServiceClusterC.Name)
 
-	verifyClusterIpWithDig(f, framework.ClusterB, nginxServiceClusterC, netshootPodList, false)
+	verifyClusterIpWithDig(f, framework.ClusterB, nginxServiceClusterC, netshootPodList, false, false)
 }
 
-func verifyClusterIpWithDig(f *framework.Framework, cluster framework.ClusterIndex, service *corev1.Service, targetPod *v1.PodList, shouldContain bool) {
+func verifyClusterIpWithDig(f *framework.Framework, cluster framework.ClusterIndex, service *corev1.Service, targetPod *v1.PodList, shouldContain bool, logOnly bool) {
 	kubeDnsService, _ := framework.KubeClients[cluster].CoreV1().Services("kube-system").Get("kube-dns", metav1.GetOptions{})
 	kubeDnsServiceIP := kubeDnsService.Spec.ClusterIP
 
@@ -119,13 +109,32 @@ func verifyClusterIpWithDig(f *framework.Framework, cluster framework.ClusterInd
 	}, func(result interface{}) (bool, string, error) {
 		doesContain := strings.Contains(result.(string), serviceIP)
 		if doesContain && !shouldContain {
-			return false, fmt.Sprintf("expected execution result %q not to contain %q", result, serviceIP), nil
+			return false || logOnly, fmt.Sprintf("expected execution result %q not to contain %q", result, serviceIP), nil
 		}
 
 		if !doesContain && shouldContain {
-			return false, fmt.Sprintf("expected execution result %q to contain %q", result, serviceIP), nil
+			return false || logOnly, fmt.Sprintf("expected execution result %q to contain %q", result, serviceIP), nil
 		}
+		By(fmt.Sprintf("Validating dig result: %q", result))
 
 		return true, "", nil
 	})
+}
+
+func verifyCurl(f *framework.Framework, cluster framework.ClusterIndex, pod v1.Pod, target string, shouldPass bool) {
+	cmd := []string{"curl", target}
+	stdout, _, err := f.ExecWithOptions(framework.ExecOptions{
+		Command:       cmd,
+		Namespace:     f.Namespace,
+		PodName:       pod.Name,
+		ContainerName: pod.Spec.Containers[0].Name,
+		CaptureStdout: true,
+		CaptureStderr: true,
+	}, framework.ClusterB)
+	if shouldPass {
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stdout).To(ContainSubstring("Welcome to nginx!"))
+	} else {
+		Expect(err).To(HaveOccurred())
+	}
 }


### PR DESCRIPTION
Service Discovery E2E should only test if query to service name
resolves or not. It should not check for actual IP returned as that
will depend on deployment - globalnet enabled or not.

Fixes #129