### PR TITLE
Fix helm deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ E2E_ARGS=cluster1 cluster2
 # Process extra flags from the `using=a,b,c` optional flag
 
 ifneq (,$(filter helm,$(_using)))
-override DEPLOY_ARGS += --deploytool_broker_args '--set submariner.serviceDiscovery=true' --deploytool_submariner_args '--set submariner.serviceDiscovery=true,lighthouse.image.repository=localhost:5000/lighthouse-agent,serviceAccounts.lighthouse.create=true'
+override DEPLOY_ARGS += --deploytool_broker_args '--set submariner.serviceDiscovery=true' --deploytool_submariner_args '--set submariner.serviceDiscovery=true,lighthouse.image.repository=localhost:5000/lighthouse-agent,lighthouse.image.tag=local,lighthouseCoredns.image.repository=localhost:5000/lighthouse-coredns,lighthouseCoredns.image.tag=local,serviceAccounts.lighthouse.create=true'
 else
 override DEPLOY_ARGS += --deploytool_broker_args '--service-discovery'
 endif


### PR DESCRIPTION
Since the charts were changed, we need to explicitly specify the `local`
tag for E2E deployment.

Also make sure to deploy the built coredns and not one from external
repos.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>