### PR TITLE
Use the PR base branch as reference when linting

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           config-file: ".markdownlinkcheck.json"
           check-modified-files-only: "yes"
+          base-branch: ${{ github.base_ref }}
 
   markdownlint:
     name: Markdown


### PR DESCRIPTION
To determine the changed files, the Markdown linter needs to know the
base branch; instead of using the default everywhere, use the base
branch set in the PR.

Signed-off-by: Stephen Kitt <skitt@redhat.com>