### PR TITLE
Don't use 'docker system prune' for reclaiming space

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -23,7 +23,6 @@ jobs:
         run: |
           sudo swapoff -a
           sudo rm -f /swapfile
-          docker system prune --volumes --all --force
           df -h
           free -h
 
@@ -36,4 +35,7 @@ jobs:
 
       - name: Post Mortem
         if: failure()
-        run: make post-mortem
+        run: |
+          df -h
+          free -h
+          make post-mortem


### PR DESCRIPTION
Sometimes it takes more than a minute to run, turning swap off should give us enough headroom