### PR TITLE
Use Shipyard devel image

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM quay.io/submariner/shipyard-dapper-base
+FROM quay.io/submariner/shipyard-dapper-base:devel
 
 ENV DAPPER_ENV="REPO TAG QUAY_USERNAME QUAY_PASSWORD GITHUB_SHA BUILD_ARGS CLUSTERS_ARGS DEPLOY_ARGS RELEASE_ARGS" \
     DAPPER_SOURCE=/go/src/github.com/submariner-io/lighthouse DAPPER_DOCKER_SOCKET=true


### PR DESCRIPTION
Since we moved to tag only the stable releases 'latest', we now need
to use the 'devel' tag to get the cutting edge Shipyard image.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>