### PR TITLE
Fix typo in e2e logs

### DIFF
--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -304,7 +304,7 @@ func verifyServiceIpWithDig(f *framework.Framework, srcCluster, targetCluster fr
 		return stdout, nil
 	}, func(result interface{}) (bool, string, error) {
 		doesContain := strings.Contains(result.(string), serviceIP)
-		By(fmt.Sprintf("Validating that dig result %s %q", op, result))
+		By(fmt.Sprintf("Validating that dig result %q %s %q", result, op, serviceIP))
 		if doesContain && !shouldContain {
 			return false, fmt.Sprintf("expected execution result %q not to contain %q", result, serviceIP), nil
 		}


### PR DESCRIPTION
When running LH e2e tests, we see the following logs
When ServiceDiscovery is expected to succeed:
STEP: Validating that dig result is "100.3.162.213"

When ServiceDiscovery is expected to fail:
STEP: Validating that dig result is not ""

The above log is confusing and should actually be
STEP: Validating that dig result is not "100.3.162.213"

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>