### PR TITLE
Filter ServiceImports from other clusters

### DIFF
--- a/pkg/agent/controller/serviceimport.go
+++ b/pkg/agent/controller/serviceimport.go
@@ -173,12 +173,15 @@ func (c *ServiceImportController) serviceImportDeleted(key string) error {
 	obj, found := c.serviceImportDeletedMap.Load(key)
 	if !found {
 		klog.Warningf("No endpoint controller found  for %q", key)
+		c.serviceImportDeletedMap.Delete(key)
+
 		return nil
 	}
 
 	si := obj.(*lighthousev2a1.ServiceImport)
 
 	if si.GetLabels()[lhconstants.LabelSourceCluster] != c.clusterID {
+		c.serviceImportDeletedMap.Delete(key)
 		return nil
 	}
 

--- a/pkg/agent/controller/serviceimport.go
+++ b/pkg/agent/controller/serviceimport.go
@@ -133,7 +133,8 @@ func (c *ServiceImportController) serviceImportCreatedOrUpdated(obj interface{},
 	}
 
 	serviceImportCreated := obj.(*lighthousev2a1.ServiceImport)
-	if serviceImportCreated.Spec.Type != lighthousev2a1.Headless {
+	if serviceImportCreated.Spec.Type != lighthousev2a1.Headless ||
+		serviceImportCreated.GetLabels()[lhconstants.LabelSourceCluster] != c.clusterID {
 		return nil
 	}
 
@@ -176,6 +177,10 @@ func (c *ServiceImportController) serviceImportDeleted(key string) error {
 	}
 
 	si := obj.(*lighthousev2a1.ServiceImport)
+
+	if si.GetLabels()[lhconstants.LabelSourceCluster] != c.clusterID {
+		return nil
+	}
 
 	if obj, found := c.endpointControllers.Load(key); found {
 		endpointController := obj.(*EndpointController)

--- a/test/e2e/discovery/statefulsets.go
+++ b/test/e2e/discovery/statefulsets.go
@@ -91,9 +91,6 @@ func RunSSDiscoveryLocalTest(f *lhframework.Framework) {
 
 	nginxServiceClusterB := f.NewNginxHeadlessServiceWithParams(nginxSSClusterB.Spec.ServiceName, appName, framework.ClusterB)
 
-	f.NewServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
-	f.AwaitServiceExportedStatusCondition(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
-
 	// Create StatefulSet on ClusterA
 	By(fmt.Sprintf("Creating an Nginx Stateful Set on on %q", clusterAName))
 
@@ -102,6 +99,9 @@ func RunSSDiscoveryLocalTest(f *lhframework.Framework) {
 	By(fmt.Sprintf("Creating a Nginx Headless Service on %q", clusterAName))
 
 	nginxServiceClusterA := f.NewNginxHeadlessServiceWithParams(nginxSSClusterA.Spec.ServiceName, appName, framework.ClusterA)
+
+	f.NewServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	f.AwaitServiceExportedStatusCondition(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 
 	f.NewServiceExport(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace)
 	f.AwaitServiceExportedStatusCondition(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace)


### PR DESCRIPTION
The serviceimport controller need to respond only for the
serviceimport created in the local cluster.

Signed-off-by: Aswin Surayanarayanan <asuryana@redhat.com>