### PR TITLE
Use ServiceExport in agent

### DIFF
--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -2,18 +2,18 @@ package controller
 
 import (
 	"github.com/submariner-io/admiral/pkg/syncer/broker"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
 type Controller struct {
-	clusterID         string
-	restConfig        *rest.Config
-	excludeNamespaces map[string]bool
-	svcSyncer         *broker.Syncer
+	clusterID     string
+	restConfig    *rest.Config
+	kubeClientSet kubernetes.Interface
+	svcSyncer     *broker.Syncer
 }
 
 type AgentSpecification struct {
 	ClusterID string
 	Namespace string
-	ExcludeNS []string
 }

--- a/pkg/agent/main.go
+++ b/pkg/agent/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kelseyhightower/envconfig"
 	"github.com/submariner-io/lighthouse/pkg/agent/controller"
 	lighthousev1 "github.com/submariner-io/lighthouse/pkg/apis/lighthouse.submariner.io/v1"
+	lighthousev2a1 "github.com/submariner-io/lighthouse/pkg/apis/lighthouse.submariner.io/v2alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
 
 	"k8s.io/client-go/tools/clientcmd"
@@ -34,6 +35,10 @@ func main() {
 	err = lighthousev1.AddToScheme(scheme.Scheme)
 	if err != nil {
 		klog.Exitf("Error adding lighthouse V1 to the scheme: %v", err)
+	}
+	err = lighthousev2a1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		klog.Exitf("Error adding lighthouse V2alpha1 to the scheme: %v", err)
 	}
 	cfg, err := clientcmd.BuildConfigFromFlags(masterURL, kubeConfig)
 	if err != nil {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -1,0 +1,76 @@
+package framework
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/lighthouse/pkg/apis/lighthouse.submariner.io/v2alpha1"
+	"github.com/submariner-io/shipyard/test/e2e/framework"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+
+	lighthouseClientset "github.com/submariner-io/lighthouse/pkg/client/clientset/versioned"
+)
+
+const (
+	cleanupWait = time.Second * 5
+)
+
+// Framework supports common operations used by e2e tests; it will keep a client & a namespace for you.
+type Framework struct {
+	*framework.Framework
+}
+
+var LighthouseClients []*lighthouseClientset.Clientset
+
+func init() {
+	framework.AddBeforeSuite(beforeSuite)
+}
+
+// NewFramework creates a test framework.
+func NewFramework(baseName string) *Framework {
+	f := &Framework{Framework: framework.NewFramework(baseName)}
+	return f
+}
+
+func beforeSuite() {
+	By("Creating lighthouse clients")
+
+	for _, restConfig := range framework.RestConfigs {
+		LighthouseClients = append(LighthouseClients, createLighthouseClient(restConfig))
+	}
+}
+
+func createLighthouseClient(restConfig *rest.Config) *lighthouseClientset.Clientset {
+	clientSet, err := lighthouseClientset.NewForConfig(restConfig)
+	Expect(err).To(Not(HaveOccurred()))
+	return clientSet
+}
+
+func (f *Framework) NewServiceExport(cluster framework.ClusterIndex, name string, namespace string) *v2alpha1.ServiceExport {
+	nginxServiceExport := v2alpha1.ServiceExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	se := LighthouseClients[cluster].LighthouseV2alpha1().ServiceExports(namespace)
+	By(fmt.Sprintf("Creating serviceExport %s.%s on %q", name, namespace, framework.TestContext.ClusterIDs[cluster]))
+	serviceExport := framework.AwaitUntil("create serviceExport", func() (interface{}, error) {
+		return se.Create(&nginxServiceExport)
+
+	}, framework.NoopCheckResult).(*v2alpha1.ServiceExport)
+	return serviceExport
+}
+
+func (f *Framework) DeleteServiceExport(cluster framework.ClusterIndex, name string, namespace string) {
+	By(fmt.Sprintf("Deleting serviceExport %s.%s on %q", name, namespace, framework.TestContext.ClusterIDs[cluster]))
+	framework.AwaitUntil("delete service export", func() (interface{}, error) {
+		return nil, LighthouseClients[cluster].LighthouseV2alpha1().ServiceExports(namespace).Delete(name, &metav1.DeleteOptions{})
+	}, framework.NoopCheckResult)
+	// Give time for ServiceExport cleanup to propagate
+	//TODO: Add a WaitUntilDeleted method for this
+	By("Waiting for mcs cleanup...")
+	time.Sleep(cleanupWait)
+}


### PR DESCRIPTION
Use ServicExport to decide which services will be multicluster. This
changes the to an opt-in model from current all-in default.