### PR TITLE
DNS Parser changes to support host.cluster.*

### DIFF
--- a/plugin/lighthouse/handler.go
+++ b/plugin/lighthouse/handler.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"strings"
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/request"
@@ -45,11 +44,7 @@ func (lh *Lighthouse) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns
 		return lh.nextOrFailure(state.Name(), ctx, w, r, dns.RcodeNameError, "Only services supported")
 	}
 
-	query := strings.Split(qname, ".")
-	svcName := query[0]
-	namespace := query[1]
-
-	serviceIps, found := lh.serviceImports.GetIPs(namespace, svcName, lh.clusterStatus.IsConnected)
+	serviceIps, found := lh.serviceImports.GetIPs(pReq.namespace, pReq.service, lh.clusterStatus.IsConnected)
 	if !found {
 		// We couldn't find record for this service name
 		log.Debugf("No record found for service %q", qname)


### PR DESCRIPTION
Current parser is taken as-is from coredns/kubernetes plugin and doesn't
handle the `<host>.<cluster>.<svcname>.<ns>.clusterset.local` type queries
for headless multicluster service use case. Since we currently don't
support SRV records, replace port and protocol parsing with
hostname and cluster.

This is a pre-requisite to support StatefulSets use case #215

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>