### PR TITLE
server ip selection

### DIFF
--- a/pkg/serviceimport/map.go
+++ b/pkg/serviceimport/map.go
@@ -2,19 +2,47 @@ package serviceimport
 
 import (
 	"sync"
+	"sync/atomic"
 
 	lighthousev2a1 "github.com/submariner-io/lighthouse/pkg/apis/lighthouse.submariner.io/v2alpha1"
 )
+
+type clusterInfo struct {
+	Ip				string
+	Name			string
+	Weight		uint64
+}
 
 type serviceInfo struct {
 	key         string
 	clusterInfo map[string]string
 	ipList      []string
+	queue 			[]clusterInfo // clusters queue [each could have an 1 vertual ip or an ip pool of nodes (headless)]
+	rrCount			uint64
 }
 
 type Map struct {
 	svcMap map[string]*serviceInfo
 	sync.RWMutex
+}
+
+func (m *Map) GetQueue(namespace, name string) ([]clusterInfo, bool) {
+	m.RLock()
+	defer m.RUnlock()
+	if val, ok := m.svcMap[keyFunc(namespace, name)]; ok {
+		return val.queue, len(val.queue) > 0
+	}
+	return nil, false
+}
+
+func (m *Map) GetAndIncRRCounter(namespace, name string) (uint64, bool) {
+	m.RLock()
+	defer m.RUnlock()
+	if val, ok := m.svcMap[keyFunc(namespace, name)]; ok {
+		atomic.AddUint64(&val.rrCount, 1)
+		return val.rrCount, true
+	}
+	return 0, false
 }
 
 func (m *Map) GetIps(namespace, name string) ([]string, bool) {
@@ -52,13 +80,19 @@ func (m *Map) Put(serviceImport *lighthousev2a1.ServiceImport) {
 			remoteService = &serviceInfo{
 				key:         key,
 				clusterInfo: make(map[string]string),
+				rrCount:	0,
 			}
 		}
+
 		for _, info := range serviceImport.Status.Clusters {
 			remoteService.clusterInfo[info.Cluster] = info.IPs[0]
 		}
+
+		remoteService.queue = make([]clusterInfo, 0)
 		remoteService.ipList = make([]string, 0)
-		for _, v := range remoteService.clusterInfo {
+		for k, v := range remoteService.clusterInfo {
+			c := clusterInfo{ Name: k, Ip: v, Weight: 0, }
+			remoteService.queue = append(remoteService.queue, c)
 			remoteService.ipList = append(remoteService.ipList, v)
 		}
 		m.svcMap[key] = remoteService
@@ -81,8 +115,11 @@ func (m *Map) Remove(serviceImport *lighthousev2a1.ServiceImport) {
 		if len(remoteService.clusterInfo) == 0 {
 			delete(m.svcMap, key)
 		} else {
+			remoteService.queue = make([]clusterInfo, 0)
 			remoteService.ipList = make([]string, 0)
-			for _, v := range remoteService.clusterInfo {
+			for k, v := range remoteService.clusterInfo {
+				c := clusterInfo{ Name: k, Ip: v, Weight: 0, }
+				remoteService.queue = append(remoteService.queue, c)
 				remoteService.ipList = append(remoteService.ipList, v)
 			}
 		}


### PR DESCRIPTION
@mkolesnik @vthapar @mangelajo 
Notes and questions:

1) Is there a chance that we will get the same cluster more than once? in `func (m *Map) Put(serviceImport *lighthousev2a1.ServiceImport)` in the `serviceImport.Status.Clusters ` object?
In addition, I saw that headless services can have a list of ips pointing to their pods, should accommodate that case?
2) I was thinking of how to apply the RR mechanism in the best way, and because we don't deal with thousands of clusters I thought that to implement it the way I did - each loop run will cause max of len(queue) increments which will yield a read lock.
Two more possible solutions I came up with:
- Get before loop - Update after -> could cause race with the counting
- Get before the loop (will cause an inc) and just iterate without updating at all - each lookup will cause 1 increment
3) I'm using the clasterInfo by value and not pointers, hope that is ok. It allows me to simplify the code and not worry about clearing memory on deletion. on the other hand, it feels a bit out of the way we are writing code in Golang