### PR TITLE
Don't install serviceexport in e2e

### DIFF
--- a/scripts/deploy
+++ b/scripts/deploy
@@ -37,6 +37,6 @@ import_image quay.io/submariner/lighthouse-coredns
 
 run_subm_clusters update_coredns_configmap
 run_subm_clusters update_coredns_deployment
-run_subm_clusters install_service_export
+#run_subm_clusters install_service_export
 
 ${SCRIPTS_DIR}/deploy.sh "$@"


### PR DESCRIPTION
helm already installs serviceexport, so trying to do it again from e2e
results in an error. This was a temporary workaround in e2e till we get
it from helm. With helm installing it for us, this is not needed
anymore.