### PR TITLE
Increase lint timeout, ignore generated clientset

### DIFF
--- a/scripts/validate
+++ b/scripts/validate
@@ -19,4 +19,5 @@ if [[ $(goimports -l ${PACKAGES} | wc -l) -gt 0 ]]; then
     exit 1
 fi
 
-golangci-lint run
+golangci-lint run --timeout 5m --skip-dirs pkg/client
+


### PR DESCRIPTION
The updated golangci-lint identifies an issue in the clientset, but
since that’s generated we should ignore it instead.

The timeout also needs to be increased.

Signed-off-by: Stephen Kitt <skitt@redhat.com>