### PR TITLE
Remove EndpointSlice DeleteCollection

### DIFF
--- a/pkg/agent/controller/serviceimport.go
+++ b/pkg/agent/controller/serviceimport.go
@@ -191,13 +191,6 @@ func (c *ServiceImportController) serviceImportDeleted(key string) error {
 		c.endpointControllers.Delete(key)
 	}
 
-	labelSelector := labels.Set(map[string]string{lhconstants.LabelSourceName: si.Name}).AsSelector()
-	err := c.kubeClientSet.DiscoveryV1beta1().EndpointSlices(si.Namespace).
-		DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: labelSelector.String()})
-	if err != nil && !errors.IsNotFound(err) {
-		return err
-	}
-
 	c.serviceImportDeletedMap.Delete(key)
 
 	return nil

--- a/test/e2e/discovery/statefulsets.go
+++ b/test/e2e/discovery/statefulsets.go
@@ -73,6 +73,7 @@ func RunSSDiscoveryTest(f *lhframework.Framework) {
 
 	f.DeleteServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 	f.AwaitServiceImportCount(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 0)
+	f.AwaitEndpointSlices(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 0, 0)
 
 	verifyEndpointSlices(f.Framework, framework.ClusterA, netshootPodList, endpointSlices, nginxServiceClusterB.Name, 1, false)
 }
@@ -133,6 +134,7 @@ func RunSSDiscoveryLocalTest(f *lhframework.Framework) {
 
 	f.DeleteServiceExport(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 	f.AwaitServiceImportCount(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 0)
+	f.AwaitEndpointSlices(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 0, 0)
 }
 
 func RunSSPodsAvailabilityTest(f *lhframework.Framework) {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -355,11 +355,15 @@ func (f *Framework) AwaitEndpointSlices(targetCluster framework.ClusterIndex, na
 		if sliceCount != anyCount && len(endpointSliceList.Items) != sliceCount {
 			return false, fmt.Sprintf("%d endpointslices found when expected %d", len(endpointSliceList.Items), sliceCount), nil
 		}
-		endpointSlice := &endpointSliceList.Items[0]
 
-		if epCount != anyCount && len(endpointSlice.Endpoints) != epCount {
-			return false, fmt.Sprintf("endpointslices have %d hosts when expected %d", len(endpointSlice.Endpoints), epCount), nil
+		if len(endpointSliceList.Items) > 0 {
+			endpointSlice := &endpointSliceList.Items[0]
+
+			if epCount != anyCount && len(endpointSlice.Endpoints) != epCount {
+				return false, fmt.Sprintf("endpointslices have %d hosts when expected %d", len(endpointSlice.Endpoints), epCount), nil
+			}
 		}
+
 		return true, "", nil
 	})
 


### PR DESCRIPTION
Since we set the `ServiceImport` as the owner of the `EndpointSlice`, we don't ned to explicitly delete the `EndpointSlice` on `ServiceImport` delete.

Added verification of `EndpointSlice` deleted in E2E.