### PR TITLE
Run flake finder twice a day, off-peak

### DIFF
--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -3,7 +3,7 @@ name: Flake Finder
 
 on:
   schedule:
-    - cron: "0 0/2 * * *"
+    - cron: "0 0,1 * * *"
 
 jobs:
   e2e:


### PR DESCRIPTION
The flaky test finder is currently set to run very frequently, as we
were verifying stability during the 0.8 release. Out of 50 runs, there
was one failure and it was due to non-Submariner network issues.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>