### PR TITLE
E2E retrieves now cluster names from ClusterIDs

### DIFF
--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -34,8 +34,8 @@ var _ = Describe("[discovery] Test Service Discovery Across Clusters", func() {
 })
 
 func RunServiceDiscoveryTest(f *lhframework.Framework) {
-	clusterAName := framework.TestContext.KubeContexts[framework.ClusterA]
-	clusterBName := framework.TestContext.KubeContexts[framework.ClusterB]
+	clusterAName := framework.TestContext.ClusterIDs[framework.ClusterA]
+	clusterBName := framework.TestContext.ClusterIDs[framework.ClusterB]
 
 	By(fmt.Sprintf("Creating an Nginx Deployment on on %q", clusterBName))
 	f.NewNginxDeployment(framework.ClusterB)
@@ -56,8 +56,8 @@ func RunServiceDiscoveryTest(f *lhframework.Framework) {
 }
 
 func RunServiceDiscoveryLocalTest(f *lhframework.Framework) {
-	clusterAName := framework.TestContext.KubeContexts[framework.ClusterA]
-	clusterBName := framework.TestContext.KubeContexts[framework.ClusterB]
+	clusterAName := framework.TestContext.ClusterIDs[framework.ClusterA]
+	clusterBName := framework.TestContext.ClusterIDs[framework.ClusterB]
 
 	By(fmt.Sprintf("Creating an Nginx Deployment on %q", clusterAName))
 	f.NewNginxDeployment(framework.ClusterA)


### PR DESCRIPTION
Subctl consumes the testing framework by providing 2 config files
and no contexts. That's why we introduced ClusterIDs which is a symbolic
name for the clusters the user can understand. While the context,
in some cases can simply not exists.