### PR TITLE
Honour the image_tag flags

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM quay.io/submariner/shipyard-dapper-base:0.8.0-rc0
+FROM quay.io/submariner/shipyard-dapper-base:devel
 
 ENV DAPPER_ENV="REPO TAG QUAY_USERNAME QUAY_PASSWORD GITHUB_SHA BUILD_ARGS CLUSTERS_ARGS DEPLOY_ARGS RELEASE_ARGS" \
     DAPPER_SOURCE=/go/src/github.com/submariner-io/lighthouse DAPPER_DOCKER_SOCKET=true

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -21,11 +21,19 @@ function update_coredns_configmap() {
     fi 
 }
 
+### Extract the image_tag if necessary ###
+image_tag=
+for arg; do
+    if [[ "$arg" =~ "--image_tag=" ]]; then
+        image_tag=${arg##*=}
+    fi
+done
+
 ### Main ###
 
 declare_kubeconfig
-import_image quay.io/submariner/lighthouse-agent
-import_image quay.io/submariner/lighthouse-coredns
+import_image quay.io/submariner/lighthouse-agent ${image_tag}
+import_image quay.io/submariner/lighthouse-coredns ${image_tag}
 
 ${SCRIPTS_DIR}/deploy.sh "$@"
 


### PR DESCRIPTION
Lighthouse has its own image deployment, to handle the
Lighthouse-specific images. For the upgrade tests to work, this needs
to take into account image_tag, which determines which images need to
be pulled.

Along with https://github.com/submariner-io/shipyard/pull/376 (which
is why this also bumpd to the devel Shipyard base image) this should
allow Lighthouse upgrade tests to work.

Signed-off-by: Stephen Kitt <skitt@redhat.com>