### PR TITLE
Initial changes for StatefulSet

### DIFF
--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -126,7 +126,7 @@ func NewWithDetail(spec *AgentSpecification, syncerConf *broker.SyncerConfig, re
 
 				LocalSourceNamespace: metav1.NamespaceAll,
 				LocalResourceType:    &discovery.EndpointSlice{},
-				LocalTransform:       agentController.validateEndpointSliceLocal,
+				LocalTransform:       agentController.filterLocalEndpointSlices,
 				LocalResourcesEquivalent: func(obj1, obj2 *unstructured.Unstructured) bool {
 					return false
 				},
@@ -549,7 +549,7 @@ func (a *Controller) remoteEndpointSliceToLocal(obj runtime.Object, op syncer.Op
 	}, false
 }
 
-func (a *Controller) validateEndpointSliceLocal(obj runtime.Object, op syncer.Operation) (runtime.Object, bool) {
+func (a *Controller) filterLocalEndpointSlices(obj runtime.Object, op syncer.Operation) (runtime.Object, bool) {
 	endpointSlice := obj.(*discovery.EndpointSlice)
 	labels := endpointSlice.GetObjectMeta().GetLabels()
 

--- a/pkg/agent/controller/endpoint.go
+++ b/pkg/agent/controller/endpoint.go
@@ -3,6 +3,8 @@ package controller
 import (
 	"fmt"
 
+	"github.com/submariner-io/admiral/pkg/log"
+	lhconstants "github.com/submariner-io/lighthouse/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1beta1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -52,21 +54,21 @@ func (e *EndpointController) Start(stopCh <-chan struct{}, labelSelector fmt.Str
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				key, err := cache.MetaNamespaceKeyFunc(obj)
-				klog.Infof("Endpoint %q added", key)
+				klog.V(log.DEBUG).Infof("Endpoint %q added", key)
 				if err == nil {
 					e.endPointqueue.Add(key)
 				}
 			},
 			UpdateFunc: func(obj interface{}, new interface{}) {
 				key, err := cache.MetaNamespaceKeyFunc(new)
-				klog.Infof("Endpoint %q updated", key)
+				klog.V(log.DEBUG).Infof("Endpoint %q updated", key)
 				if err == nil {
 					e.endPointqueue.Add(key)
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
 				key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-				klog.Infof("Endpoint %q deleted", key)
+				klog.V(log.DEBUG).Infof("Endpoint %q deleted", key)
 				if err == nil {
 					var endPoints *corev1.Endpoints
 					var ok bool
@@ -198,10 +200,10 @@ func (e *EndpointController) endpointSliceFromEndpoints(endpoints *corev1.Endpoi
 	controllerFlag := false
 	endpointSlice.Name = endpoints.Name + "-" + e.clusterID
 	endpointSlice.Labels = map[string]string{
-		labelServiceImportName:   e.serviceImportName,
-		discovery.LabelManagedBy: labelValueManagedBy,
-		labelSourceNamespace:     e.serviceImportSourceNameSpace,
-		labelSourceCluster:       e.clusterID,
+		lhconstants.LabelServiceImportName: e.serviceImportName,
+		discovery.LabelManagedBy:           lhconstants.LabelValueManagedBy,
+		lhconstants.LabelSourceNamespace:   e.serviceImportSourceNameSpace,
+		lhconstants.LabelSourceCluster:     e.clusterID,
 	}
 	endpointSlice.OwnerReferences = []metav1.OwnerReference{{
 		APIVersion:         "lighthouse.submariner.io.v2alpha1",
@@ -258,7 +260,6 @@ func endpointFromAddress(address corev1.EndpointAddress, ready bool) discovery.E
 	return discovery.Endpoint{
 		Addresses:  []string{address.IP},
 		Conditions: discovery.EndpointConditions{Ready: &ready},
-		TargetRef:  address.TargetRef,
 		Topology:   topology,
 		Hostname:   &address.Hostname,
 	}

--- a/pkg/agent/controller/serviceimport.go
+++ b/pkg/agent/controller/serviceimport.go
@@ -133,10 +133,6 @@ func (c *ServiceImportController) runServiceImportWorker() {
 			}
 
 			if err != nil {
-				if !exists {
-					c.serviceImportDeletedMap.Store(key, obj)
-				}
-
 				c.queue.AddRateLimited(key)
 			} else {
 				c.queue.Forget(key)
@@ -194,8 +190,6 @@ func (c *ServiceImportController) serviceImportDeleted(key string) error {
 		return nil
 	}
 
-	c.serviceImportDeletedMap.Delete(key)
-
 	si := obj.(*lighthousev2a1.ServiceImport)
 
 	if obj, found := c.endpointControllers.Load(key); found {
@@ -210,6 +204,8 @@ func (c *ServiceImportController) serviceImportDeleted(key string) error {
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
+
+	c.serviceImportDeletedMap.Delete(key)
 
 	return nil
 }

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -59,13 +59,3 @@ type EndpointController struct {
 	endpointDeletedMap           sync.Map
 	stopCh                       chan struct{}
 }
-
-const (
-	originName             = "origin-name"
-	originNamespace        = "origin-namespace"
-	labelSourceName        = "lighthouse.submariner.io/sourceName"
-	labelSourceNamespace   = "lighthouse.submariner.io/sourceNamespace"
-	labelSourceCluster     = "lighthouse.submariner.io/sourceCluster"
-	labelServiceImportName = "multicluster.kubernetes.io/service-name"
-	labelValueManagedBy    = "lighthouse-agent.submariner.io"
-)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,11 @@
+package constants
+
+const (
+	OriginName             = "origin-name"
+	OriginNamespace        = "origin-namespace"
+	LabelSourceName        = "lighthouse.submariner.io/sourceName"
+	LabelSourceNamespace   = "lighthouse.submariner.io/sourceNamespace"
+	LabelSourceCluster     = "lighthouse.submariner.io/sourceCluster"
+	LabelServiceImportName = "multicluster.kubernetes.io/service-name"
+	LabelValueManagedBy    = "lighthouse-agent.submariner.io"
+)

--- a/pkg/endpointslice/controller.go
+++ b/pkg/endpointslice/controller.go
@@ -1,0 +1,123 @@
+package endpointslice
+
+import (
+	"fmt"
+
+	lhconstants "github.com/submariner-io/lighthouse/pkg/constants"
+	discovery "k8s.io/api/discovery/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+)
+
+type Controller struct {
+	// Indirection hook for unit tests to supply fake client sets
+	NewClientset func(kubeConfig *rest.Config) (kubernetes.Interface, error)
+	epsInformer  cache.Controller
+	stopCh       chan struct{}
+	mapStore     Store
+	store        cache.Store
+}
+
+func NewController(endpointSliceStore Store) *Controller {
+	return &Controller{
+		NewClientset: func(c *rest.Config) (kubernetes.Interface, error) {
+			return kubernetes.NewForConfig(c)
+		},
+		stopCh:   make(chan struct{}),
+		mapStore: endpointSliceStore,
+	}
+}
+
+func (c *Controller) Start(kubeConfig *rest.Config) error {
+	klog.Infof("Starting EndpointSlice Controller")
+
+	clientSet, err := c.NewClientset(kubeConfig)
+	if err != nil {
+		return fmt.Errorf("Error creating client set: %v", err)
+	}
+
+	labelMap := map[string]string{
+		discovery.LabelManagedBy: lhconstants.LabelValueManagedBy,
+	}
+	labelSelector := labels.Set(labelMap).String()
+
+	c.store, c.epsInformer = cache.NewInformer(
+		&cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				options.LabelSelector = labelSelector
+				return clientSet.DiscoveryV1beta1().EndpointSlices(metav1.NamespaceAll).List(options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				options.LabelSelector = labelSelector
+				return clientSet.DiscoveryV1beta1().EndpointSlices(metav1.NamespaceAll).Watch(options)
+			},
+		},
+		&discovery.EndpointSlice{},
+		0,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				key, err := cache.MetaNamespaceKeyFunc(obj)
+				if err == nil {
+					c.endpointSliceCreatedOrUpdated(key)
+				}
+			},
+			UpdateFunc: func(obj interface{}, new interface{}) {
+				key, err := cache.MetaNamespaceKeyFunc(obj)
+				if err == nil {
+					c.endpointSliceCreatedOrUpdated(key)
+				}
+			},
+			DeleteFunc: func(obj interface{}) {
+				key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+				if err == nil {
+					var endpointSlice *discovery.EndpointSlice
+					var ok bool
+					if endpointSlice, ok = obj.(*discovery.EndpointSlice); !ok {
+						tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+						if !ok {
+							klog.Errorf("Failed to get deleted endpointSlice object for key %s", key)
+							return
+						}
+
+						endpointSlice, ok = tombstone.Obj.(*discovery.EndpointSlice)
+
+						if !ok {
+							klog.Errorf("Failed to convert deleted tombstone object %v  to endpointSlice", tombstone.Obj)
+							return
+						}
+					}
+					c.mapStore.Remove(endpointSlice)
+				}
+			},
+		},
+	)
+
+	go c.epsInformer.Run(c.stopCh)
+
+	return nil
+}
+
+func (c *Controller) Stop() {
+	close(c.stopCh)
+
+	klog.Infof("EndpointSlice Controller stopped")
+}
+
+func (c *Controller) endpointSliceCreatedOrUpdated(key string) {
+	obj, exists, err := c.store.GetByKey(key)
+	if err != nil {
+		klog.Errorf("Error retrieving the object with key  %s from the cache: %v", key, err)
+		return
+	}
+
+	if exists {
+		endpointSlice := obj.(*discovery.EndpointSlice)
+		c.mapStore.Put(endpointSlice)
+	}
+}

--- a/pkg/endpointslice/map.go
+++ b/pkg/endpointslice/map.go
@@ -1,0 +1,70 @@
+package endpointslice
+
+import (
+	"sync"
+
+	"github.com/submariner-io/lighthouse/pkg/constants"
+	discovery "k8s.io/api/discovery/v1beta1"
+)
+
+type endpointInfo struct {
+	key     string
+	hostIPs map[string][]string
+}
+
+type Map struct {
+	epMap map[string]*endpointInfo
+	sync.RWMutex
+}
+
+func (m *Map) GetIPs(hostname, cluster, namespace, name string) ([]string, bool) {
+	key := keyFunc(namespace, name, cluster)
+
+	result, ok := m.epMap[key]
+	if !ok {
+		return nil, false
+	}
+
+	ips, ok := result.hostIPs[hostname]
+
+	return ips, ok
+}
+
+func NewMap() *Map {
+	return &Map{
+		epMap: make(map[string]*endpointInfo),
+	}
+}
+
+func (m *Map) Put(es *discovery.EndpointSlice) {
+	key, ok := es.Labels[constants.LabelServiceImportName]
+	if !ok {
+		return
+	}
+
+	m.Lock()
+	defer m.Unlock()
+
+	epInfo := &endpointInfo{
+		key:     key,
+		hostIPs: make(map[string][]string),
+	}
+
+	for _, endpoint := range es.Endpoints {
+		epInfo.hostIPs[*endpoint.Hostname] = endpoint.Addresses
+	}
+
+	m.epMap[key] = epInfo
+}
+
+func (m *Map) Remove(es *discovery.EndpointSlice) {
+	if key, ok := es.Labels[constants.LabelServiceImportName]; ok {
+		m.Lock()
+		defer m.Unlock()
+		delete(m.epMap, key)
+	}
+}
+
+func keyFunc(namespace, name, cluster string) string {
+	return name + "-" + namespace + "-" + cluster
+}

--- a/pkg/endpointslice/map.go
+++ b/pkg/endpointslice/map.go
@@ -20,6 +20,9 @@ type Map struct {
 func (m *Map) GetIPs(hostname, cluster, namespace, name string) ([]string, bool) {
 	key := keyFunc(namespace, name, cluster)
 
+	m.RLock()
+	defer m.RUnlock()
+
 	result, ok := m.epMap[key]
 	if !ok {
 		return nil, false
@@ -42,13 +45,13 @@ func (m *Map) Put(es *discovery.EndpointSlice) {
 		return
 	}
 
-	m.Lock()
-	defer m.Unlock()
-
 	epInfo := &endpointInfo{
 		key:     key,
 		hostIPs: make(map[string][]string),
 	}
+
+	m.Lock()
+	defer m.Unlock()
 
 	for _, endpoint := range es.Endpoints {
 		if endpoint.Hostname != nil {

--- a/pkg/endpointslice/map.go
+++ b/pkg/endpointslice/map.go
@@ -51,7 +51,9 @@ func (m *Map) Put(es *discovery.EndpointSlice) {
 	}
 
 	for _, endpoint := range es.Endpoints {
-		epInfo.hostIPs[*endpoint.Hostname] = endpoint.Addresses
+		if endpoint.Hostname != nil {
+			epInfo.hostIPs[*endpoint.Hostname] = endpoint.Addresses
+		}
 	}
 
 	m.epMap[key] = epInfo

--- a/pkg/endpointslice/store.go
+++ b/pkg/endpointslice/store.go
@@ -1,0 +1,9 @@
+package endpointslice
+
+import discovery "k8s.io/api/discovery/v1beta1"
+
+type Store interface {
+	Put(endpointSlice *discovery.EndpointSlice)
+
+	Remove(endpointSlice *discovery.EndpointSlice)
+}

--- a/plugin/lighthouse/lighthouse.go
+++ b/plugin/lighthouse/lighthouse.go
@@ -6,6 +6,7 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/fall"
 	clog "github.com/coredns/coredns/plugin/pkg/log"
+	"github.com/submariner-io/lighthouse/pkg/endpointslice"
 	"github.com/submariner-io/lighthouse/pkg/serviceimport"
 )
 
@@ -27,6 +28,7 @@ type Lighthouse struct {
 	Fall           fall.F
 	Zones          []string
 	serviceImports *serviceimport.Map
+	endpointSlices *endpointslice.Map
 	clusterStatus  ClusterStatus
 }
 

--- a/test/e2e/discovery/statefulsets.go
+++ b/test/e2e/discovery/statefulsets.go
@@ -1,0 +1,263 @@
+package discovery
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	lhconstants "github.com/submariner-io/lighthouse/pkg/constants"
+	lhframework "github.com/submariner-io/lighthouse/test/e2e/framework"
+	"github.com/submariner-io/shipyard/test/e2e/framework"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/api/discovery/v1beta1"
+)
+
+var _ = Describe("[discovery] Test Stateful Sets Discovery Across Clusters", func() {
+	f := lhframework.NewFramework("discovery")
+
+	When("a pod tries to resolve a podname from stateful set in a remote cluster", func() {
+		It("should resolve the pod IP from the remote cluster", func() {
+			if !framework.TestContext.GlobalnetEnabled {
+				RunSSDiscoveryTest(f)
+			} else {
+				framework.Skipf("Globalnet is enabled, skipping the test...")
+			}
+		})
+	})
+
+	When("a pod tries to resolve a podname from stateful set in a local cluster", func() {
+		It("should resolve the pod IP from the local cluster", func() {
+			if !framework.TestContext.GlobalnetEnabled {
+				RunSSDiscoveryLocalTest(f)
+			} else {
+				framework.Skipf("Globalnet is enabled, skipping the test...")
+			}
+		})
+	})
+
+	When("the number of active pods backing a stateful set changes", func() {
+		It("should only resolve the IPs from the active pods", func() {
+			if !framework.TestContext.GlobalnetEnabled {
+				RunSSPodsAvailabilityTest(f)
+			} else {
+				framework.Skipf("Globalnet is enabled, skipping the test...")
+			}
+		})
+	})
+})
+
+func RunSSDiscoveryTest(f *lhframework.Framework) {
+	clusterAName := framework.TestContext.ClusterIDs[framework.ClusterA]
+	clusterBName := framework.TestContext.ClusterIDs[framework.ClusterB]
+
+	By(fmt.Sprintf("Creating an Nginx Stateful Set on on %q", clusterBName))
+
+	nginxSSClusterB := f.NewNginxStatefulSet(framework.ClusterB)
+	appName := nginxSSClusterB.Spec.Selector.MatchLabels["app"]
+
+	By(fmt.Sprintf("Creating a Nginx Headless Service on %q", clusterBName))
+
+	nginxServiceClusterB := f.NewNginxHeadlessServiceWithParams(nginxSSClusterB.Spec.ServiceName, appName, framework.ClusterB)
+
+	f.NewServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	f.AwaitServiceExportedStatusCondition(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+
+	By(fmt.Sprintf("Creating a Netshoot Deployment on %q", clusterAName))
+
+	netshootPodList := f.NewNetShootDeployment(framework.ClusterA)
+
+	endpointSlices := f.AwaitEndpointSlices(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
+
+	verifyCount := 0
+
+	for _, endpointSlice := range endpointSlices.Items {
+		sourceCluster := endpointSlice.Labels[lhconstants.LabelSourceCluster]
+
+		for _, endpoint := range endpointSlice.Endpoints {
+			verifyEndpointsWithDig(f.Framework, framework.ClusterA, netshootPodList, endpoint, sourceCluster,
+				nginxServiceClusterB.Name, checkedDomains, true)
+			verifyCount++
+		}
+	}
+
+	Expect(verifyCount).To(Equal(1))
+	f.DeleteServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	f.AwaitServiceImportCount(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 0)
+
+	for _, endpointSlice := range endpointSlices.Items {
+		sourceCluster := endpointSlice.Labels[lhconstants.LabelSourceCluster]
+
+		for _, endpoint := range endpointSlice.Endpoints {
+			verifyEndpointsWithDig(f.Framework, framework.ClusterA, netshootPodList, endpoint, sourceCluster,
+				nginxServiceClusterB.Name, checkedDomains, false)
+		}
+	}
+}
+
+func RunSSDiscoveryLocalTest(f *lhframework.Framework) {
+	clusterAName := framework.TestContext.ClusterIDs[framework.ClusterA]
+	clusterBName := framework.TestContext.ClusterIDs[framework.ClusterB]
+
+	// Create StatefulSet on ClusterB
+	By(fmt.Sprintf("Creating an Nginx Stateful Set on on %q", clusterBName))
+
+	nginxSSClusterB := f.NewNginxStatefulSet(framework.ClusterB)
+	appName := nginxSSClusterB.Spec.Selector.MatchLabels["app"]
+
+	By(fmt.Sprintf("Creating a Nginx Headless Service on %q", clusterBName))
+
+	nginxServiceClusterB := f.NewNginxHeadlessServiceWithParams(nginxSSClusterB.Spec.ServiceName, appName, framework.ClusterB)
+
+	f.NewServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	f.AwaitServiceExportedStatusCondition(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+
+	// Create StatefulSet on ClusterA
+	By(fmt.Sprintf("Creating an Nginx Stateful Set on on %q", clusterAName))
+
+	nginxSSClusterA := f.NewNginxStatefulSet(framework.ClusterA)
+
+	By(fmt.Sprintf("Creating a Nginx Headless Service on %q", clusterAName))
+
+	nginxServiceClusterA := f.NewNginxHeadlessServiceWithParams(nginxSSClusterA.Spec.ServiceName, appName, framework.ClusterA)
+
+	f.NewServiceExport(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace)
+	f.AwaitServiceExportedStatusCondition(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace)
+
+	By(fmt.Sprintf("Creating a Netshoot Deployment on %q", clusterAName))
+
+	netshootPodList := f.NewNetShootDeployment(framework.ClusterA)
+
+	endpointSlices := f.AwaitEndpointSlices(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 2, 1)
+
+	verifyCount := 0
+
+	for _, endpointSlice := range endpointSlices.Items {
+		sourceCluster := endpointSlice.Labels[lhconstants.LabelSourceCluster]
+
+		for _, endpoint := range endpointSlice.Endpoints {
+			verifyEndpointsWithDig(f.Framework, framework.ClusterA, netshootPodList, endpoint, sourceCluster,
+				nginxServiceClusterB.Name, checkedDomains, true)
+			verifyCount++
+		}
+	}
+
+	Expect(verifyCount).To(Equal(2))
+
+	f.DeleteServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	f.AwaitServiceImportCount(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1)
+
+	verifyCount = 0
+
+	for _, endpointSlice := range endpointSlices.Items {
+		sourceCluster := endpointSlice.Labels[lhconstants.LabelSourceCluster]
+
+		for _, endpoint := range endpointSlice.Endpoints {
+			verifyEndpointsWithDig(f.Framework, framework.ClusterA, netshootPodList, endpoint, sourceCluster,
+				nginxServiceClusterB.Name, checkedDomains, sourceCluster == clusterAName)
+			verifyCount++
+		}
+	}
+
+	Expect(verifyCount).To(Equal(2))
+}
+
+func RunSSPodsAvailabilityTest(f *lhframework.Framework) {
+	clusterAName := framework.TestContext.ClusterIDs[framework.ClusterA]
+	clusterBName := framework.TestContext.ClusterIDs[framework.ClusterB]
+
+	By(fmt.Sprintf("Creating an Nginx Stateful Set on on %q", clusterBName))
+
+	nginxSSClusterB := f.NewNginxStatefulSet(framework.ClusterB)
+	f.SetNginxStatefulSetReplicas(framework.ClusterB, 3)
+
+	appName := nginxSSClusterB.Spec.Selector.MatchLabels["app"]
+
+	By(fmt.Sprintf("Creating a Nginx Headless Service on %q", clusterBName))
+
+	nginxServiceClusterB := f.NewNginxHeadlessServiceWithParams(nginxSSClusterB.Spec.ServiceName, appName, framework.ClusterB)
+
+	f.NewServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	f.AwaitServiceExportedStatusCondition(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+
+	By(fmt.Sprintf("Creating a Netshoot Deployment on %q", clusterAName))
+
+	netshootPodList := f.NewNetShootDeployment(framework.ClusterA)
+
+	endpointSlices := f.AwaitEndpointSlices(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 3)
+
+	verifyCount := 0
+
+	for _, endpointSlice := range endpointSlices.Items {
+		sourceCluster := endpointSlice.Labels[lhconstants.LabelSourceCluster]
+
+		for _, endpoint := range endpointSlice.Endpoints {
+			verifyEndpointsWithDig(f.Framework, framework.ClusterA, netshootPodList, endpoint, sourceCluster,
+				nginxServiceClusterB.Name, checkedDomains, true)
+			verifyCount++
+		}
+	}
+
+	Expect(verifyCount).To(Equal(3))
+
+	f.SetNginxStatefulSetReplicas(framework.ClusterB, 1)
+
+	for _, endpointSlice := range endpointSlices.Items {
+		sourceCluster := endpointSlice.Labels[lhconstants.LabelSourceCluster]
+
+		for _, endpoint := range endpointSlice.Endpoints {
+			verifyEndpointsWithDig(f.Framework, framework.ClusterA, netshootPodList, endpoint, sourceCluster,
+				nginxServiceClusterB.Name, checkedDomains, *endpoint.Hostname == "web-0")
+		}
+	}
+}
+
+func verifyEndpointsWithDig(f *framework.Framework, targetCluster framework.ClusterIndex, targetPod *corev1.PodList,
+	endpoint v1beta1.Endpoint, sourceCluster, service string, domains []string, shouldContain bool) {
+	cmd := []string{"dig", "+short"}
+
+	query := *endpoint.Hostname + "." + sourceCluster + "." + service
+
+	for i := range domains {
+		cmd = append(cmd, query+"."+f.Namespace+".svc."+domains[i])
+	}
+
+	op := "are"
+	if !shouldContain {
+		op += " not"
+	}
+
+	By(fmt.Sprintf("Executing %q to verify IPs %v for pod %q %q discoverable", strings.Join(cmd, " "), endpoint.Addresses, query, op))
+	framework.AwaitUntil(" service IP verification", func() (interface{}, error) {
+		stdout, _, err := f.ExecWithOptions(framework.ExecOptions{
+			Command:       cmd,
+			Namespace:     f.Namespace,
+			PodName:       targetPod.Items[0].Name,
+			ContainerName: targetPod.Items[0].Spec.Containers[0].Name,
+			CaptureStdout: true,
+			CaptureStderr: true,
+		}, targetCluster)
+		if err != nil {
+			return nil, err
+		}
+
+		return stdout, nil
+	}, func(result interface{}) (bool, string, error) {
+		By(fmt.Sprintf("Validating that dig result %s %q", op, result))
+		if len(endpoint.Addresses) == 0 && result != "" {
+			return false, fmt.Sprintf("expected execution result %q to be empty", result), nil
+		}
+		for _, ip := range endpoint.Addresses {
+			doesContain := strings.Contains(result.(string), ip)
+			if doesContain && !shouldContain {
+				return false, fmt.Sprintf("expected execution result %q not to contain %q", result, ip), nil
+			}
+
+			if !doesContain && shouldContain {
+				return false, fmt.Sprintf("expected execution result %q to contain %q", result, ip), nil
+			}
+		}
+
+		return true, "", nil
+	})
+}

--- a/test/e2e/discovery/statefulsets.go
+++ b/test/e2e/discovery/statefulsets.go
@@ -160,6 +160,9 @@ func RunSSDiscoveryLocalTest(f *lhframework.Framework) {
 	}
 
 	Expect(verifyCount).To(Equal(2))
+
+	f.DeleteServiceExport(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	f.AwaitServiceImportCount(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 0)
 }
 
 func RunSSPodsAvailabilityTest(f *lhframework.Framework) {
@@ -210,6 +213,9 @@ func RunSSPodsAvailabilityTest(f *lhframework.Framework) {
 				nginxServiceClusterB.Name, checkedDomains, *endpoint.Hostname == "web-0")
 		}
 	}
+
+	f.DeleteServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	f.AwaitServiceImportCount(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 0)
 }
 
 func verifyEndpointsWithDig(f *framework.Framework, targetCluster framework.ClusterIndex, targetPod *corev1.PodList,


### PR DESCRIPTION
This adds the following to the plugin code:
1. Endpointslice controller to get CRUD events for Endpointslices. We only watch for endpointslices managed by lighthouse.
2. An endpoints map to store hostname->IP information from endpoints present in EndpointSlices
3. `handler.go` changes to use endpoints map for queries of type `hostname.clusterX.svcname.ns.clusterset.local`

This also refactors some existing code.
1. Create lhconstants file to store all lighthouse specific strings used across controllers.
2. Add a localtransform to EndpointSlice syncer to filter out ones not managed by lighthouse.
3. Disable local and remote equivalency checks for EndpointSlice syncer. This is coz we already have that check when creating endpoint slices and these were not adding any value, just unnecessary overhead.

Fixes #215 

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>