### PR TITLE
Fix periodic broken link test issue reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/broken-link.md
+++ b/.github/ISSUE_TEMPLATE/broken-link.md
@@ -1,8 +1,2 @@
----
-name: Broken link detected by CI
-labels: bug
----
-
-<!-- Used by automation to raise an Issue when the periodic link aliveness tests detect a broken link. -->
-
-Periodic link aliveness CI detected a broken link. Please see the job results for details.
+Periodic link aliveness CI detected a broken link. Please see the [periodic job
+results](https://github.com/submariner-io/lighthouse/actions?query=workflow%3APeriodic) for details.

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -20,8 +20,8 @@ jobs:
 
       - name: Raise an Issue to report broken links
         if: ${{ failure() }}
-        uses: JasonEtco/create-an-issue@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: peter-evans/create-issue-from-file@v2.3.2
         with:
-          filename: .github/ISSUE_TEMPLATE/broken-link.md
+          title: Broken link detected by CI
+          content-filepath: .github/ISSUE_TEMPLATE/broken-link.md
+          labels: automated, broken link


### PR DESCRIPTION
Use new GHA for reporting issues when broken links are detected. This
logic was verified to work by the frequently-run flaky test finder.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>