### PR TITLE
Rename E2E to discovery

### DIFF
--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -1,4 +1,4 @@
-package dataplane
+package discovery
 
 import (
 	"fmt"
@@ -16,8 +16,8 @@ const (
 	submarinerIpamGlobalIp = "submariner.io/globalIp"
 )
 
-var _ = Describe("[dataplane] Test Service Discovery Across Clusters", func() {
-	f := lhframework.NewFramework("dataplane-sd")
+var _ = Describe("[discovery] Test Service Discovery Across Clusters", func() {
+	f := lhframework.NewFramework("discovery")
 
 	When("a pod tries to resolve a service in a remote cluster", func() {
 		It("should be able to discover the remote service successfully", func() {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -3,7 +3,7 @@ package e2e
 import (
 	"testing"
 
-	_ "github.com/submariner-io/lighthouse/test/e2e/dataplane"
+	_ "github.com/submariner-io/lighthouse/test/e2e/discovery"
 	"github.com/submariner-io/shipyard/test/e2e"
 )
 


### PR DESCRIPTION
Lighthouse E2E still uses `dataplane` as tag/name for its E2E eventhough
we don't test dataplane at all. Rename it to avoid conflict with
submarine `dataplane` tests.