### PR TITLE
fix(service-import): modify the controller spec

### DIFF
--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -262,7 +262,9 @@ func (a *Controller) serviceExportToRemoteServiceImport(obj runtime.Object, op s
 	}
 
 	serviceImport.Spec = lighthousev2a1.ServiceImportSpec{
-		Type: svcType,
+		Ports:                 []lighthousev2a1.ServicePort{},
+		Type:                  svcType,
+		SessionAffinityConfig: new(corev1.SessionAffinityConfig),
 	}
 
 	ips, err := a.getIPsForService(svc, svcType)


### PR DESCRIPTION
The json schema validation fails during Lighthouse e2e test on null values.
`Ports` and `SessionAffinityConfig` properties expect to get array and object
respectively

Signed-off-by: Steve Mattar <smattar@redhat.com>