### PR TITLE
Use metadata.labels as selector for endpoints

### DIFF
--- a/pkg/agent/controller/serviceimport.go
+++ b/pkg/agent/controller/serviceimport.go
@@ -159,7 +159,7 @@ func (c *ServiceImportController) serviceImportCreatedOrUpdated(obj interface{},
 		return nil
 	}
 
-	labelSelector := labels.Set(service.Spec.Selector).AsSelector()
+	labelSelector := labels.Set(service.GetLabels()).AsSelector()
 	endpointController := newEndpointController(c.kubeClientSet, serviceImportCreated.ObjectMeta.UID,
 		serviceImportCreated.ObjectMeta.Name, serviceNameSpace, c.clusterID)
 


### PR DESCRIPTION
When creating an endpoint watcher for a serviceimport, use
metadata.labels instead of selector.labels. K8s copies over a service's
metadata.labels to the endpoint labels, making for a more accurate
filter criteria than selector labels which can vary.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>