### PR TITLE
During cleanup use proper namespace for EPSlices verification

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -46,10 +46,11 @@ func NewFramework(baseName string) *Framework {
 	BeforeEach(f.BeforeEach)
 
 	AfterEach(func() {
+		namespace := f.Namespace
 		f.AfterEach()
 
-		f.AwaitEndpointSlices(framework.ClusterB, "", f.Namespace, 0, 0)
-		f.AwaitEndpointSlices(framework.ClusterA, "", f.Namespace, 0, 0)
+		f.AwaitEndpointSlices(framework.ClusterB, "", namespace, 0, 0)
+		f.AwaitEndpointSlices(framework.ClusterA, "", namespace, 0, 0)
 	})
 
 	return f


### PR DESCRIPTION
While checking the endpointslices during cleanup, the current code
was looking in all the namespaces. This PR fixes the code to validate
the presence of any endpoint slices only in the namespace used during
the e2e test run.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>