### PR TITLE
Remove the obsolete coredns variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-coredns ?= 1.5.2
-
 ifneq (,$(DAPPER_HOST_ARCH))
 
 # Running in Dapper


### PR DESCRIPTION
The coredns version variable in the Makefile is no longer needed, and
ends up being misleading; this removes it.

Signed-off-by: Stephen Kitt <skitt@redhat.com>