### PR TITLE
Use DetectGlobalnet from shipyard

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -76,6 +76,8 @@ func beforeSuite() {
 			}
 		}
 	}
+
+	framework.DetectGlobalnet()
 }
 
 func createLighthouseClient(restConfig *rest.Config) *mcsClientset.Clientset {


### PR DESCRIPTION
DetectGlobalnet is now available in shipyard but
currently not called. Add call to it in beforeSuite
so it is set correctly

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>