### PR TITLE
Reduce default agent log verbosity

### DIFF
--- a/package/lighthouse-agent.sh
+++ b/package/lighthouse-agent.sh
@@ -3,10 +3,12 @@ set -e -x
 
 trap "exit 1" SIGTERM SIGINT
 
+LIGHTHOUSE_VERBOSITY=${LIGHTHOUSE_VERBOSITY:-1}
+
 if [ "${LIGHTHOUSE_DEBUG}" == "true" ]; then
-    DEBUG="--debug -v=9"
+    DEBUG="-v=3"
 else
-    DEBUG="-v=4"
+    DEBUG="-v=${LIGHTHOUSE_VERBOSITY}"
 fi
 
 exec lighthouse-agent ${DEBUG} -alsologtostderr


### PR DESCRIPTION
Current default for lighthouse-agent log verbosity is set to 4 while
admiral uses 2 for debug. This changes the default to 1 and adds option
to set custom verbosity through env variable in deployment spec.

Fixes #212

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>