### PR TITLE
Fix globalnet e2e

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -2,20 +2,22 @@ package framework
 
 import (
 	"fmt"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/lighthouse/pkg/apis/lighthouse.submariner.io/v2alpha1"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
+	lighthousev2a1 "github.com/submariner-io/lighthouse/pkg/apis/lighthouse.submariner.io/v2alpha1"
 	lighthouseClientset "github.com/submariner-io/lighthouse/pkg/client/clientset/versioned"
 )
 
 const (
-	cleanupWait = time.Second * 5
+	submarinerIpamGlobalIp = "submariner.io/globalIp"
 )
 
 // Framework supports common operations used by e2e tests; it will keep a client & a namespace for you.
@@ -85,8 +87,65 @@ func (f *Framework) DeleteServiceExport(cluster framework.ClusterIndex, name str
 	framework.AwaitUntil("delete service export", func() (interface{}, error) {
 		return nil, LighthouseClients[cluster].LighthouseV2alpha1().ServiceExports(namespace).Delete(name, &metav1.DeleteOptions{})
 	}, framework.NoopCheckResult)
-	// Give time for ServiceExport cleanup to propagate
-	//TODO: Add a WaitUntilDeleted method for this
-	By("Waiting for mcs cleanup...")
-	time.Sleep(cleanupWait)
+}
+
+func (f *Framework) GetService(cluster framework.ClusterIndex, name string, namespace string) (*v1.Service, error) {
+	By(fmt.Sprintf("Retrieving service %s.%s on %q", name, namespace, framework.TestContext.ClusterIDs[cluster]))
+	return framework.KubeClients[cluster].CoreV1().Services(namespace).Get(name, metav1.GetOptions{})
+}
+
+func (f *Framework) AwaitServiceImportIP(targetCluster framework.ClusterIndex, sourceCluster framework.ClusterIndex, svc *v1.Service) *lighthousev2a1.ServiceImport {
+	var serviceIP string
+
+	if framework.TestContext.GlobalnetEnabled {
+		serviceIP = svc.Annotations[submarinerIpamGlobalIp]
+	} else {
+		serviceIP = svc.Spec.ClusterIP
+	}
+	siName := svc.Name + "-" + svc.Namespace + "-" + framework.TestContext.ClusterIDs[sourceCluster]
+	si := LighthouseClients[targetCluster].LighthouseV2alpha1().ServiceImports(framework.TestContext.SubmarinerNamespace)
+	By(fmt.Sprintf("Retrieving ServiceImport %s on %q", siName, framework.TestContext.ClusterIDs[targetCluster]))
+	return framework.AwaitUntil("retrieve ServiceImport", func() (interface{}, error) {
+		return si.Get(siName, metav1.GetOptions{})
+
+	}, func(result interface{}) (bool, string, error) {
+		si := result.(*lighthousev2a1.ServiceImport)
+		if si.Status.Clusters[0].IPs[0] != serviceIP {
+			return false, fmt.Sprintf("ServiceImportIP %s doesn't match %s", si.Status.Clusters[0].IPs[0], serviceIP), nil
+		}
+		return true, "", nil
+	}).(*lighthousev2a1.ServiceImport)
+}
+
+func (f *Framework) AwaitServiceImportDelete(targetCluster framework.ClusterIndex, sourceCluster framework.ClusterIndex, name string, namespace string) {
+	siName := name + "-" + namespace + "-" + framework.TestContext.ClusterIDs[sourceCluster]
+	si := LighthouseClients[targetCluster].LighthouseV2alpha1().ServiceImports(framework.TestContext.SubmarinerNamespace)
+	framework.AwaitUntil("retrieve ServiceImport", func() (interface{}, error) {
+		_, err := si.Get(siName, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}, func(result interface{}) (bool, string, error) {
+		return result.(bool), "", nil
+	})
+}
+
+func (f *Framework) AwaitGlobalnetIP(cluster framework.ClusterIndex, name string, namespace string) string {
+	if framework.TestContext.GlobalnetEnabled {
+		svc := framework.KubeClients[cluster].CoreV1().Services(namespace)
+		svcObj := framework.AwaitUntil("retrieve service", func() (interface{}, error) {
+			return svc.Get(name, metav1.GetOptions{})
+
+		}, func(result interface{}) (bool, string, error) {
+			svc := result.(*v1.Service)
+			globalIp := svc.Annotations[submarinerIpamGlobalIp]
+			if globalIp == "" {
+				return false, "GlobalIP not available", nil
+			}
+			return true, "", nil
+		}).(*v1.Service)
+		return svcObj.Annotations[submarinerIpamGlobalIp]
+	}
+	return ""
 }


### PR DESCRIPTION
E2E tests are not checking for globalnetIP correctly. To verify IP, we
use service object returned at time of creation. This will never have
globalnetIp as it is annotated later in an update. We should get the
latest service object before verifying.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>