### PR TITLE
Bump shipyard base image to 0.6.1

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM quay.io/submariner/shipyard-dapper-base:0.6.0
+FROM quay.io/submariner/shipyard-dapper-base:0.6.1
 
 ENV DAPPER_ENV="REPO TAG QUAY_USERNAME QUAY_PASSWORD GITHUB_SHA BUILD_ARGS CLUSTERS_ARGS DEPLOY_ARGS RELEASE_ARGS" \
     DAPPER_SOURCE=/go/src/github.com/submariner-io/lighthouse DAPPER_DOCKER_SOCKET=true


### PR DESCRIPTION
This includes the latest 0.6.0-rc0 subctl version
and git commit message linting support.