### PR TITLE
Use nginx image from quay.io

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -329,7 +329,7 @@ func (f *Framework) NewNginxStatefulSet(cluster framework.ClusterIndex) *appsv1.
 					Containers: []v1.Container{
 						{
 							Name:            statefulServiceName,
-							Image:           "nginxinc/nginx-unprivileged:stable-alpine",
+							Image:           "quay.io/bitnami/nginx:latest",
 							ImagePullPolicy: v1.PullAlways,
 							Ports: []v1.ContainerPort{
 								{


### PR DESCRIPTION
Due to dockerhub api limits, we run into sporadic failures
when running e2e as it fails to load nginx image.
Use `quay.io/bitnami/nginx:latest` instead to avoid such issues.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>