### PR TITLE
Add golangci-lint config file, add linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,50 @@
+linters-settings:
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      #- opinionated
+      #- performance
+      #- style
+    disabled-checks:
+  gocyclo:
+    min-complexity: 15
+  lll:
+    line-length: 140
+  maligned:
+    suggest-new: true
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dupl
+    - errcheck
+    #- exportloopref
+    #- funlen
+    #- gochecknoglobals
+    #- gochecknoinits
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    #- golint
+    #- gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    #- lll
+    - maligned
+    - misspell
+    - nakedret
+    - staticcheck
+    - structcheck
+    #- stylecheck
+    #- testpackage
+    - typecheck
+    - unconvert
+    #- unparam
+    - unused
+    - varcheck
+    #- whitespace


### PR DESCRIPTION
Explicitly enable linters to be run by golangci-lint. Makes testing more
explicit/consistent and also allows us to add non-default linters.

Enables these extra linters over the defaults:

* bodyclose: checks whether HTTP response body is closed successfully
* depguard: Go linter that checks if package imports are in a list of
  acceptable packages
* dupl: Tool for code clone detection
* gocritic: The most opinionated Go source code linter
* gocyclo: Computes and checks the cyclomatic complexity of functions
* gofmt: Gofmt checks whether code was gofmt-ed. By default this tool
  runs with -s option to check for code simplification
* goimports: Goimports does everything that gofmt does. Additionally it
  checks unused imports
* interfacer: Linter that suggests narrower interface types
* maligned: Tool to detect Go structs that would take less memory if
  their fields were sorted
* misspell: Finds commonly misspelled English words in comments
* nakedret: Finds naked returns in functions greater than a specified
  function length
* unconvert: Remove unnecessary type conversions

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>