### PR TITLE
Add second broker client in agent controller tests

### DIFF
--- a/pkg/agent/controller/agent_test.go
+++ b/pkg/agent/controller/agent_test.go
@@ -31,7 +31,8 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
-const clusterID = "east"
+const clusterID1 = "east"
+const clusterID2 = "west"
 
 var _ = Describe("ServiceImport syncing", func() {
 	t := newTestDiver()
@@ -63,8 +64,7 @@ var _ = Describe("ServiceImport syncing", func() {
 			t.awaitServiceExported(t.service.Spec.ClusterIP, 0)
 
 			t.deleteServiceExport()
-			t.awaitNoServiceImport(t.brokerServiceImportClient)
-			t.awaitNoServiceImport(t.localServiceImportClient)
+			t.awaitServiceUnexported()
 		})
 	})
 
@@ -75,8 +75,7 @@ var _ = Describe("ServiceImport syncing", func() {
 			nextStatusIndex := t.awaitServiceExported(t.service.Spec.ClusterIP, 0)
 
 			t.deleteService()
-			t.awaitNoServiceImport(t.brokerServiceImportClient)
-			t.awaitNoServiceImport(t.localServiceImportClient)
+			t.awaitServiceUnexported()
 			t.awaitServiceUnavailableStatus(nextStatusIndex)
 		})
 	})
@@ -112,11 +111,11 @@ var _ = Describe("ServiceImport syncing", func() {
 
 			t.endpoints.Subsets[0].Addresses = nil
 			t.updateEndpoints()
-			t.awaitUpdatedServiceImport(t.localServiceImportClient)
+			t.awaitUpdatedServiceImport()
 
 			t.endpoints.Subsets[0].Addresses = append(t.endpoints.Subsets[0].Addresses, corev1.EndpointAddress{IP: "192.168.5.10"})
 			t.updateEndpoints()
-			t.awaitUpdatedServiceImport(t.localServiceImportClient, t.service.Spec.ClusterIP)
+			t.awaitUpdatedServiceImport()
 		})
 	})
 
@@ -161,7 +160,8 @@ var _ = Describe("Globalnet enabled", func() {
 	t := newTestDiver()
 
 	globalIP := "192.168.10.34"
-	t.agentSpec.GlobalnetEnabled = true
+	t.cluster1.agentSpec.GlobalnetEnabled = true
+	t.cluster2.agentSpec.GlobalnetEnabled = true
 
 	JustBeforeEach(func() {
 		t.createService()
@@ -184,7 +184,7 @@ var _ = Describe("Globalnet enabled", func() {
 				corev1.ConditionFalse, "ServiceGlobalIPUnavailable"))
 
 			t.service.SetAnnotations(map[string]string{"submariner.io/globalIp": globalIP})
-			_, err := t.localServiceClient.CoreV1().Services(t.service.Namespace).Update(t.service)
+			_, err := t.cluster1.localServiceClient.CoreV1().Services(t.service.Namespace).Update(t.service)
 			Expect(err).To(Succeed())
 
 			t.awaitServiceExported(globalIP, 1)
@@ -222,8 +222,7 @@ var _ = Describe("Headless service syncing", func() {
 				t.createEndpoints()
 				t.createServiceExport()
 
-				t.awaitServiceImport(t.localServiceImportClient, lighthousev2a1.Headless, t.endpointIPs()...)
-				t.awaitServiceImport(t.brokerServiceImportClient, lighthousev2a1.Headless, t.endpointIPs()...)
+				t.awaitHeadlessServiceExported(t.endpointIPs()...)
 			})
 		})
 
@@ -231,13 +230,11 @@ var _ = Describe("Headless service syncing", func() {
 			It("should eventually sync a correct ServiceImport", func() {
 				t.createServiceExport()
 
-				t.awaitServiceImport(t.localServiceImportClient, lighthousev2a1.Headless)
-				t.awaitServiceImport(t.brokerServiceImportClient, lighthousev2a1.Headless)
+				t.awaitHeadlessServiceExported()
 
 				t.createEndpoints()
 
-				t.awaitUpdatedServiceImport(t.localServiceImportClient, t.endpointIPs()...)
-				t.awaitUpdatedServiceImport(t.brokerServiceImportClient, t.endpointIPs()...)
+				t.awaitUpdatedServiceImport(t.endpointIPs()...)
 			})
 		})
 	})
@@ -247,14 +244,11 @@ var _ = Describe("Headless service syncing", func() {
 			t.createEndpoints()
 			t.createServiceExport()
 
-			t.awaitServiceImport(t.localServiceImportClient, lighthousev2a1.Headless, t.endpointIPs()...)
-			t.awaitServiceImport(t.brokerServiceImportClient, lighthousev2a1.Headless, t.endpointIPs()...)
+			t.awaitHeadlessServiceExported(t.endpointIPs()...)
 
 			t.endpoints.Subsets[0].Addresses = append(t.endpoints.Subsets[0].Addresses, corev1.EndpointAddress{IP: "192.168.5.3"})
 			t.updateEndpoints()
-
-			t.awaitUpdatedServiceImport(t.localServiceImportClient, t.endpointIPs()...)
-			t.awaitUpdatedServiceImport(t.brokerServiceImportClient, t.endpointIPs()...)
+			t.awaitUpdatedServiceImport(t.endpointIPs()...)
 		})
 	})
 })
@@ -270,13 +264,13 @@ var _ = Describe("Service export failures", func() {
 
 	When("Service retrieval initially fails", func() {
 		BeforeEach(func() {
-			t.servicesReactor.SetFailOnGet(errors.New("fake Get error"))
+			t.cluster1.servicesReactor.SetFailOnGet(errors.New("fake Get error"))
 		})
 
 		It("should update the ServiceExport status and eventually sync a ServiceImport", func() {
 			t.awaitServiceExportStatus(0, newServiceExportCondition(lighthousev2a1.ServiceExportInitialized,
 				corev1.ConditionUnknown, "ServiceRetrievalFailed"))
-			t.servicesReactor.SetResetOnFailure(true)
+			t.cluster1.servicesReactor.SetResetOnFailure(true)
 			t.awaitServiceExported(t.service.Spec.ClusterIP, 1)
 		})
 	})
@@ -284,14 +278,14 @@ var _ = Describe("Service export failures", func() {
 	When("Endpoints retrieval initially fails", func() {
 		BeforeEach(func() {
 			t.service.Spec.ClusterIP = corev1.ClusterIPNone
-			t.endpointsReactor.SetFailOnGet(errors.New("fake Get error"))
+			t.cluster1.endpointsReactor.SetFailOnGet(errors.New("fake Get error"))
 		})
 
 		It("should update the ServiceExport status and eventually sync a ServiceImport", func() {
 			t.awaitServiceExportStatus(0, newServiceExportCondition(lighthousev2a1.ServiceExportInitialized,
 				corev1.ConditionUnknown, "ServiceRetrievalFailed"))
-			t.endpointsReactor.SetResetOnFailure(true)
-			t.awaitServiceImport(t.localServiceImportClient, lighthousev2a1.Headless, t.endpointIPs()...)
+			t.cluster1.endpointsReactor.SetResetOnFailure(true)
+			t.awaitHeadlessServiceExported(t.endpointIPs()...)
 		})
 	})
 
@@ -299,10 +293,10 @@ var _ = Describe("Service export failures", func() {
 		It("should eventually delete the ServiceImport", func() {
 			t.awaitServiceExported(t.service.Spec.ClusterIP, 0)
 
-			t.serviceExportReactor.SetFailOnGet(errors.New("fake Get error"))
-			t.serviceExportReactor.SetResetOnFailure(true)
+			t.cluster1.serviceExportReactor.SetFailOnGet(errors.New("fake Get error"))
+			t.cluster1.serviceExportReactor.SetResetOnFailure(true)
 			t.deleteService()
-			t.awaitNoServiceImport(t.localServiceImportClient)
+			t.awaitNoServiceImport(t.cluster1.localServiceImportClient)
 		})
 	})
 
@@ -312,14 +306,14 @@ var _ = Describe("Service export failures", func() {
 		})
 
 		It("should eventually update the ServiceImport", func() {
-			t.awaitServiceImport(t.localServiceImportClient, lighthousev2a1.Headless, t.endpointIPs()...)
+			t.awaitHeadlessServiceExported(t.endpointIPs()...)
 
-			t.serviceExportReactor.SetFailOnGet(errors.New("fake Get error"))
-			t.serviceExportReactor.SetResetOnFailure(true)
+			t.cluster1.serviceExportReactor.SetFailOnGet(errors.New("fake Get error"))
+			t.cluster1.serviceExportReactor.SetResetOnFailure(true)
 			t.endpoints.Subsets[0].Addresses = append(t.endpoints.Subsets[0].Addresses, corev1.EndpointAddress{IP: "192.168.5.3"})
 			t.updateEndpoints()
 
-			t.awaitUpdatedServiceImport(t.localServiceImportClient, t.endpointIPs()...)
+			t.awaitUpdatedServiceImport(t.endpointIPs()...)
 		})
 	})
 
@@ -329,22 +323,22 @@ var _ = Describe("Service export failures", func() {
 		})
 
 		It("should eventually update the ServiceImport", func() {
-			t.awaitServiceImport(t.localServiceImportClient, lighthousev2a1.Headless, t.endpointIPs()...)
+			t.awaitHeadlessServiceExported(t.endpointIPs()...)
 
-			t.serviceImportReactor.SetFailOnGet(errors.New("fake Get error"))
-			t.serviceImportReactor.SetResetOnFailure(true)
+			t.cluster1.serviceImportReactor.SetFailOnGet(errors.New("fake Get error"))
+			t.cluster1.serviceImportReactor.SetResetOnFailure(true)
 			t.endpoints.Subsets[0].Addresses = append(t.endpoints.Subsets[0].Addresses, corev1.EndpointAddress{IP: "192.168.5.3"})
 			t.updateEndpoints()
 
-			t.awaitUpdatedServiceImport(t.localServiceImportClient, t.endpointIPs()...)
+			t.awaitUpdatedServiceImport(t.endpointIPs()...)
 		})
 	})
 
 	When("a conflict initially occurs when updating the ServiceExport status", func() {
 		BeforeEach(func() {
-			t.serviceExportReactor.SetFailOnUpdate(apierrors.NewConflict(schema.GroupResource{}, t.serviceExport.Name,
+			t.cluster1.serviceExportReactor.SetFailOnUpdate(apierrors.NewConflict(schema.GroupResource{}, t.serviceExport.Name,
 				errors.New("fake conflict")))
-			t.serviceExportReactor.SetResetOnFailure(true)
+			t.cluster1.serviceExportReactor.SetResetOnFailure(true)
 		})
 
 		It("should eventually update the ServiceExport status", func() {
@@ -353,34 +347,49 @@ var _ = Describe("Service export failures", func() {
 	})
 })
 
+type cluster struct {
+	agentSpec                controller.AgentSpecification
+	localDynClient           dynamic.Interface
+	localServiceExportClient dynamic.ResourceInterface
+	localServiceImportClient dynamic.ResourceInterface
+	localServiceClient       kubernetes.Interface
+	lighthouseClient         lighthouseClientset.Interface
+	endpointsReactor         *fake.FailingReactor
+	servicesReactor          *fake.FailingReactor
+	serviceExportReactor     *fake.FailingReactor
+	serviceImportReactor     *fake.FailingReactor
+}
+
 type testDriver struct {
-	agentController           *controller.Controller
-	agentSpec                 *controller.AgentSpecification
-	localDynClient            dynamic.Interface
+	cluster1                  cluster
+	cluster2                  cluster
 	brokerDynClient           dynamic.Interface
-	localServiceExportClient  dynamic.ResourceInterface
-	localServiceImportClient  dynamic.ResourceInterface
 	brokerServiceImportClient *fake.DynamicResourceClient
-	localServiceClient        kubernetes.Interface
-	lighthouseClient          lighthouseClientset.Interface
 	service                   *corev1.Service
 	serviceExport             *lighthousev2a1.ServiceExport
 	endpoints                 *corev1.Endpoints
 	stopCh                    chan struct{}
 	now                       time.Time
 	restMapper                meta.RESTMapper
-	endpointsReactor          *fake.FailingReactor
-	servicesReactor           *fake.FailingReactor
-	serviceExportReactor      *fake.FailingReactor
-	serviceImportReactor      *fake.FailingReactor
 }
 
 func newTestDiver() *testDriver {
-	t := &testDriver{agentSpec: &controller.AgentSpecification{
-		ClusterID:        clusterID,
-		Namespace:        test.LocalNamespace,
-		GlobalnetEnabled: false,
-	}}
+	t := &testDriver{
+		cluster1: cluster{
+			agentSpec: controller.AgentSpecification{
+				ClusterID:        clusterID1,
+				Namespace:        test.LocalNamespace,
+				GlobalnetEnabled: false,
+			},
+		},
+		cluster2: cluster{
+			agentSpec: controller.AgentSpecification{
+				ClusterID:        clusterID2,
+				Namespace:        test.LocalNamespace,
+				GlobalnetEnabled: false,
+			},
+		},
+	}
 
 	BeforeEach(func() {
 		t.now = time.Now()
@@ -425,27 +434,13 @@ func newTestDiver() *testDriver {
 		t.restMapper = test.GetRESTMapperFor(&lighthousev2a1.ServiceExport{}, &lighthousev2a1.ServiceImport{},
 			&corev1.Service{}, &corev1.Endpoints{}, &discovery.EndpointSlice{})
 
-		t.localDynClient = fake.NewDynamicClient()
 		t.brokerDynClient = fake.NewDynamicClient()
-
-		t.localServiceExportClient = t.localDynClient.Resource(*test.GetGroupVersionResourceFor(t.restMapper,
-			&lighthousev2a1.ServiceExport{})).Namespace(test.LocalNamespace)
-
-		t.localServiceImportClient = t.localDynClient.Resource(*test.GetGroupVersionResourceFor(t.restMapper,
-			&lighthousev2a1.ServiceImport{})).Namespace(test.LocalNamespace)
 
 		t.brokerServiceImportClient = t.brokerDynClient.Resource(*test.GetGroupVersionResourceFor(t.restMapper,
 			&lighthousev2a1.ServiceImport{})).Namespace(test.RemoteNamespace).(*fake.DynamicResourceClient)
 
-		fakeCS := fakeKubeClient.NewSimpleClientset()
-		t.endpointsReactor = fake.NewFailingReactorForResource(&fakeCS.Fake, "endpoints")
-		t.servicesReactor = fake.NewFailingReactorForResource(&fakeCS.Fake, "services")
-		t.localServiceClient = fakeCS
-
-		fakeLH := fakeLighthouseClientset.NewSimpleClientset()
-		t.serviceExportReactor = fake.NewFailingReactorForResource(&fakeLH.Fake, "serviceexports")
-		t.serviceImportReactor = fake.NewFailingReactorForResource(&fakeLH.Fake, "serviceimports")
-		t.lighthouseClient = fakeLH
+		t.cluster1.init(t.restMapper)
+		t.cluster2.init(t.restMapper)
 	})
 
 	JustBeforeEach(func() {
@@ -457,15 +452,8 @@ func newTestDiver() *testDriver {
 		Expect(corev1.AddToScheme(syncerScheme)).To(Succeed())
 		Expect(lighthousev2a1.AddToScheme(syncerScheme)).To(Succeed())
 
-		var err error
-		t.agentController, err = controller.NewWithDetail(t.agentSpec, syncerConfig, t.restMapper, t.localDynClient,
-			t.localServiceClient, t.lighthouseClient, syncerScheme, func(config *broker.SyncerConfig) (*broker.Syncer, error) {
-				return broker.NewSyncerWithDetail(config, t.localDynClient, t.brokerDynClient, t.restMapper)
-			})
-
-		Expect(err).To(Succeed())
-
-		Expect(t.agentController.Start(t.stopCh)).To(Succeed())
+		t.cluster1.start(t, syncerConfig, syncerScheme)
+		t.cluster2.start(t, syncerConfig, syncerScheme)
 	})
 
 	AfterEach(func() {
@@ -475,75 +463,67 @@ func newTestDiver() *testDriver {
 	return t
 }
 
-func (t *testDriver) createService() {
-	_, err := t.localServiceClient.CoreV1().Services(t.service.Namespace).Create(t.service)
+func (c *cluster) init(restMapper meta.RESTMapper) {
+	c.localDynClient = fake.NewDynamicClient()
+
+	c.localServiceExportClient = c.localDynClient.Resource(*test.GetGroupVersionResourceFor(restMapper,
+		&lighthousev2a1.ServiceExport{})).Namespace(test.LocalNamespace)
+
+	c.localServiceImportClient = c.localDynClient.Resource(*test.GetGroupVersionResourceFor(restMapper,
+		&lighthousev2a1.ServiceImport{})).Namespace(test.LocalNamespace)
+
+	fakeCS := fakeKubeClient.NewSimpleClientset()
+	c.endpointsReactor = fake.NewFailingReactorForResource(&fakeCS.Fake, "endpoints")
+	c.servicesReactor = fake.NewFailingReactorForResource(&fakeCS.Fake, "services")
+	c.localServiceClient = fakeCS
+
+	fakeLH := fakeLighthouseClientset.NewSimpleClientset()
+	c.serviceExportReactor = fake.NewFailingReactorForResource(&fakeLH.Fake, "serviceexports")
+	c.serviceImportReactor = fake.NewFailingReactorForResource(&fakeLH.Fake, "serviceimports")
+	c.lighthouseClient = fakeLH
+}
+
+func (c *cluster) start(t *testDriver, syncerConfig *broker.SyncerConfig, syncerScheme *runtime.Scheme) {
+	agentController, err := controller.NewWithDetail(&c.agentSpec, syncerConfig, t.restMapper, c.localDynClient,
+		c.localServiceClient, c.lighthouseClient, syncerScheme, func(config *broker.SyncerConfig) (*broker.Syncer, error) {
+			return broker.NewSyncerWithDetail(config, c.localDynClient, t.brokerDynClient, t.restMapper)
+		})
+
 	Expect(err).To(Succeed())
-
-	test.CreateResource(t.dynamicServiceClient(), t.service)
+	Expect(agentController.Start(t.stopCh)).To(Succeed())
 }
 
-func (t *testDriver) createEndpoints() {
-	_, err := t.localServiceClient.CoreV1().Endpoints(t.endpoints.Namespace).Create(t.endpoints)
-	Expect(err).To(Succeed())
-
-	test.CreateResource(t.dynamicEndpointsClient(), t.endpoints)
-}
-
-func (t *testDriver) updateEndpoints() {
-	_, err := t.localServiceClient.CoreV1().Endpoints(t.endpoints.Namespace).Update(t.endpoints)
-	Expect(err).To(Succeed())
-
-	test.UpdateResource(t.dynamicEndpointsClient(), t.endpoints)
-}
-
-func (t *testDriver) dynamicEndpointsClient() dynamic.ResourceInterface {
-	return t.localDynClient.Resource(schema.GroupVersionResource{Version: "v1", Resource: "endpoints"}).Namespace(t.service.Namespace)
-}
-
-func (t *testDriver) createServiceExport() {
-	_, err := t.lighthouseClient.LighthouseV2alpha1().ServiceExports(t.serviceExport.Namespace).Create(t.serviceExport)
-	Expect(err).To(Succeed())
-
-	test.CreateResource(t.localServiceExportClient, t.serviceExport)
-}
-
-func (t *testDriver) deleteServiceExport() {
-	Expect(t.localServiceExportClient.Delete(t.service.GetName(), nil)).To(Succeed())
-}
-
-func (t *testDriver) deleteService() {
-	Expect(t.dynamicServiceClient().Delete(t.service.Name, nil)).To(Succeed())
-
-	Expect(t.localServiceClient.CoreV1().Services(t.service.Namespace).Delete(t.service.Name, nil)).To(Succeed())
-}
-
-func (t *testDriver) dynamicServiceClient() dynamic.ResourceInterface {
-	return t.localDynClient.Resource(schema.GroupVersionResource{Version: "v1", Resource: "services"}).Namespace(t.service.Namespace)
-}
-
-func (t *testDriver) awaitServiceImport(client dynamic.ResourceInterface, sType lighthousev2a1.ServiceImportType, serviceIPs ...string) {
-	obj := test.AwaitResource(client, t.service.Name+"-"+t.service.Namespace+"-"+clusterID)
+func awaitServiceImport(client dynamic.ResourceInterface, service *corev1.Service, sType lighthousev2a1.ServiceImportType,
+	serviceIPs ...string) *lighthousev2a1.ServiceImport {
+	obj := test.AwaitResource(client, service.Name+"-"+service.Namespace+"-"+clusterID1)
 
 	serviceImport := &lighthousev2a1.ServiceImport{}
 	Expect(scheme.Scheme.Convert(obj, serviceImport, nil)).To(Succeed())
 
-	Expect(serviceImport.GetAnnotations()["origin-name"]).To(Equal(t.service.Name))
-	Expect(serviceImport.GetAnnotations()["origin-namespace"]).To(Equal(t.service.Namespace))
+	Expect(serviceImport.GetAnnotations()["origin-name"]).To(Equal(service.Name))
+	Expect(serviceImport.GetAnnotations()["origin-namespace"]).To(Equal(service.Namespace))
 	Expect(serviceImport.Spec.Type).To(Equal(sType))
 
 	Expect(serviceImport.Status.Clusters).To(HaveLen(1))
-	Expect(serviceImport.Status.Clusters[0].Cluster).To(Equal(clusterID))
+	Expect(serviceImport.Status.Clusters[0].Cluster).To(Equal(clusterID1))
 
 	sort.Strings(serviceIPs)
 	sort.Strings(serviceImport.Status.Clusters[0].IPs)
 	Expect(serviceImport.Status.Clusters[0].IPs).To(Equal(serviceIPs))
 
-	_, err := t.lighthouseClient.LighthouseV2alpha1().ServiceImports(serviceImport.Namespace).Create(serviceImport)
+	return serviceImport
+}
+
+func (c *cluster) awaitServiceImport(service *corev1.Service, sType lighthousev2a1.ServiceImportType, serviceIPs ...string) {
+	serviceImport := awaitServiceImport(c.localServiceImportClient, service, sType, serviceIPs...)
+
+	_, err := c.lighthouseClient.LighthouseV2alpha1().ServiceImports(serviceImport.Namespace).Create(serviceImport)
 	Expect(err).To(Succeed())
 }
 
-func (t *testDriver) awaitUpdatedServiceImport(client dynamic.ResourceInterface, serviceIPs ...string) {
-	name := t.service.Name + "-" + t.service.Namespace + "-" + clusterID
+func awaitUpdatedServiceImport(client dynamic.ResourceInterface, service *corev1.Service,
+	serviceIPs ...string) *lighthousev2a1.ServiceImport {
+	name := service.Name + "-" + service.Namespace + "-" + clusterID1
 
 	sort.Strings(serviceIPs)
 
@@ -567,19 +547,81 @@ func (t *testDriver) awaitUpdatedServiceImport(client dynamic.ResourceInterface,
 
 	Expect(err).To(Succeed())
 
-	_, err = t.lighthouseClient.LighthouseV2alpha1().ServiceImports(serviceImport.Namespace).Update(serviceImport)
+	return serviceImport
+}
+
+func (c *cluster) awaitUpdatedServiceImport(service *corev1.Service, serviceIPs ...string) {
+	serviceImport := awaitUpdatedServiceImport(c.localServiceImportClient, service, serviceIPs...)
+
+	_, err := c.lighthouseClient.LighthouseV2alpha1().ServiceImports(serviceImport.Namespace).Update(serviceImport)
 	Expect(err).To(Succeed())
 }
 
+func (t *testDriver) awaitBrokerServiceImport(sType lighthousev2a1.ServiceImportType, serviceIPs ...string) {
+	awaitServiceImport(t.brokerServiceImportClient, t.service, sType, serviceIPs...)
+}
+
+func (t *testDriver) awaitUpdatedServiceImport(serviceIPs ...string) {
+	awaitUpdatedServiceImport(t.brokerServiceImportClient, t.service, serviceIPs...)
+	t.cluster1.awaitUpdatedServiceImport(t.service, serviceIPs...)
+	t.cluster2.awaitUpdatedServiceImport(t.service, serviceIPs...)
+}
+
+func (t *testDriver) createService() {
+	_, err := t.cluster1.localServiceClient.CoreV1().Services(t.service.Namespace).Create(t.service)
+	Expect(err).To(Succeed())
+
+	test.CreateResource(t.dynamicServiceClient(), t.service)
+}
+
+func (t *testDriver) createEndpoints() {
+	_, err := t.cluster1.localServiceClient.CoreV1().Endpoints(t.endpoints.Namespace).Create(t.endpoints)
+	Expect(err).To(Succeed())
+
+	test.CreateResource(t.dynamicEndpointsClient(), t.endpoints)
+}
+
+func (t *testDriver) updateEndpoints() {
+	_, err := t.cluster1.localServiceClient.CoreV1().Endpoints(t.endpoints.Namespace).Update(t.endpoints)
+	Expect(err).To(Succeed())
+
+	test.UpdateResource(t.dynamicEndpointsClient(), t.endpoints)
+}
+
+func (t *testDriver) dynamicEndpointsClient() dynamic.ResourceInterface {
+	return t.cluster1.localDynClient.Resource(schema.GroupVersionResource{Version: "v1", Resource: "endpoints"}).Namespace(t.service.Namespace)
+}
+
+func (t *testDriver) createServiceExport() {
+	_, err := t.cluster1.lighthouseClient.LighthouseV2alpha1().ServiceExports(t.serviceExport.Namespace).Create(t.serviceExport)
+	Expect(err).To(Succeed())
+
+	test.CreateResource(t.cluster1.localServiceExportClient, t.serviceExport)
+}
+
+func (t *testDriver) deleteServiceExport() {
+	Expect(t.cluster1.localServiceExportClient.Delete(t.service.GetName(), nil)).To(Succeed())
+}
+
+func (t *testDriver) deleteService() {
+	Expect(t.dynamicServiceClient().Delete(t.service.Name, nil)).To(Succeed())
+
+	Expect(t.cluster1.localServiceClient.CoreV1().Services(t.service.Namespace).Delete(t.service.Name, nil)).To(Succeed())
+}
+
+func (t *testDriver) dynamicServiceClient() dynamic.ResourceInterface {
+	return t.cluster1.localDynClient.Resource(schema.GroupVersionResource{Version: "v1", Resource: "services"}).Namespace(t.service.Namespace)
+}
+
 func (t *testDriver) awaitNoServiceImport(client dynamic.ResourceInterface) {
-	test.AwaitNoResource(client, t.service.Name+"-"+t.service.Namespace+"-"+clusterID)
+	test.AwaitNoResource(client, t.service.Name+"-"+t.service.Namespace+"-"+clusterID1)
 }
 
 func (t *testDriver) awaitServiceExportStatus(atIndex int, expCond ...*lighthousev2a1.ServiceExportCondition) {
 	var found *lighthousev2a1.ServiceExport
 
 	err := wait.PollImmediate(50*time.Millisecond, 5*time.Second, func() (bool, error) {
-		se, err := t.lighthouseClient.LighthouseV2alpha1().ServiceExports(t.service.Namespace).Get(t.service.Name, metav1.GetOptions{})
+		se, err := t.cluster1.lighthouseClient.LighthouseV2alpha1().ServiceExports(t.service.Namespace).Get(t.service.Name, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return false, nil
@@ -623,7 +665,8 @@ func (t *testDriver) awaitServiceExportStatus(atIndex int, expCond ...*lighthous
 
 func (t *testDriver) awaitNotServiceExportStatus(notCond *lighthousev2a1.ServiceExportCondition) {
 	err := wait.PollImmediate(50*time.Millisecond, 300*time.Millisecond, func() (bool, error) {
-		se, err := t.lighthouseClient.LighthouseV2alpha1().ServiceExports(t.service.Namespace).Get(t.service.Name, metav1.GetOptions{})
+		se, err := t.cluster1.lighthouseClient.LighthouseV2alpha1().ServiceExports(t.service.Namespace).Get(t.service.Name,
+			metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return false, nil
 		}
@@ -650,14 +693,27 @@ func (t *testDriver) awaitNotServiceExportStatus(notCond *lighthousev2a1.Service
 }
 
 func (t *testDriver) awaitServiceExported(serviceIP string, statusIndex int) int {
-	t.awaitServiceImport(t.brokerServiceImportClient, lighthousev2a1.ClusterSetIP, serviceIP)
-	t.awaitServiceImport(t.localServiceImportClient, lighthousev2a1.ClusterSetIP, serviceIP)
+	t.awaitBrokerServiceImport(lighthousev2a1.ClusterSetIP, serviceIP)
+	t.cluster1.awaitServiceImport(t.service, lighthousev2a1.ClusterSetIP, serviceIP)
+	t.cluster2.awaitServiceImport(t.service, lighthousev2a1.ClusterSetIP, serviceIP)
 
 	t.awaitServiceExportStatus(statusIndex, newServiceExportCondition(lighthousev2a1.ServiceExportInitialized,
 		corev1.ConditionTrue, "AwaitingSync"), newServiceExportCondition(lighthousev2a1.ServiceExportExported,
 		corev1.ConditionTrue, ""))
 
 	return statusIndex + 2
+}
+
+func (t *testDriver) awaitHeadlessServiceExported(serviceIPs ...string) {
+	t.awaitBrokerServiceImport(lighthousev2a1.Headless, serviceIPs...)
+	t.cluster1.awaitServiceImport(t.service, lighthousev2a1.Headless, serviceIPs...)
+	t.cluster2.awaitServiceImport(t.service, lighthousev2a1.Headless, serviceIPs...)
+}
+
+func (t *testDriver) awaitServiceUnexported() {
+	t.awaitNoServiceImport(t.brokerServiceImportClient)
+	t.awaitNoServiceImport(t.cluster1.localServiceImportClient)
+	t.awaitNoServiceImport(t.cluster2.localServiceImportClient)
 }
 
 func (t *testDriver) awaitServiceUnavailableStatus(atIndex int) {


### PR DESCRIPTION
This simulates a second cluster connected to the broker to ensure correct service export to an external cluster.