### PR TITLE
Initial support for headless services

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
 	github.com/pkg/errors v0.9.1
-	github.com/submariner-io/admiral v0.6.0-pre1
-	github.com/submariner-io/shipyard v0.5.0
+	github.com/submariner-io/admiral v0.6.0-pre4
+	github.com/submariner-io/shipyard v0.5.1-0.20200727153411-5c0d49acd978
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2
 	k8s.io/client-go v11.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -236,7 +236,6 @@ github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2K
 github.com/go-openapi/validate v0.19.5/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85nY1c2z52x1Gk4=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
-github.com/gogo/protobuf v0.0.0-20171007142547-342cbe0a0415/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
@@ -291,6 +290,7 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
+github.com/googleapis/gnostic v0.1.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.2.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.3.1 h1:WeAefnSUHlBb0iJKwxFDZdbfGwkd7xRNuV+IpXMJhYk=
 github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
@@ -415,6 +415,8 @@ github.com/namedotcom/go v0.0.0-20180403034216-08470befbe04/go.mod h1:5sN+Lt1CaY
 github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=
 github.com/naoina/toml v0.1.1/go.mod h1:NBIhNtsFMo3G2szEBne+bO4gS192HuIYRqfvOWb4i1E=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nrdcg/auroradns v1.0.0/go.mod h1:6JPXKzIRzZzMqtTDgueIhTi6rFf1QvYE/HzqidhOhjw=
 github.com/nrdcg/goinwx v0.6.1/go.mod h1:XPiut7enlbEdntAqalBIqcYcTEVhpv/dKWgDCX2SwKQ=
 github.com/nrdcg/namesilo v0.2.1/go.mod h1:lwMvfQTyYq+BbjJd30ylEG4GPSS6PII0Tia4rRpRiyw=
@@ -532,10 +534,12 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/submariner-io/admiral v0.6.0-pre1 h1:v3KBPSQlfFovfkpyXnrwmWeAcSdbJ5zGBgslsLNSAMY=
-github.com/submariner-io/admiral v0.6.0-pre1/go.mod h1:cBv1Zvfai117idhYv5WPxTZEsgWQfeSqwPpxo0EMZXg=
-github.com/submariner-io/shipyard v0.5.0 h1:o4kTCubLFLeh+PaBDac1J7zNY3JKWwj7QrMLNb4g/p8=
-github.com/submariner-io/shipyard v0.5.0/go.mod h1:2OrKoDmJSo1jVurxiVH9FqGFmDwshIU7Vgu9pFLBsYo=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/submariner-io/admiral v0.6.0-pre4 h1:jQAGIjPOPO/lOs8aWyw7yI1atJHhTIPLUPByKLJj+JE=
+github.com/submariner-io/admiral v0.6.0-pre4/go.mod h1:WEryl/5SDe0+7lPoEJo4TMmqkLXId9VVvbTToU4hWWA=
+github.com/submariner-io/shipyard v0.5.1-0.20200727153411-5c0d49acd978 h1:fMxqvFRftIaXcwgSjOPFk6vbmhPejSH8YJGEZMfHMDA=
+github.com/submariner-io/shipyard v0.5.1-0.20200727153411-5c0d49acd978/go.mod h1:9H9ctEv+K61bMy5teo/fG2azZswmXsPVfFTVdk8ZGk0=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/timewasted/linode v0.0.0-20160829202747-37e84520dcf7/go.mod h1:imsgLplxEC/etjIhdr3dNzV3JeT27LbVu5pYWm0JCBY=
 github.com/tinylib/msgp v1.1.0 h1:9fQd+ICuRIu/ue4vxJZu6/LzxN0HwMds2nq/0cFvxHU=
@@ -637,6 +641,8 @@ golang.org/x/net v0.0.0-20191027093000-83d349e8ac1a/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7 h1:AeiKBIuRw3UomYXSbLy0Mc2dDLfdtbT/IVn4keq83P0=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
+golang.org/x/net v0.0.0-20200602114024-627f9648deb9 h1:pNX+40auqi2JqRfOP1akLGtYcn15TUbkhwuCO3foqqM=
+golang.org/x/net v0.0.0-20200602114024-627f9648deb9/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -682,6 +688,8 @@ golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 h1:DYfZAGf2WMFjMxbgTjaC+2HC7NkNAQs+6Q8b9WEB/F4=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 h1:ogLJMz+qpzav7lGMh10LMvAkM/fAoGlaiiHYiFYdm80=
+golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -766,6 +774,8 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/h2non/gock.v1 v1.0.15/go.mod h1:sX4zAkdYX1TRGJ2JY156cFspQn4yRWn6p9EMdODlynE=
@@ -789,6 +799,9 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c h1:grhR+C34yXImVGp7EzNk+DTIk+323eIUWOmEevy6bDo=
+gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
@@ -809,10 +822,8 @@ k8s.io/component-base v0.17.0/go.mod h1:rKuRAokNMY2nn2A6LP/MiwpoaMRHpfRnrPaUJJj1
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20190822140433-26a664648505/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
-k8s.io/klog v0.0.0-20181108234604-8139d8cb77af/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.3/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
-k8s.io/klog v0.4.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.0.0 h1:Foj74zO6RbjjP4hBEKjnYtjjAhGg4jNynUdYF6fJrok=
@@ -837,7 +848,6 @@ sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06/go.mod h1
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 sigs.k8s.io/testing_frameworks v0.1.1 h1:cP2l8fkA3O9vekpy5Ks8mmA0NW/F7yBdXf8brkWhVrs=
 sigs.k8s.io/testing_frameworks v0.1.1/go.mod h1:VVBKrHmJ6Ekkfz284YKhQePcdycOzNH9qL6ht1zEr/U=
-sigs.k8s.io/yaml v0.0.0-20181102190223-fd68e9863619/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=

--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -11,9 +11,11 @@ import (
 	lighthousev2a1 "github.com/submariner-io/lighthouse/pkg/apis/lighthouse.submariner.io/v2alpha1"
 	lighthouseClientset "github.com/submariner-io/lighthouse/pkg/client/clientset/versioned"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/dynamic"
@@ -26,8 +28,13 @@ import (
 const (
 	submarinerIpamGlobalIp = "submariner.io/globalIp"
 	serviceUnavailable     = "ServiceUnavailable"
+	invalidServiceType     = "UnsupportedServiceType"
+	clusterIP              = "cluster-ip"
 	originName             = "origin-name"
 	originNamespace        = "origin-namespace"
+	labelSourceName        = "lighthouse.submariner.io/sourceName"
+	labelSourceNamespace   = "lighthouse.submariner.io/sourceNamespace"
+	labelSourceCluster     = "lighthouse.submariner.io/sourceCluster"
 )
 
 var MaxExportStatusConditions = 10
@@ -67,17 +74,19 @@ func NewWithDetail(spec *AgentSpecification, syncerConf *broker.SyncerConfig, re
 	newSyncer func(*broker.SyncerConfig) (*broker.Syncer, error)) (*Controller, error) {
 	agentController := &Controller{
 		clusterID:        spec.ClusterID,
+		namespace:        spec.Namespace,
 		globalnetEnabled: spec.GlobalnetEnabled,
 		kubeClientSet:    kubeClientSet,
 		lighthouseClient: lighthouseClient,
 	}
 
 	svcExportResourceConfig := broker.ResourceConfig{
-		LocalSourceNamespace:  metav1.NamespaceAll,
-		LocalResourceType:     &lighthousev2a1.ServiceExport{},
-		LocalTransform:        agentController.serviceExportToRemoteServiceImport,
-		LocalOnSuccessfulSync: agentController.onSuccessfulServiceImportSync,
-		BrokerResourceType:    &lighthousev2a1.ServiceImport{},
+		LocalSourceNamespace:      metav1.NamespaceAll,
+		LocalResourceType:         &lighthousev2a1.ServiceExport{},
+		LocalTransform:            agentController.serviceExportToRemoteServiceImport,
+		LocalOnSuccessfulSync:     agentController.onSuccessfulServiceImportSync,
+		BrokerResourceType:        &lighthousev2a1.ServiceImport{},
+		BrokerResourcesEquivalent: agentController.serviceImportEquivalent,
 	}
 
 	syncerConf.Scheme = scheme
@@ -108,6 +117,23 @@ func NewWithDetail(spec *AgentSpecification, syncerConf *broker.SyncerConfig, re
 		return nil, err
 	}
 
+	agentController.endpointSyncer, err = syncer.NewResourceSyncer(&syncer.ResourceSyncerConfig{
+		Name:                "Endpoint events",
+		SourceClient:        localClient,
+		SourceNamespace:     metav1.NamespaceAll,
+		Direction:           syncer.LocalToRemote,
+		RestMapper:          restMapper,
+		Federator:           agentController.serviceExportSyncer.GetBrokerFederator(),
+		ResourceType:        &corev1.Endpoints{},
+		Transform:           agentController.endpointToRemoteServiceImport,
+		ResourcesEquivalent: agentController.endpointEquivalent,
+		Scheme:              scheme,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
 	return agentController, nil
 }
 
@@ -128,12 +154,20 @@ func (a *Controller) Start(stopCh <-chan struct{}) error {
 		return err
 	}
 
+	if err := a.endpointSyncer.Start(stopCh); err != nil {
+		return err
+	}
+
 	klog.Info("Lighthouse agent syncer started")
 
 	return nil
 }
 
 func (a *Controller) serviceExportToRemoteServiceImport(obj runtime.Object, op syncer.Operation) (runtime.Object, bool) {
+	if op == syncer.Update {
+		return nil, false
+	}
+
 	svcExport := obj.(*lighthousev2a1.ServiceExport)
 	serviceImport := a.newServiceImport(svcExport)
 
@@ -156,6 +190,21 @@ func (a *Controller) serviceExportToRemoteServiceImport(obj runtime.Object, op s
 		return nil, true
 	}
 
+	svcType, ok := getServiceImportType(svc)
+
+	if !ok {
+		a.updateExportedServiceStatus(svcExport.Name, svcExport.Namespace, lighthousev2a1.ServiceExportInitialized,
+			corev1.ConditionFalse, invalidServiceType, fmt.Sprintf("Service of type %v not supported", svc.Spec.Type))
+		klog.Errorf("Service type %q not supported", svc.Spec.Type)
+
+		return nil, false
+	}
+
+	if a.globalnetEnabled && svcType == lighthousev2a1.Headless {
+		klog.Errorf("Headless Services not supported with globalnet yet")
+		return nil, false
+	}
+
 	if a.globalnetEnabled && getGlobalIpFromService(svc) == "" {
 		klog.V(log.DEBUG).Infof("Service to be exported (%s/%s) doesn't have a global IP yet", svcExport.Namespace, svcExport.Name)
 
@@ -167,18 +216,38 @@ func (a *Controller) serviceExportToRemoteServiceImport(obj runtime.Object, op s
 	}
 
 	serviceImport.Spec = lighthousev2a1.ServiceImportSpec{
-		Type: lighthousev2a1.SuperclusterIP,
+		Type: svcType,
 	}
+
 	serviceImport.Status = lighthousev2a1.ServiceImportStatus{
 		Clusters: []lighthousev2a1.ClusterStatus{
-			a.newClusterStatus(svc, a.clusterID),
+			{
+				Cluster: a.clusterID,
+				IPs:     a.getIpsForService(svc, svcType),
+			},
 		},
+	}
+
+	if svcType == lighthousev2a1.SuperclusterIP {
+		serviceImport.Annotations[clusterIP] = serviceImport.Status.Clusters[0].IPs[0]
 	}
 
 	a.updateExportedServiceStatus(svcExport.Name, svcExport.Namespace, lighthousev2a1.ServiceExportInitialized,
 		corev1.ConditionTrue, "AwaitingSync", "Awaiting sync of the ServiceImport to the broker")
 
 	return serviceImport, false
+}
+
+func getServiceImportType(service *corev1.Service) (lighthousev2a1.ServiceImportType, bool) {
+	if service.Spec.Type != "" && service.Spec.Type != corev1.ServiceTypeClusterIP {
+		return "", false
+	}
+
+	if service.Spec.ClusterIP == corev1.ClusterIPNone {
+		return lighthousev2a1.Headless, true
+	}
+
+	return lighthousev2a1.SuperclusterIP, true
 }
 
 func (a *Controller) onSuccessfulServiceImportSync(synced runtime.Object, op syncer.Operation) {
@@ -215,6 +284,54 @@ func (a *Controller) serviceToRemoteServiceImport(obj runtime.Object, op syncer.
 	// Update the status and requeue
 	a.updateExportedServiceStatus(svcExport.Name, svcExport.Namespace, lighthousev2a1.ServiceExportInitialized,
 		corev1.ConditionFalse, serviceUnavailable, "Service to be exported doesn't exist")
+
+	return serviceImport, false
+}
+
+func (a *Controller) endpointToRemoteServiceImport(obj runtime.Object, op syncer.Operation) (runtime.Object, bool) {
+	ep := obj.(*corev1.Endpoints)
+	svcExport, err := a.lighthouseClient.LighthouseV2alpha1().ServiceExports(ep.Namespace).Get(ep.Name, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		// Service Export not created yet
+		return nil, false
+	} else if err != nil {
+		// some other error. Log and requeue
+		klog.Errorf("Unable to get ServiceExport for %#v: %v", ep, err)
+		return nil, true
+	}
+
+	serviceImport, err := a.getServiceImport(svcExport)
+
+	if err != nil {
+		// Requeue
+		return nil, true
+	}
+
+	if serviceImport.Spec.Type == lighthousev2a1.Headless && a.globalnetEnabled {
+		klog.Errorf("Headless Services not supported with globalnet yet")
+		return nil, false
+	}
+
+	oldStatus := serviceImport.Status.DeepCopy()
+	ipList := getIpsFromEndpoint(ep)
+
+	if serviceImport.Spec.Type == lighthousev2a1.SuperclusterIP && len(ipList) > 0 {
+		// Once we cache service and related objecs, this won't be needed
+		ipList = []string{serviceImport.Annotations[clusterIP]}
+	}
+
+	serviceImport.Status = lighthousev2a1.ServiceImportStatus{
+		Clusters: []lighthousev2a1.ClusterStatus{
+			{
+				Cluster: a.clusterID,
+				IPs:     ipList,
+			},
+		},
+	}
+	if reflect.DeepEqual(oldStatus, serviceImport.Status) {
+		klog.V(log.DEBUG).Infof("Old and new cluster status are same")
+		return nil, false
+	}
 
 	return serviceImport, false
 }
@@ -263,21 +380,19 @@ func (a *Controller) updateExportedServiceStatus(name, namespace string, condTyp
 	}
 }
 
+func (a *Controller) serviceImportEquivalent(obj1, obj2 *unstructured.Unstructured) bool {
+	return syncer.DefaultResourcesEquivalent(obj1, obj2) &&
+		equality.Semantic.DeepEqual(util.GetNestedField(obj1, "status"), util.GetNestedField(obj2, "status"))
+}
+
+func (a *Controller) endpointEquivalent(obj1, obj2 *unstructured.Unstructured) bool {
+	return equality.Semantic.DeepEqual(util.GetNestedField(obj1, "subsets"),
+		util.GetNestedField(obj2, "subsets"))
+}
+
 func serviceExportConditionEqual(c1, c2 *lighthousev2a1.ServiceExportCondition) bool {
 	return c1.Type == c2.Type && c1.Status == c2.Status && reflect.DeepEqual(c1.Reason, c2.Reason) &&
 		reflect.DeepEqual(c1.Message, c2.Message)
-}
-
-func (a *Controller) newClusterStatus(service *corev1.Service, clusterID string) lighthousev2a1.ClusterStatus {
-	mcsIp := getGlobalIpFromService(service)
-	if mcsIp == "" {
-		mcsIp = service.Spec.ClusterIP
-	}
-
-	return lighthousev2a1.ClusterStatus{
-		Cluster: clusterID,
-		IPs:     []string{mcsIp},
-	}
 }
 
 func (a *Controller) newServiceImport(svcExport *lighthousev2a1.ServiceExport) *lighthousev2a1.ServiceImport {
@@ -288,8 +403,57 @@ func (a *Controller) newServiceImport(svcExport *lighthousev2a1.ServiceExport) *
 				originName:      svcExport.Name,
 				originNamespace: svcExport.Namespace,
 			},
+			Labels: map[string]string{
+				labelSourceName:      svcExport.Name,
+				labelSourceNamespace: svcExport.Namespace,
+				labelSourceCluster:   a.clusterID,
+			},
 		},
 	}
+}
+
+func (a *Controller) getServiceImport(svcExport *lighthousev2a1.ServiceExport) (*lighthousev2a1.ServiceImport, error) {
+	siName := svcExport.Name + "-" + svcExport.Namespace + "-" + a.clusterID
+	serviceImport, err := a.lighthouseClient.LighthouseV2alpha1().ServiceImports(a.namespace).Get(siName, metav1.GetOptions{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return serviceImport, nil
+}
+
+func (a *Controller) getIpsForService(service *corev1.Service, siType lighthousev2a1.ServiceImportType) []string {
+	if siType == lighthousev2a1.SuperclusterIP {
+		mcsIp := getGlobalIpFromService(service)
+		if mcsIp == "" {
+			mcsIp = service.Spec.ClusterIP
+		}
+
+		return []string{mcsIp}
+	}
+
+	endpoint, err := a.kubeClientSet.CoreV1().Endpoints(service.Namespace).Get(service.Name, metav1.GetOptions{})
+	if err != nil {
+		klog.V(log.DEBUG).Infof("Endpoints for svc  (%s/%s) not found: %v", service.Namespace, service.Name, err)
+		return make([]string, 0)
+	}
+
+	return getIpsFromEndpoint(endpoint)
+}
+
+func getIpsFromEndpoint(endpoint *corev1.Endpoints) []string {
+	ipList := make([]string, 0)
+
+	for _, eps := range endpoint.Subsets {
+		for _, addr := range eps.Addresses {
+			ipList = append(ipList, addr.IP)
+		}
+	}
+
+	klog.V(log.DEBUG).Infof("IPList %v for endpoint (%s/%s)", ipList, endpoint.Namespace, endpoint.Name)
+
+	return ipList
 }
 
 func getGlobalIpFromService(service *corev1.Service) string {

--- a/pkg/agent/controller/agent_test.go
+++ b/pkg/agent/controller/agent_test.go
@@ -202,7 +202,8 @@ func newTestDiver() *testDriver {
 			},
 		}
 
-		t.restMapper = test.GetRESTMapperFor(&lighthousev2a1.ServiceExport{}, &lighthousev2a1.ServiceImport{}, &corev1.Service{})
+		t.restMapper = test.GetRESTMapperFor(&lighthousev2a1.ServiceExport{}, &lighthousev2a1.ServiceImport{},
+			&corev1.Service{}, &corev1.Endpoints{})
 
 		t.localDynClient = fake.NewDynamicClient()
 		t.brokerDynClient = fake.NewDynamicClient()
@@ -278,7 +279,7 @@ func (t *testDriver) dynamicServiceClient() dynamic.ResourceInterface {
 }
 
 func (t *testDriver) awaitServiceImport(client dynamic.ResourceInterface, serviceIP string) {
-	obj := test.WaitForResource(client, t.service.Name+"-"+t.service.Namespace+"-"+clusterID)
+	obj := test.AwaitResource(client, t.service.Name+"-"+t.service.Namespace+"-"+clusterID)
 
 	serviceImport := &lighthousev2a1.ServiceImport{}
 	Expect(scheme.Scheme.Convert(obj, serviceImport, nil)).To(Succeed())
@@ -294,7 +295,7 @@ func (t *testDriver) awaitServiceImport(client dynamic.ResourceInterface, servic
 }
 
 func (t *testDriver) awaitNoServiceImport(client dynamic.ResourceInterface) {
-	test.WaitForNoResource(client, t.service.Name+"-"+t.service.Namespace+"-"+clusterID)
+	test.AwaitNoResource(client, t.service.Name+"-"+t.service.Namespace+"-"+clusterID)
 }
 
 func (t *testDriver) awaitServiceExportStatus(atIndex int, expCond ...*lighthousev2a1.ServiceExportCondition) {

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -10,10 +10,12 @@ import (
 type Controller struct {
 	clusterID           string
 	globalnetEnabled    bool
+	namespace           string
 	kubeClientSet       kubernetes.Interface
 	lighthouseClient    lighthouseClientset.Interface
 	serviceExportSyncer *broker.Syncer
 	serviceSyncer       syncer.Interface
+	endpointSyncer      syncer.Interface
 }
 
 type AgentSpecification struct {

--- a/pkg/serviceimport/map_test.go
+++ b/pkg/serviceimport/map_test.go
@@ -33,9 +33,12 @@ var _ = Describe("ServiceImport map", func() {
 	}
 
 	selectIP := func(ns, name string) string {
-		ip, found := serviceImportMap.SelectIP(ns, name, checkCluster)
+		ip, found := serviceImportMap.GetIPs(ns, name, checkCluster)
 		Expect(found).To(BeTrue())
-		return ip
+		if len(ip) == 0 {
+			return ""
+		}
+		return ip[0]
 	}
 
 	When("a service is present in one connected cluster", func() {
@@ -141,7 +144,7 @@ var _ = Describe("ServiceImport map", func() {
 
 	When("a service does not exist", func() {
 		It("should return not found", func() {
-			_, found := serviceImportMap.SelectIP(namespace1, service1, checkCluster)
+			_, found := serviceImportMap.GetIPs(namespace1, service1, checkCluster)
 			Expect(found).To(BeFalse())
 		})
 	})
@@ -163,7 +166,7 @@ var _ = Describe("ServiceImport map", func() {
 			Expect(selectIP(namespace1, service1)).To(Equal(serviceIP1))
 
 			serviceImportMap.Remove(si)
-			_, found := serviceImportMap.SelectIP(namespace1, service1, checkCluster)
+			_, found := serviceImportMap.GetIPs(namespace1, service1, checkCluster)
 			Expect(found).To(BeFalse())
 
 			// Should be a no-op


### PR DESCRIPTION
This adds limited initial support for headless services.

TBD:
 * Allow creation of headless service after service export
 * Support for stateful sets
 * Conflict resolution for service type between clusters
 * E2E

Fixes #117

Reference: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>