### PR TITLE
Fix flaky verify failures with headless+globalnet

### DIFF
--- a/test/e2e/discovery/headless_services.go
+++ b/test/e2e/discovery/headless_services.go
@@ -13,26 +13,35 @@ import (
 var _ = Describe("[discovery] Test Headless Service Discovery Across Clusters", func() {
 	f := lhframework.NewFramework("discovery")
 
-	if !framework.TestContext.GlobalnetEnabled {
-
-		When("a pod tries to resolve a headless service in a remote cluster", func() {
-			It("should resolve the backing pod IPs from the remote cluster", func() {
+	When("a pod tries to resolve a headless service in a remote cluster", func() {
+		It("should resolve the backing pod IPs from the remote cluster", func() {
+			if !framework.TestContext.GlobalnetEnabled {
 				RunHeadlessDiscoveryTest(f)
-			})
+			} else {
+				framework.Skipf("Globalnet is enabled, skipping the test...")
+			}
 		})
+	})
 
-		When("a pod tries to resolve a headless service which is exported locally and in a remote cluster", func() {
-			It("should resolve the backing pod IPs from both clusters", func() {
+	When("a pod tries to resolve a headless service which is exported locally and in a remote cluster", func() {
+		It("should resolve the backing pod IPs from both clusters", func() {
+			if !framework.TestContext.GlobalnetEnabled {
 				RunHeadlessDiscoveryLocalAndRemoteTest(f)
-			})
+			} else {
+				framework.Skipf("Globalnet is enabled, skipping the test...")
+			}
 		})
+	})
 
-		When("the number of active pods backing a service changes", func() {
-			It("should only resolve the IPs from the active pods", func() {
+	When("the number of active pods backing a service changes", func() {
+		It("should only resolve the IPs from the active pods", func() {
+			if !framework.TestContext.GlobalnetEnabled {
 				RunHeadlessPodsAvailabilityTest(f)
-			})
+			} else {
+				framework.Skipf("Globalnet is enabled, skipping the test...")
+			}
 		})
-	}
+	})
 })
 
 func RunHeadlessDiscoveryTest(f *lhframework.Framework) {


### PR DESCRIPTION
When running `subctl verify`, TestContext.GlobalnetEnabled flag is not set by the
time we check for it. Move the flag check to inside `It()` block to make
sure it is always set by the time we run our tests.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>