### PR TITLE
Set non zero TTL in dns replies

### DIFF
--- a/plugin/lighthouse/handler.go
+++ b/plugin/lighthouse/handler.go
@@ -73,7 +73,7 @@ func (lh *Lighthouse) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns
 	records := make([]dns.RR, 0)
 
 	for _, ip := range ips {
-		record := &dns.A{Hdr: dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeA, Class: state.QClass()}, A: net.ParseIP(ip).To4()}
+		record := &dns.A{Hdr: dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeA, Class: state.QClass(), Ttl: lh.ttl}, A: net.ParseIP(ip).To4()}
 		log.Debugf("rr is %v", record)
 		records = append(records, record)
 	}

--- a/plugin/lighthouse/handler_test.go
+++ b/plugin/lighthouse/handler_test.go
@@ -66,6 +66,7 @@ func testWithoutFallback() {
 			Zones:          []string{"cluster.local."},
 			serviceImports: setupServiceImportMap(),
 			clusterStatus:  mockCs,
+			ttl:            defaultTtl,
 		}
 
 		rec = dnstest.NewRecorder(&test.ResponseWriter{})
@@ -78,7 +79,7 @@ func testWithoutFallback() {
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.A(service1 + "." + namespace1 + ".svc.cluster.local.    0    IN    A    " + serviceIP),
+					test.A(service1 + "." + namespace1 + ".svc.cluster.local.    5    IN    A    " + serviceIP),
 				},
 			})
 		})
@@ -92,7 +93,7 @@ func testWithoutFallback() {
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.A(service1 + "." + namespace2 + ".svc.cluster.local.    0    IN    A    " + serviceIP),
+					test.A(service1 + "." + namespace2 + ".svc.cluster.local.    5    IN    A    " + serviceIP),
 				},
 			})
 		})
@@ -179,6 +180,7 @@ func testWithFallback() {
 			Next:           test.NextHandler(dns.RcodeBadCookie, errors.New("dummy plugin")),
 			serviceImports: setupServiceImportMap(),
 			clusterStatus:  mockCs,
+			ttl:            defaultTtl,
 		}
 
 		rec = dnstest.NewRecorder(&test.ResponseWriter{})
@@ -252,6 +254,7 @@ func testClusterStatus() {
 			Zones:          []string{"cluster.local."},
 			serviceImports: setupServiceImportMap(),
 			clusterStatus:  mockCs,
+			ttl:            defaultTtl,
 		}
 		lh.serviceImports.Put(newServiceImport(namespace1, service1, clusterID2, []string{serviceIP}, lighthousev2a1.ClusterSetIP))
 
@@ -265,7 +268,7 @@ func testClusterStatus() {
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.A(service1 + "." + namespace1 + ".svc.cluster.local.    0    IN    A    " + serviceIP),
+					test.A(service1 + "." + namespace1 + ".svc.cluster.local.    5    IN    A    " + serviceIP),
 				},
 			})
 		})
@@ -281,7 +284,7 @@ func testClusterStatus() {
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.A(service1 + "." + namespace1 + ".svc.cluster.local.    0    IN    A    " + serviceIP),
+					test.A(service1 + "." + namespace1 + ".svc.cluster.local.    5    IN    A    " + serviceIP),
 				},
 			})
 		})
@@ -297,7 +300,7 @@ func testClusterStatus() {
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.A(service1 + "." + namespace1 + ".svc.cluster.local.    0    IN    A    " + serviceIP),
+					test.A(service1 + "." + namespace1 + ".svc.cluster.local.    5    IN    A    " + serviceIP),
 				},
 			})
 		})
@@ -349,6 +352,7 @@ func testHeadlessService() {
 			Zones:          []string{"cluster.local."},
 			serviceImports: serviceimport.NewMap(),
 			clusterStatus:  mockCs,
+			ttl:            defaultTtl,
 		}
 
 		rec = dnstest.NewRecorder(&test.ResponseWriter{})
@@ -378,7 +382,7 @@ func testHeadlessService() {
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.A(service1 + "." + namespace1 + ".svc.cluster.local.    0    IN    A    " + serviceIP),
+					test.A(service1 + "." + namespace1 + ".svc.cluster.local.    5    IN    A    " + serviceIP),
 				},
 			})
 		})
@@ -394,8 +398,8 @@ func testHeadlessService() {
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.A(service1 + "." + namespace1 + ".svc.cluster.local.    0    IN    A    " + serviceIP),
-					test.A(service1 + "." + namespace1 + ".svc.cluster.local.    0    IN    A    " + serviceIP2),
+					test.A(service1 + "." + namespace1 + ".svc.cluster.local.    5    IN    A    " + serviceIP),
+					test.A(service1 + "." + namespace1 + ".svc.cluster.local.    5    IN    A    " + serviceIP2),
 				},
 			})
 		})
@@ -413,8 +417,8 @@ func testHeadlessService() {
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.A(service1 + "." + namespace1 + ".svc.cluster.local.    0    IN    A    " + serviceIP),
-					test.A(service1 + "." + namespace1 + ".svc.cluster.local.    0    IN    A    " + serviceIP2),
+					test.A(service1 + "." + namespace1 + ".svc.cluster.local.    5    IN    A    " + serviceIP),
+					test.A(service1 + "." + namespace1 + ".svc.cluster.local.    5    IN    A    " + serviceIP2),
 				},
 			})
 		})

--- a/plugin/lighthouse/lighthouse.go
+++ b/plugin/lighthouse/lighthouse.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	Svc = "svc"
-	Pod = "pod"
+	Svc        = "svc"
+	Pod        = "pod"
+	defaultTtl = uint32(5)
 )
 
 var (
@@ -27,6 +28,7 @@ type Lighthouse struct {
 	Next           plugin.Handler
 	Fall           fall.F
 	Zones          []string
+	ttl            uint32
 	serviceImports *serviceimport.Map
 	endpointSlices *endpointslice.Map
 	clusterStatus  ClusterStatus


### PR DESCRIPTION
1. Set default ttl of 5 in DNS response as 0 is not recommended.
2. Make TTL a configurable parameter with range of 0-3600.

Note that default of 5 and range both are same as used in kubernetes
plugin.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>