### PR TITLE
Bump MD link check linter 0.6->1.*

### DIFF
--- a/.github/workflows/md-links-periodic.yml
+++ b/.github/workflows/md-links-periodic.yml
@@ -12,7 +12,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Run markdown-link-check
-      uses: gaurav-nelson/github-action-markdown-link-check@0.6.0
+      uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         config-file: ".markdownlinkcheck.json"
 

--- a/.github/workflows/md-links.yml
+++ b/.github/workflows/md-links.yml
@@ -10,7 +10,7 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Run markdown-link-check
-      uses: gaurav-nelson/github-action-markdown-link-check@0.6.0
+      uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         config-file: ".markdownlinkcheck.json"
         check-modified-files-only: "yes"


### PR DESCRIPTION
Adds support for check-modified-files-only config, which currently isn't
honored and throws a warning.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>