### PR TITLE
Update serviceimport.Controller unit tests

### DIFF
--- a/pkg/serviceimport/store.go
+++ b/pkg/serviceimport/store.go
@@ -1,0 +1,9 @@
+package serviceimport
+
+import lighthousev2a1 "github.com/submariner-io/lighthouse/pkg/apis/lighthouse.submariner.io/v2alpha1"
+
+type Store interface {
+	Put(serviceImport *lighthousev2a1.ServiceImport)
+
+	Remove(serviceImport *lighthousev2a1.ServiceImport)
+}


### PR DESCRIPTION
Created a Store interface to decouple the Controller from Map.GetIPs and
enable simple mocking of Put/Remove.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>