### PR TITLE
Add build Make target for building both binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ package/.image.lighthouse-agent: bin/lighthouse-agent
 
 package/.image.lighthouse-coredns: bin/lighthouse-coredns
 
+build: bin/lighthouse-agent bin/lighthouse-coredns
+
 bin/lighthouse-agent: vendor/modules.txt $(shell find pkg/agent)
 	${SCRIPTS_DIR}/compile.sh $@ pkg/agent/main.go
 


### PR DESCRIPTION
Add a "build" Make target to group building all binaries of this repo
under a single well-known command.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>