### PR TITLE
Use supercluster.local for service discovery

### DIFF
--- a/scripts/resources/coredns-cm.yaml
+++ b/scripts/resources/coredns-cm.yaml
@@ -8,10 +8,9 @@ data:
         kubernetes cluster1.local in-addr.arpa ip6.arpa {
            pods insecure
            upstream
-           #fallthrough in-addr.arpa ip6.arpa
-           fallthrough
+           fallthrough in-addr.arpa ip6.arpa
         }
-        lighthouse cluster1.local cluster2.local {
+        lighthouse supercluster.local {
            fallthrough
         }
         prometheus :9153


### PR DESCRIPTION
With opt-in model, lighthouse should only respond to queries for
services in `supercluster.local`. This updates the e2e and coredns to
use `supercluster.local` for lighthouse.