### PR TITLE
Call framework.By instead of ginkgo in e2e framework beforeSuite

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -47,7 +47,7 @@ func NewFramework(baseName string) *Framework {
 }
 
 func beforeSuite() {
-	By("Creating lighthouse clients")
+	framework.By("Creating lighthouse clients")
 
 	for _, restConfig := range framework.RestConfigs {
 		LighthouseClients = append(LighthouseClients, createLighthouseClient(restConfig))


### PR DESCRIPTION
Related to: submariner-io/submariner-operator#748

This will enable using any By() method set in the framework
Useful when running tests with verbose=false

Signed-off-by: Maayan Friedman <maafried@redhat.com>