### PR TITLE
Create only one Netshoot deployment during e2e headless tests

### DIFF
--- a/test/e2e/discovery/headless_services.go
+++ b/test/e2e/discovery/headless_services.go
@@ -60,7 +60,6 @@ func RunHeadlessDiscoveryTest(f *lhframework.Framework) {
 
 	By(fmt.Sprintf("Creating a Netshoot Deployment on %q", clusterAName))
 
-	f.NewNetShootDeployment(framework.ClusterA)
 	netshootPodList := f.NewNetShootDeployment(framework.ClusterA)
 
 	ipList := f.GetEndpointIPs(framework.ClusterB, nginxHeadlessClusterB.Name, nginxHeadlessClusterB.Namespace)
@@ -97,7 +96,6 @@ func RunHeadlessDiscoveryLocalAndRemoteTest(f *lhframework.Framework) {
 
 	By(fmt.Sprintf("Creating a Netshoot Deployment on %q", clusterAName))
 
-	f.NewNetShootDeployment(framework.ClusterA)
 	netshootPodList := f.NewNetShootDeployment(framework.ClusterA)
 
 	ipListB := f.GetEndpointIPs(framework.ClusterB, nginxHeadlessClusterB.Name, nginxHeadlessClusterB.Namespace)
@@ -131,7 +129,6 @@ func RunHeadlessPodsAvailabilityTest(f *lhframework.Framework) {
 
 	By(fmt.Sprintf("Creating a Netshoot Deployment on %q", clusterAName))
 
-	f.NewNetShootDeployment(framework.ClusterA)
 	netshootPodList := f.NewNetShootDeployment(framework.ClusterA)
 
 	ipList := f.AwaitEndpointIPs(framework.ClusterB, nginxHeadlessClusterB.Name, nginxHeadlessClusterB.Namespace, 3)


### PR DESCRIPTION
Otherwise, it will fail sometimes with:

```
Failed to find pods for app netshoot. Actual pod count 2 does
not match the expected pod count 1
    Unexpected error:
        <*errors.errorString | 0xc0003e67b0>: {
            s: "timed out waiting for the condition",
        }
        timed out waiting for the condition occurred
```

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>