### PR TITLE
Change return code for Ipv6 queries

### DIFF
--- a/plugin/lighthouse/handler.go
+++ b/plugin/lighthouse/handler.go
@@ -30,7 +30,7 @@ func (lh *Lighthouse) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns
 	if state.QType() != dns.TypeA {
 		// We only support TypeA
 		log.Debugf("Only TypeA queries are supported yet")
-		return lh.nextOrFailure(state.Name(), ctx, w, r, dns.RcodeNotImplemented, "Only TypeA supported")
+		return lh.nextOrFailure(state.Name(), ctx, w, r, dns.RcodeNameError, "Only TypeA supported")
 	}
 
 	zone = qname[len(qname)-len(zone):] // maintain case of original query

--- a/plugin/lighthouse/handler_test.go
+++ b/plugin/lighthouse/handler_test.go
@@ -124,7 +124,7 @@ func testWithoutFallback() {
 			executeTestCase(lh, rec, test.Case{
 				Qname: service1 + "." + namespace1 + ".svc.cluster.local.",
 				Qtype: dns.TypeAAAA,
-				Rcode: dns.RcodeNotImplemented,
+				Rcode: dns.RcodeNameError,
 			})
 		})
 	})


### PR DESCRIPTION
We return NotImplemented for IPv6 queries. Return NXDOMAIN instead which
is handled better by most applications like curl etc.