### PR TITLE
Convert ServiceImportController to use ResourceSyncer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
 	github.com/pkg/errors v0.9.1
-	github.com/submariner-io/admiral v0.6.2
+	github.com/submariner-io/admiral v0.6.3
 	github.com/submariner-io/shipyard v0.6.1
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2

--- a/go.sum
+++ b/go.sum
@@ -538,10 +538,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/submariner-io/admiral v0.6.1 h1:EWGnf7Yem6dEvbvF/MaQYcYhZ8rTflPgQukl2IojMhI=
-github.com/submariner-io/admiral v0.6.1/go.mod h1:bPMiLdXmGVj3EHnrPoVzn6jTukKeaH2IoWoZdFg2blM=
-github.com/submariner-io/admiral v0.6.2 h1:6iPGX8gSFQq02nNwkpj/zrqA1CbRkc+Too3TziI2HzA=
-github.com/submariner-io/admiral v0.6.2/go.mod h1:/lm9D8AUs/cZE0lhxBfKDwkaU1XhmLkRnRwoD6BNsfg=
+github.com/submariner-io/admiral v0.6.3 h1:96wOqGEDKv0Oq6QXozE6C7/HJ87kEIdHZp4AutykC5s=
+github.com/submariner-io/admiral v0.6.3/go.mod h1:/lm9D8AUs/cZE0lhxBfKDwkaU1XhmLkRnRwoD6BNsfg=
 github.com/submariner-io/shipyard v0.6.1 h1:jkZc9WJpK+ZKjHmuDOM7BT0rkp41pOAsEGJtPAqFs14=
 github.com/submariner-io/shipyard v0.6.1/go.mod h1:9H9ctEv+K61bMy5teo/fG2azZswmXsPVfFTVdk8ZGk0=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -158,7 +158,10 @@ func NewWithDetail(spec *AgentSpecification, syncerConf *broker.SyncerConfig, re
 		return nil, err
 	}
 
-	agentController.serviceImportController = newServiceImportController(spec, kubeClientSet, lighthouseClient)
+	agentController.serviceImportController, err = newServiceImportController(spec, kubeClientSet, restMapper, localClient, scheme)
+	if err != nil {
+		return nil, err
+	}
 
 	return agentController, nil
 }

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -35,14 +35,10 @@ type AgentSpecification struct {
 // and creates an EndpointController in response. The EndpointController will use the app label as filter
 // to listen only for the endpoints event related to ServiceImport created
 type ServiceImportController struct {
-	kubeClientSet           kubernetes.Interface
-	lighthouseClient        lighthouseClientset.Interface
-	serviceInformer         cache.SharedIndexInformer
-	queue                   workqueue.RateLimitingInterface
-	endpointControllers     sync.Map
-	serviceImportDeletedMap sync.Map
-	clusterID               string
-	namespace               string
+	kubeClientSet       kubernetes.Interface
+	serviceImportSyncer syncer.Interface
+	endpointControllers sync.Map
+	clusterID           string
 }
 
 // Each EndpointController listens for the endpoints that backs a service and have a ServiceImport


### PR DESCRIPTION
This eliminates some boilerplate. Use the transform function to start the `Endpoints` watch and return nil resource so nothing is synced. Also  use the `NoopFederator`.
