### PR TITLE
Fix intermittent plugin handler test failure

### DIFF
--- a/plugin/lighthouse/handler_test.go
+++ b/plugin/lighthouse/handler_test.go
@@ -323,9 +323,10 @@ func testClusterStatus() {
 		})
 	})
 
-	When("service is in two connected clusters and one has no IP", func() {
+	When("service is in two connected clusters and one is not of type ClusterSetIP", func() {
 		JustBeforeEach(func() {
-			lh.serviceImports.Put(newServiceImport(namespace1, service1, clusterID2, serviceIP, ""))
+			lh.serviceImports = setupServiceImportMap()
+			lh.serviceImports.Put(newServiceImport(namespace1, service1, clusterID2, serviceIP2, ""))
 		})
 		It("should succeed and write an A record response with the available IP", func() {
 			executeTestCase(lh, rec, test.Case{


### PR DESCRIPTION
```
Cluster connectivity status
  when service is in two connected clusters and one has no IP
    [It] should succeed and write an A record response with the available IP

 Expected success, but got an error:
  RR 0 should have a Address of "100.96.156.101", but has "100.96.156.102"
```

It sets up the second cluster SI as follows:

`lh.serviceImports.Put(newServiceImport(namespace1, service1, clusterID2, serviceIP, ""))`

It passes in empty `ServiceImportType` so it looks like it's actually testing an SI that is not of type `ClusterSetIP`. The code ignores that case but the SI for clusterID2 was already added with IP serviceIP2 and type `ClusterSetIP` in the global BeforeEach so sometimes the query returns serviceIP2 instead of the expected serviceIP.

Fixed by re-initializing serviceImports prior to adding the SI with empty `ServiceImportType`.
