### PR TITLE
Migrate CRDs to apiextensions v1

### DIFF
--- a/package/lighthouse-crd.yaml
+++ b/package/lighthouse-crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: serviceimports.lighthouse.submariner.io


### PR DESCRIPTION
The apiextensions.k8s.io/v1beta1 version of CustomResourceDefinition
is deprecated in Kubernetes v1.16 and will no longer be served in
v1.19. Use apiextensions.k8s.io/v1 instead.

Signed-off-by: Stephen Kitt <skitt@redhat.com>