### PR TITLE
Update codegen for 1.17

### DIFF
--- a/scripts/codegen
+++ b/scripts/codegen
@@ -6,15 +6,14 @@ K8S_IO_DIR="${GOPATH:-~/go}/src/k8s.io"
 CODEGEN_SCRIPT_DIR="${K8S_IO_DIR}/code-generator"
 CODEGEN_SCRIPT="${CODEGEN_SCRIPT_DIR}/generate-groups.sh"
 CODEGEN_RELEASE_TAG=kubernetes-1.17.0
-export GO111MODULE=off
-mkdir -p $K8S_IO_DIR
 
 if [ ! -f "$CODEGEN_SCRIPT" ]; then
     echo "$CODEGEN_SCRIPT does not exist - downloading..."
-    cd $K8S_IO_DIR
-    git clone --branch $CODEGEN_RELEASE_TAG https://github.com/kubernetes/code-generator
+    git clone --branch $CODEGEN_RELEASE_TAG https://github.com/kubernetes/code-generator "${CODEGEN_SCRIPT_DIR}"
+    cd "${CODEGEN_SCRIPT_DIR}"
+    go mod vendor
     cd -
-    echo "Successfully checked out release tag $CODEGEN_RELEASE_TAG"
+    echo "Successsfully checked out release tag $CODEGEN_RELEASE_TAG"
 fi
 
-$CODEGEN_SCRIPT all github.com/submariner-io/lighthouse/pkg/client github.com/submariner-io/lighthouse/pkg/apis lighthouse.submariner.io:v1,v2alpha1
+"${CODEGEN_SCRIPT}" all github.com/submariner-io/lighthouse/pkg/client github.com/submariner-io/lighthouse/pkg/apis lighthouse.submariner.io:v1,v2alpha1


### PR DESCRIPTION
This pulls in the changes from Submariner, supporting codegen using
the Kubernetes 1.17-compatible version.

Signed-off-by: Stephen Kitt <skitt@redhat.com>