### PR TITLE
Use endpointslices for headless services

### DIFF
--- a/pkg/endpointslice/map.go
+++ b/pkg/endpointslice/map.go
@@ -3,13 +3,20 @@ package endpointslice
 import (
 	"sync"
 
+	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/lighthouse/pkg/constants"
 	discovery "k8s.io/api/discovery/v1beta1"
+	"k8s.io/klog"
 )
 
 type endpointInfo struct {
-	key     string
+	key         string
+	clusterInfo map[string]*clusterInfo
+}
+
+type clusterInfo struct {
 	hostIPs map[string][]string
+	ipList  []string
 }
 
 type Map struct {
@@ -17,20 +24,41 @@ type Map struct {
 	sync.RWMutex
 }
 
-func (m *Map) GetIPs(hostname, cluster, namespace, name string) ([]string, bool) {
-	key := keyFunc(namespace, name, cluster)
+func (m *Map) GetIPs(hostname, cluster, namespace, name string, checkCluster func(string) bool) ([]string, bool) {
+	key := keyFunc(name, namespace)
 
-	m.RLock()
-	defer m.RUnlock()
+	clusterInfos := func() map[string]*clusterInfo {
+		m.RLock()
+		defer m.RUnlock()
 
-	result, ok := m.epMap[key]
-	if !ok {
+		result, ok := m.epMap[key]
+		if !ok {
+			return nil
+		}
+
+		return result.clusterInfo
+	}()
+
+	if clusterInfos == nil {
 		return nil, false
 	}
 
-	ips, ok := result.hostIPs[hostname]
+	switch {
+	case cluster == "":
+		ips := make([]string, 0)
 
-	return ips, ok
+		for k, val := range clusterInfos {
+			if checkCluster != nil && checkCluster(k) {
+				ips = append(ips, val.ipList...)
+			}
+		}
+
+		return ips, true
+	case hostname == "":
+		return clusterInfos[cluster].ipList, true
+	default:
+		return clusterInfos[cluster].hostIPs[hostname], true
+	}
 }
 
 func NewMap() *Map {
@@ -40,36 +68,85 @@ func NewMap() *Map {
 }
 
 func (m *Map) Put(es *discovery.EndpointSlice) {
-	key, ok := es.Labels[constants.LabelServiceImportName]
+	key, ok := getKey(es)
 	if !ok {
+		klog.V(log.DEBUG).Infof("Failed to get labels on %#v", es)
 		return
 	}
 
-	epInfo := &endpointInfo{
-		key:     key,
-		hostIPs: make(map[string][]string),
+	cluster, ok := es.Labels[constants.LabelSourceCluster]
+
+	if !ok {
+		klog.V(log.DEBUG).Infof("Cluster label missing on %s", es.Name)
+		return
+	}
+
+	epInfo, ok := m.epMap[key]
+	if !ok {
+		epInfo = &endpointInfo{
+			key:         key,
+			clusterInfo: make(map[string]*clusterInfo),
+		}
 	}
 
 	m.Lock()
 	defer m.Unlock()
 
+	epInfo.clusterInfo[cluster] = &clusterInfo{
+		ipList:  make([]string, 0),
+		hostIPs: make(map[string][]string),
+	}
+
 	for _, endpoint := range es.Endpoints {
 		if endpoint.Hostname != nil {
-			epInfo.hostIPs[*endpoint.Hostname] = endpoint.Addresses
+			epInfo.clusterInfo[cluster].hostIPs[*endpoint.Hostname] = endpoint.Addresses
 		}
+
+		epInfo.clusterInfo[cluster].ipList = append(epInfo.clusterInfo[cluster].ipList, endpoint.Addresses...)
 	}
+
+	klog.V(log.DEBUG).Infof("Adding endpointInfo %#v for %s in %s", epInfo.clusterInfo[cluster], es.Name, cluster)
 
 	m.epMap[key] = epInfo
 }
 
 func (m *Map) Remove(es *discovery.EndpointSlice) {
-	if key, ok := es.Labels[constants.LabelServiceImportName]; ok {
+	if key, ok := getKey(es); ok {
+		cluster, ok := es.Labels[constants.LabelSourceCluster]
+
+		if !ok {
+			return
+		}
+
 		m.Lock()
 		defer m.Unlock()
-		delete(m.epMap, key)
+
+		epInfo, ok := m.epMap[key]
+		if !ok {
+			return
+		}
+
+		klog.V(log.DEBUG).Infof("Adding endpointInfo %#v for %s in %s", epInfo.clusterInfo[cluster], es.Name, cluster)
+		delete(epInfo.clusterInfo, cluster)
 	}
 }
 
-func keyFunc(namespace, name, cluster string) string {
-	return name + "-" + namespace + "-" + cluster
+func getKey(es *discovery.EndpointSlice) (string, bool) {
+	name, ok := es.Labels[constants.LabelSourceName]
+
+	if !ok {
+		return "", false
+	}
+
+	namespace, ok := es.Labels[constants.LabelSourceNamespace]
+
+	if !ok {
+		return "", false
+	}
+
+	return keyFunc(name, namespace), true
+}
+
+func keyFunc(name, namespace string) string {
+	return name + "-" + namespace
 }

--- a/pkg/endpointslice/map_test.go
+++ b/pkg/endpointslice/map_test.go
@@ -1,0 +1,143 @@
+package endpointslice_test
+
+import (
+	"sort"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/lighthouse/pkg/endpointslice"
+
+	lhconstants "github.com/submariner-io/lighthouse/pkg/constants"
+	discovery "k8s.io/api/discovery/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("EndpointSlice Map", func() {
+	const (
+		service1    = "service1"
+		namespace1  = "namespace1"
+		clusterID1  = "clusterID1"
+		clusterID2  = "clusterID2"
+		clusterID3  = "clusterID3"
+		endpointIP  = "100.96.157.101"
+		endpointIP2 = "100.96.157.102"
+		endpointIP3 = "100.96.157.103"
+	)
+
+	var (
+		clusterStatusMap map[string]bool
+		endpointSliceMap *endpointslice.Map
+	)
+
+	BeforeEach(func() {
+		clusterStatusMap = map[string]bool{clusterID1: true, clusterID2: true, clusterID3: true}
+		endpointSliceMap = endpointslice.NewMap()
+	})
+
+	checkCluster := func(id string) bool {
+		return clusterStatusMap[id]
+	}
+
+	getIPs := func(hostname, cluster, ns, name string) []string {
+		ips, found := endpointSliceMap.GetIPs(hostname, cluster, ns, name, checkCluster)
+		Expect(found).To(BeTrue())
+		return ips
+	}
+
+	expectIPs := func(hostname, cluster, ns, name string, expIPs []string) {
+		sort.Strings(expIPs)
+		for i := 0; i < 5; i++ {
+			ips := getIPs(hostname, cluster, namespace1, service1)
+			sort.Strings(ips)
+			Expect(ips).To(Equal(expIPs))
+		}
+	}
+
+	When("a headless service is present in multiple connected clusters", func() {
+		When("no specific cluster is queried", func() {
+			It("should consistently return all the IPs", func() {
+				es1 := newEndpointSlice(namespace1, service1, clusterID1, []string{endpointIP})
+				endpointSliceMap.Put(es1)
+				es2 := newEndpointSlice(namespace1, service1, clusterID2, []string{endpointIP2})
+				endpointSliceMap.Put(es2)
+
+				expectIPs("", "", namespace1, service1, []string{endpointIP, endpointIP2})
+			})
+		})
+		When("requested for specific cluster", func() {
+			It("should return IPs only from queried cluster", func() {
+				es1 := newEndpointSlice(namespace1, service1, clusterID1, []string{endpointIP})
+				endpointSliceMap.Put(es1)
+				es2 := newEndpointSlice(namespace1, service1, clusterID2, []string{endpointIP2})
+				endpointSliceMap.Put(es2)
+
+				expectIPs("", clusterID2, namespace1, service1, []string{endpointIP2})
+			})
+		})
+		When("specific host is queried", func() {
+			It("should return IPs from specific host", func() {
+				hostname := "host1"
+				es1 := newEndpointSlice(namespace1, service1, clusterID1, []string{endpointIP})
+				es1.Endpoints[0].Hostname = &hostname
+				endpointSliceMap.Put(es1)
+				es2 := newEndpointSlice(namespace1, service1, clusterID2, []string{endpointIP2})
+				endpointSliceMap.Put(es2)
+
+				expectIPs(hostname, clusterID1, namespace1, service1, []string{endpointIP})
+			})
+		})
+	})
+
+	When("a headless service is present in multiple connected clusters with one disconnected", func() {
+		It("should consistently return all the IPs from the connected clusters", func() {
+			es1 := newEndpointSlice(namespace1, service1, clusterID1, []string{endpointIP})
+			endpointSliceMap.Put(es1)
+			es2 := newEndpointSlice(namespace1, service1, clusterID2, []string{endpointIP2})
+			endpointSliceMap.Put(es2)
+			es3 := newEndpointSlice(namespace1, service1, clusterID3, []string{endpointIP3})
+			endpointSliceMap.Put(es3)
+
+			clusterStatusMap[clusterID2] = false
+
+			expectIPs("", "", namespace1, service1, []string{endpointIP, endpointIP3})
+		})
+	})
+
+	When("a headless service is present in multiple connected clusters and one is removed", func() {
+		It("should consistently return all the remaining IPs", func() {
+			es1 := newEndpointSlice(namespace1, service1, clusterID1, []string{endpointIP})
+			endpointSliceMap.Put(es1)
+			es2 := newEndpointSlice(namespace1, service1, clusterID2, []string{endpointIP2})
+			endpointSliceMap.Put(es2)
+
+			expectIPs("", "", namespace1, service1, []string{endpointIP, endpointIP2})
+
+			endpointSliceMap.Remove(es2)
+
+			expectIPs("", "", namespace1, service1, []string{endpointIP})
+		})
+	})
+
+})
+
+func newEndpointSlice(namespace, name, clusterID string, endpointIPs []string) *discovery.EndpointSlice {
+	return &discovery.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				lhconstants.LabelServiceImportName: name,
+				discovery.LabelManagedBy:           lhconstants.LabelValueManagedBy,
+				lhconstants.LabelSourceNamespace:   namespace,
+				lhconstants.LabelSourceCluster:     clusterID,
+				lhconstants.LabelSourceName:        name,
+			},
+		},
+		AddressType: discovery.AddressTypeIPv4,
+		Endpoints: []discovery.Endpoint{
+			{
+				Addresses: endpointIPs,
+			},
+		},
+	}
+}

--- a/pkg/endpointslice/suite_test.go
+++ b/pkg/endpointslice/suite_test.go
@@ -1,0 +1,18 @@
+package endpointslice_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/klog"
+)
+
+func init() {
+	klog.InitFlags(nil)
+}
+
+func TestEndpointSlice(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "EndpointSlice Suite")
+}

--- a/pkg/serviceimport/map.go
+++ b/pkg/serviceimport/map.go
@@ -66,7 +66,7 @@ func (m *Map) GetIPs(namespace, name, cluster string, checkCluster func(string) 
 		return si.clusterIPs, si.clustersQueue, &si.rrCount, si.isHeadless
 	}()
 
-	if clusterIPs == nil {
+	if clusterIPs == nil || isHeadless {
 		return nil, false
 	}
 
@@ -75,24 +75,12 @@ func (m *Map) GetIPs(namespace, name, cluster string, checkCluster func(string) 
 		return ips, found
 	}
 
-	if !isHeadless {
-		ip := m.selectIP(queue, counter, checkCluster)
-		if ip != "" {
-			return []string{ip}, true
-		}
-
-		return []string{}, true
+	ip := m.selectIP(queue, counter, checkCluster)
+	if ip != "" {
+		return []string{ip}, true
 	}
 
-	serviceIPs := make([]string, 0)
-
-	for cluster, ips := range clusterIPs {
-		if checkCluster(cluster) {
-			serviceIPs = append(serviceIPs, ips...)
-		}
-	}
-
-	return serviceIPs, true
+	return []string{}, true
 }
 
 func NewMap() *Map {


### PR DESCRIPTION
Currently headless services use IPs stored in status field of
`ServiceImports` which is not spec compliant. Now that we have
`EndpointSlices`, use those to resolve IPs for headless services.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>