### PR TITLE
Link to general contributing docs vs LH-specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The lighthouse architecture is explained in detail at [Service Discovery](https:
 
 ## Contribute
 
-We welcome any contributions and please refer [Contribution Guide](https://submariner-io.github.io/contributing/lighthouse/) for more details.
+We welcome any contributions. Please refer to the [Contribution Guide](https://submariner.io/contributing/) for more details.
 
 ## Build and Test
 


### PR DESCRIPTION
The Lighthouse contributing docs are proposed to be removed in:

github.com/submariner-io/submariner-website/pull/290

Update the link here to the Submariner-wide contributing docs.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>