### PR TITLE
E2E: Fetch actual clusterId

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -61,6 +61,21 @@ func beforeSuite() {
 	for _, restConfig := range framework.RestConfigs {
 		MCSClients = append(MCSClients, createLighthouseClient(restConfig))
 	}
+
+	framework.By("Fetching ClusterIDs")
+
+	for idx, kubeClient := range framework.KubeClients {
+		agentDeployment, err :=
+			kubeClient.AppsV1().Deployments(framework.TestContext.SubmarinerNamespace).Get("submariner-lighthouse-agent", metav1.GetOptions{})
+		Expect(err).To(Succeed())
+
+		for _, envVar := range agentDeployment.Spec.Template.Spec.Containers[0].Env {
+			if envVar.Name == "SUBMARINER_CLUSTERID" {
+				framework.TestContext.ClusterIDs[idx] = envVar.Value
+				break
+			}
+		}
+	}
 }
 
 func createLighthouseClient(restConfig *rest.Config) *mcsClientset.Clientset {


### PR DESCRIPTION
Currently E2E relies on test context for ClusterId, which needs to be
passed by user. This is prone to user error. Also, when running E2E
through `subctl verify` there is no means to pass such a variable.

Instead of relying on user to provide ClusterId, use actual ClusterId
configured when deploying Lighthouse agent.

Fixes https://github.com/submariner-io/submariner-operator/issues/968

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>