### PR TITLE
Add check for service name in endpoint controller

### DIFF
--- a/pkg/agent/controller/endpoint.go
+++ b/pkg/agent/controller/endpoint.go
@@ -1,8 +1,6 @@
 package controller
 
 import (
-	"fmt"
-
 	"github.com/submariner-io/admiral/pkg/log"
 	lhconstants "github.com/submariner-io/lighthouse/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
@@ -10,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
@@ -22,12 +21,13 @@ import (
 )
 
 func newEndpointController(kubeClientSet kubernetes.Interface, serviceImportuid types.UID, serviceImportName,
-	serviceImportNameSpace, clusterId string) *EndpointController {
+	serviceName, serviceImportNameSpace, clusterId string) *EndpointController {
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 	endpointController := &EndpointController{
 		endPointqueue:                queue,
 		serviceImportUID:             serviceImportuid,
 		serviceImportName:            serviceImportName,
+		serviceName:                  serviceName,
 		serviceImportSourceNameSpace: serviceImportNameSpace,
 		kubeClientSet:                kubeClientSet,
 		clusterID:                    clusterId,
@@ -37,16 +37,17 @@ func newEndpointController(kubeClientSet kubernetes.Interface, serviceImportuid 
 	return endpointController
 }
 
-func (e *EndpointController) start(stopCh <-chan struct{}, labelSelector fmt.Stringer) {
+func (e *EndpointController) start(stopCh <-chan struct{}) {
+	nameSelector := fields.OneTermEqualSelector("metadata.name", e.serviceName)
 	e.store, e.endpointInformer = cache.NewInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				options.LabelSelector = labelSelector.String()
-				return e.kubeClientSet.CoreV1().Endpoints(metav1.NamespaceAll).List(options)
+				options.FieldSelector = nameSelector.String()
+				return e.kubeClientSet.CoreV1().Endpoints(e.serviceImportSourceNameSpace).List(options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				options.LabelSelector = labelSelector.String()
-				return e.kubeClientSet.CoreV1().Endpoints(metav1.NamespaceAll).Watch(options)
+				options.FieldSelector = nameSelector.String()
+				return e.kubeClientSet.CoreV1().Endpoints(e.serviceImportSourceNameSpace).Watch(options)
 			},
 		},
 		&corev1.Endpoints{},
@@ -143,6 +144,7 @@ func (e *EndpointController) runEndpointWorker(informer cache.Controller, queue 
 
 func (e *EndpointController) endPointCreatedOrUpdated(obj interface{}, key string) error {
 	endPoints := obj.(*corev1.Endpoints)
+
 	newEndPointSlice := e.endpointSliceFromEndpoints(endPoints)
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		currentEndpointSice, err := e.kubeClientSet.DiscoveryV1beta1().EndpointSlices(endPoints.Namespace).
@@ -202,6 +204,7 @@ func (e *EndpointController) endpointSliceFromEndpoints(endpoints *corev1.Endpoi
 		discovery.LabelManagedBy:           lhconstants.LabelValueManagedBy,
 		lhconstants.LabelSourceNamespace:   e.serviceImportSourceNameSpace,
 		lhconstants.LabelSourceCluster:     e.clusterID,
+		lhconstants.LabelSourceName:        e.serviceName,
 	}
 	endpointSlice.OwnerReferences = []metav1.OwnerReference{{
 		APIVersion:         "lighthouse.submariner.io.v2alpha1",

--- a/pkg/agent/controller/serviceimport.go
+++ b/pkg/agent/controller/serviceimport.go
@@ -9,7 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
@@ -164,11 +163,10 @@ func (c *ServiceImportController) serviceImportCreatedOrUpdated(obj interface{},
 		return nil
 	}
 
-	labelSelector := labels.Set(service.GetLabels()).AsSelector()
 	endpointController := newEndpointController(c.kubeClientSet, serviceImportCreated.ObjectMeta.UID,
-		serviceImportCreated.ObjectMeta.Name, serviceNameSpace, c.clusterID)
+		serviceImportCreated.ObjectMeta.Name, serviceName, serviceNameSpace, c.clusterID)
 
-	endpointController.start(endpointController.stopCh, labelSelector)
+	endpointController.start(endpointController.stopCh)
 	c.endpointControllers.Store(key, endpointController)
 
 	return nil

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -56,6 +56,7 @@ type EndpointController struct {
 	serviceImportUID             types.UID
 	clusterID                    string
 	serviceImportName            string
+	serviceName                  string
 	serviceImportSourceNameSpace string
 	endpointDeletedMap           sync.Map
 	stopCh                       chan struct{}


### PR DESCRIPTION
Multiple services using same label can cause probelms with
serviceimports and endpoint slices. Add a check in endpoint controller
to only handle endpoints that have the same name as service that was
exported/imported.

Note: This code will be refactored once we  aggregate serviceimports and
only use endpointslices to store IP information.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>