### PR TITLE
Add e2e to for Lighthouse HA Scenario

### DIFF
--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -47,8 +47,8 @@ var _ = Describe("[discovery] Test Service Discovery Across Clusters", func() {
 		})
 	})
 
-	When("there is active pods for a service in only one cluster", func() {
-		It("should not resolve the service service without active pods", func() {
+	When("there are active pods for a service in only one cluster", func() {
+		It("should not resolve the service on the cluster without active pods", func() {
 			RunServicesPodAvailabilityMutliClusterTest(f)
 		})
 	})
@@ -223,8 +223,6 @@ func RunServicesPodAvailabilityMutliClusterTest(f *lhframework.Framework) {
 		f.AwaitServiceImportIP(framework.ClusterA, nginxServiceClusterB)
 	}
 
-	verifyServiceIpWithDig(f.Framework, framework.ClusterA, nginxServiceClusterB, netshootPodList, checkedDomains, true)
-
 	By(fmt.Sprintf("Creating an Nginx Deployment on on %q", clusterAName))
 	f.NewNginxDeployment(framework.ClusterA)
 	By(fmt.Sprintf("Creating a Nginx Service on %q", clusterAName))
@@ -241,12 +239,16 @@ func RunServicesPodAvailabilityMutliClusterTest(f *lhframework.Framework) {
 		f.AwaitServiceImportIP(framework.ClusterA, nginxServiceClusterA)
 	}
 
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, nginxServiceClusterA, netshootPodList, checkedDomains, true)
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, nginxServiceClusterB, netshootPodList, checkedDomains, true)
+
 	f.SetNginxReplicaSet(framework.ClusterB, 0)
 	verifyServiceIpWithDig(f.Framework, framework.ClusterA, nginxServiceClusterA, netshootPodList, checkedDomains, true)
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, nginxServiceClusterB, netshootPodList, checkedDomains, false)
 
 	f.SetNginxReplicaSet(framework.ClusterA, 0)
-	f.SetNginxReplicaSet(framework.ClusterB, 2)
-	verifyServiceIpWithDig(f.Framework, framework.ClusterA, nginxServiceClusterB, netshootPodList, checkedDomains, true)
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, nginxServiceClusterA, netshootPodList, checkedDomains, false)
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, nginxServiceClusterB, netshootPodList, checkedDomains, false)
 }
 
 func verifyServiceIpWithDig(f *framework.Framework, cluster framework.ClusterIndex, service *corev1.Service, targetPod *corev1.PodList,

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -267,7 +267,7 @@ func (f *Framework) GetEndpointIPs(targetCluster framework.ClusterIndex, name, n
 }
 
 func (f *Framework) SetNginxReplicaSet(cluster framework.ClusterIndex, count uint32) *appsv1.Deployment {
-	By(fmt.Sprintf("Setting Nginx deployment replicas to %v", count))
+	By(fmt.Sprintf("Setting Nginx deployment replicas to %v in cluster %q", count, framework.TestContext.ClusterIDs[cluster]))
 	patch := fmt.Sprintf(`{"spec":{"replicas":%v}}`, count)
 	deployments := framework.KubeClients[cluster].AppsV1().Deployments(f.Namespace)
 	result := framework.AwaitUntil("set replicas", func() (interface{}, error) {


### PR DESCRIPTION
* Tests when active pods are  present for service only in one
cluster while services are available in both the clusters.

Signed-off-by: Aswin Surayanarayanan <asuryana@redhat.com>