### PR TITLE
Update gitlint ignore for new Dependabot

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -5,5 +5,5 @@ ignore=body-is-missing,body-min-length
 
 [ignore-by-body]
 # Dependabot doesn't follow our conventions, unfortunately
-regex=^Signed-off-by: dependabot-preview\[bot\](.*)
+regex=^Signed-off-by: dependabot\[bot\](.*)
 ignore=all


### PR DESCRIPTION
Dependabot was recently upgraded in #414, which changed the name from
"dependabot-preview" to just "dependabot".

Update the git commit message linting ignore rules to match the new
bot's signed-off-by line, as it still doesn't follow our rules.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>