### PR TITLE
Allow creation of service-export before service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
 	github.com/pkg/errors v0.9.1
-	github.com/submariner-io/admiral v0.4.1
+	github.com/submariner-io/admiral v0.4.2-0.20200706185424-d52c64ccd7ba
 	github.com/submariner-io/shipyard v0.4.1
 	k8s.io/api v0.0.0-20190918195907-bd6ac527cfd2
 	k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d

--- a/go.sum
+++ b/go.sum
@@ -346,10 +346,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/submariner-io/admiral v0.4.1 h1:2lEQtjP2iciaEVL6ZhPMbAs/17W7zbb5NupfAHXUdxY=
-github.com/submariner-io/admiral v0.4.1/go.mod h1:cPwX5Xwr6tZs7qQZmCPKNFL5LxOHR1W4MlRSZgwVBcw=
-github.com/submariner-io/shipyard v0.4.0 h1:bO8yk6OVGX5vGGREzY1+aV4pt9d1lcL0+TuXqQVeq0Y=
-github.com/submariner-io/shipyard v0.4.0/go.mod h1:9ECh6Pvt8OnlhZKwo2UF0DXQBgxpEYeP4Jc18KRkpIQ=
+github.com/submariner-io/admiral v0.4.2-0.20200706185424-d52c64ccd7ba h1:vF5pgMibEcm11tnTbwArA1GKTFGYEVVaj4V2iYIgkZ8=
+github.com/submariner-io/admiral v0.4.2-0.20200706185424-d52c64ccd7ba/go.mod h1:E/sl3vIY2UAhX2VTP3AqvrkOfXN3WBBW6HjwniAOWcA=
 github.com/submariner-io/shipyard v0.4.1 h1:Rpf7c7XUZC3+CM1WKZepyR+FyvUC2JPeJpgG8Qi7Y7Y=
 github.com/submariner-io/shipyard v0.4.1/go.mod h1:9ECh6Pvt8OnlhZKwo2UF0DXQBgxpEYeP4Jc18KRkpIQ=
 github.com/timewasted/linode v0.0.0-20160829202747-37e84520dcf7/go.mod h1:imsgLplxEC/etjIhdr3dNzV3JeT27LbVu5pYWm0JCBY=

--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -33,6 +33,12 @@ var _ = Describe("[discovery] Test Service Discovery Across Clusters", func() {
 		})
 	})
 
+	When("service export is created before the service", func() {
+		It("should resolve the service", func() {
+			RunServiceExportTest(f)
+		})
+	})
+
 })
 
 func RunServiceDiscoveryTest(f *lhframework.Framework) {
@@ -96,6 +102,28 @@ func RunServiceDiscoveryLocalTest(f *lhframework.Framework) {
 	f.DeleteServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 
 	f.DeleteService(framework.ClusterB, nginxServiceClusterB.Name)
+
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, nginxServiceClusterB, netshootPodList, superclusterDomain, false)
+}
+
+func RunServiceExportTest(f *lhframework.Framework) {
+	clusterAName := framework.TestContext.ClusterIDs[framework.ClusterA]
+	clusterBName := framework.TestContext.ClusterIDs[framework.ClusterB]
+
+	By(fmt.Sprintf("Creating an Nginx ServiceExport on on %q", clusterBName))
+	f.NewServiceExport(framework.ClusterB, "nginx-demo", f.Namespace)
+	By(fmt.Sprintf("Creating an Nginx Deployment on on %q", clusterBName))
+	f.NewNginxDeployment(framework.ClusterB)
+
+	By(fmt.Sprintf("Creating a Nginx Service on %q", clusterBName))
+	nginxServiceClusterB := f.NewNginxService(framework.ClusterB)
+
+	By(fmt.Sprintf("Creating a Netshoot Deployment on %q", clusterAName))
+	netshootPodList := f.NewNetShootDeployment(framework.ClusterA)
+
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, nginxServiceClusterB, netshootPodList, superclusterDomain, true)
+
+	f.DeleteServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 
 	verifyServiceIpWithDig(f.Framework, framework.ClusterA, nginxServiceClusterB, netshootPodList, superclusterDomain, false)
 }


### PR DESCRIPTION
Currently to export a service, it must already exist. This change is to
allow creation of service export before service.

Fixes #165

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>