### PR TITLE
0.8.1 backports

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   e2e:
     name: E2E
-    timeout-minutes: 30
+    timeout-minutes: 45
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,8 +20,8 @@ jobs:
 
       - name: Reclaim free space
         run: |
-          sudo swapoff -a
-          sudo rm -f /swapfile
+          # cleanup 30GB+ of tools we don't need for our CI
+          rm -rf /opt/ghc /usr/share/dotnet /usr/share/swift
           df -h
           free -h
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           config-file: ".markdownlinkcheck.json"
           check-modified-files-only: "yes"
+          base-branch: ${{ github.base_ref }}
 
   markdownlint:
     name: Markdown

--- a/.github/workflows/upgrade-e2e.yml
+++ b/.github/workflows/upgrade-e2e.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Reclaim free space!
+      - name: Reclaim free space
         run: |
-          sudo swapoff -a
-          sudo rm -f /swapfile
+          # cleanup 30GB+ of tools we don't need for our CI
+          rm -rf /opt/ghc /usr/share/dotnet /usr/share/swift
           df -h
           free -h
 

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM quay.io/submariner/shipyard-dapper-base:0.8.0
+FROM quay.io/submariner/shipyard-dapper-base:release-0.8
 
 ENV DAPPER_ENV="REPO TAG QUAY_USERNAME QUAY_PASSWORD GITHUB_SHA BUILD_ARGS CLUSTERS_ARGS DEPLOY_ARGS RELEASE_ARGS" \
     DAPPER_SOURCE=/go/src/github.com/submariner-io/lighthouse DAPPER_DOCKER_SOCKET=true

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ TARGETS := $(shell ls -p scripts | grep -v -e / -e deploy)
 CLUSTER_SETTINGS_FLAG = --cluster_settings $(DAPPER_SOURCE)/scripts/cluster_settings
 override CLUSTERS_ARGS += $(CLUSTER_SETTINGS_FLAG)
 override DEPLOY_ARGS += $(CLUSTER_SETTINGS_FLAG)
-override E2E_ARGS += cluster1 cluster2
+override E2E_ARGS += cluster1 cluster2 cluster3
 override UNIT_TEST_ARGS += test/e2e
 
 # Process extra flags from the `using=a,b,c` optional flag

--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -261,7 +261,7 @@ func (a *Controller) serviceExportToServiceImport(obj runtime.Object, op syncer.
 		SessionAffinityConfig: new(corev1.SessionAffinityConfig),
 	}
 
-	ips, err := a.getIPsForService(svc, svcType)
+	ips, ports, err := a.getIPsAndPortsForService(svc, svcType)
 	if err != nil {
 		// Failed to get ips for some reason, requeue
 		a.updateExportedServiceStatus(svcExport.Name, svcExport.Namespace, mcsv1a1.ServiceExportValid,
@@ -280,6 +280,7 @@ func (a *Controller) serviceExportToServiceImport(obj runtime.Object, op syncer.
 
 	if svcType == mcsv1a1.ClusterSetIP {
 		serviceImport.Spec.IPs = ips
+		serviceImport.Spec.Ports = ports
 		/* We also store the clusterIP in an annotation as an optimization to recover it in case the IPs are
 		cleared out when here's no backing Endpoint pods.
 		*/
@@ -433,27 +434,35 @@ func (a *Controller) newServiceImport(svcExport *mcsv1a1.ServiceExport) *mcsv1a1
 	}
 }
 
-func (a *Controller) getIPsForService(service *corev1.Service, siType mcsv1a1.ServiceImportType) ([]string, error) {
+func (a *Controller) getIPsAndPortsForService(service *corev1.Service, siType mcsv1a1.ServiceImportType) (
+	[]string, []mcsv1a1.ServicePort, error) {
+	mcsPort := mcsv1a1.ServicePort{}
+	if len(service.Spec.Ports) > 0 {
+		mcsPort.Name = service.Spec.Ports[0].Name
+		mcsPort.Protocol = service.Spec.Ports[0].Protocol
+		mcsPort.Port = service.Spec.Ports[0].Port
+	}
+
 	if siType == mcsv1a1.ClusterSetIP {
 		mcsIp := getGlobalIpFromService(service)
 		if mcsIp == "" {
 			mcsIp = service.Spec.ClusterIP
 		}
 
-		return []string{mcsIp}, nil
+		return []string{mcsIp}, []mcsv1a1.ServicePort{mcsPort}, nil
 	}
 
 	endpoint, err := a.kubeClientSet.CoreV1().Endpoints(service.Namespace).Get(service.Name, metav1.GetOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			klog.Errorf("Error retrieving Endpoints for Service (%s/%s): %v", service.Namespace, service.Name, err)
-			return nil, errors.WithMessage(err, "Error retrieving the Endpoints for the Service")
+			return nil, nil, errors.WithMessage(err, "Error retrieving the Endpoints for the Service")
 		}
 
-		return make([]string, 0), nil
+		return make([]string, 0), make([]mcsv1a1.ServicePort, 0), nil
 	}
 
-	return getIPsFromEndpoint(endpoint), nil
+	return getIPsFromEndpoint(endpoint), []mcsv1a1.ServicePort{mcsPort}, nil
 }
 
 func (a *Controller) getObjectNameWithClusterId(name, namespace string) string {

--- a/pkg/agent/controller/agent_test.go
+++ b/pkg/agent/controller/agent_test.go
@@ -86,8 +86,8 @@ var _ = Describe("ServiceImport syncing", func() {
 		})
 	})
 
-	When("an exported Service is deleted while the ServiceExport still exists", func() {
-		It("should delete the ServiceImport", func() {
+	When("an exported Service is deleted and recreated while the ServiceExport still exists", func() {
+		It("should delete and recreate the ServiceImport", func() {
 			t.createService()
 			t.createServiceExport()
 			nextStatusIndex := t.awaitServiceExported(t.service.Spec.ClusterIP, 0)
@@ -95,6 +95,9 @@ var _ = Describe("ServiceImport syncing", func() {
 			t.deleteService()
 			t.awaitServiceUnexported()
 			t.awaitServiceUnavailableStatus(nextStatusIndex)
+
+			t.createService()
+			t.awaitServiceExported(t.service.Spec.ClusterIP, nextStatusIndex+1)
 		})
 	})
 

--- a/pkg/gateway/controller.go
+++ b/pkg/gateway/controller.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"fmt"
+	"os"
 	"sync/atomic"
 
 	"github.com/submariner-io/admiral/pkg/log"
@@ -41,8 +42,13 @@ func NewController() *Controller {
 		stopCh:           make(chan struct{}),
 		gatewayAvailable: true,
 	}
+
 	controller.clusterStatusMap.Store(make(map[string]bool))
-	controller.localClusterID.Store("")
+
+	localClusterId := os.Getenv("SUBMARINER_CLUSTERID")
+
+	klog.Infof("Setting localClusterID from env: %q", localClusterId)
+	controller.localClusterID.Store(localClusterId)
 
 	return controller
 }

--- a/scripts/cluster_settings
+++ b/scripts/cluster_settings
@@ -1,10 +1,12 @@
 . "${SCRIPTS_DIR}"/lib/source_only
 
 # We need a minimal setup to verify that lighthouse works
-clusters=('cluster1' 'cluster2')
+clusters=('cluster1' 'cluster2' 'cluster3')
 cluster_nodes['cluster1']="control-plane worker worker"
 cluster_nodes['cluster2']="control-plane worker worker"
+cluster_nodes['cluster3']="control-plane worker"
 
-cluster_cni=( ['cluster1']="weave" ['cluster2']="weave" )
+cluster_cni=( ['cluster1']="weave" ['cluster2']="weave" ['cluster3']="weave" )
 
-cluster_subm=( ['cluster1']="true" ['cluster2']="true" )
+cluster_subm=( ['cluster1']="true" ['cluster2']="true"  ['cluster3']="true" )
+

--- a/test/e2e/discovery/headless_services.go
+++ b/test/e2e/discovery/headless_services.go
@@ -43,6 +43,16 @@ var _ = Describe("[discovery] Test Headless Service Discovery Across Clusters", 
 			}
 		})
 	})
+
+	When("a pod tries to resolve a headless service in a specific remote cluster by its cluster name", func() {
+		It("should resolve the backing pod IPs from the specified remote cluster", func() {
+			if !framework.TestContext.GlobalnetEnabled {
+				RunHeadlessDiscoveryClusterNameTest(f)
+			} else {
+				framework.Skipf("Globalnet is enabled, skipping the test...")
+			}
+		})
+	})
 })
 
 func RunHeadlessDiscoveryTest(f *lhframework.Framework) {
@@ -65,12 +75,16 @@ func RunHeadlessDiscoveryTest(f *lhframework.Framework) {
 
 	ipList := f.GetEndpointIPs(framework.ClusterB, nginxHeadlessClusterB.Name, nginxHeadlessClusterB.Namespace)
 
-	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains, true)
+	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains,
+		"", true)
+	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains,
+		clusterBName, true)
 
 	f.DeleteServiceExport(framework.ClusterB, nginxHeadlessClusterB.Name, nginxHeadlessClusterB.Namespace)
 	f.AwaitServiceImportCount(framework.ClusterA, nginxHeadlessClusterB.Name, nginxHeadlessClusterB.Namespace, 0)
 
-	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains, false)
+	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains,
+		"", false)
 }
 
 func RunHeadlessDiscoveryLocalAndRemoteTest(f *lhframework.Framework) {
@@ -103,13 +117,16 @@ func RunHeadlessDiscoveryLocalAndRemoteTest(f *lhframework.Framework) {
 	ipListA := f.GetEndpointIPs(framework.ClusterA, nginxHeadlessClusterA.Name, nginxHeadlessClusterA.Namespace)
 	ipList := append(ipListB, ipListA...)
 
-	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains, true)
+	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains,
+		"", true)
 
 	f.DeleteServiceExport(framework.ClusterB, nginxHeadlessClusterB.Name, nginxHeadlessClusterB.Namespace)
 	f.AwaitServiceImportCount(framework.ClusterA, nginxHeadlessClusterB.Name, nginxHeadlessClusterB.Namespace, 1)
 
-	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipListB, checkedDomains, false)
-	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipListA, checkedDomains, true)
+	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipListB, checkedDomains,
+		"", false)
+	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipListA, checkedDomains,
+		"", true)
 }
 
 func RunHeadlessPodsAvailabilityTest(f *lhframework.Framework) {
@@ -133,22 +150,67 @@ func RunHeadlessPodsAvailabilityTest(f *lhframework.Framework) {
 	netshootPodList := f.NewNetShootDeployment(framework.ClusterA)
 
 	ipList := f.AwaitEndpointIPs(framework.ClusterB, nginxHeadlessClusterB.Name, nginxHeadlessClusterB.Namespace, 3)
-	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains, true)
+	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains,
+		"", true)
 
 	f.SetNginxReplicaSet(framework.ClusterB, 0)
 	ipList = f.AwaitEndpointIPs(framework.ClusterB, nginxHeadlessClusterB.Name, nginxHeadlessClusterB.Namespace, 0)
-	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains, false)
+	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains,
+		"", false)
 
 	f.SetNginxReplicaSet(framework.ClusterB, 2)
 	ipList = f.AwaitEndpointIPs(framework.ClusterB, nginxHeadlessClusterB.Name, nginxHeadlessClusterB.Namespace, 2)
-	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains, true)
+	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains,
+		"", true)
+}
+
+func RunHeadlessDiscoveryClusterNameTest(f *lhframework.Framework) {
+	clusterAName := framework.TestContext.ClusterIDs[framework.ClusterA]
+	clusterBName := framework.TestContext.ClusterIDs[framework.ClusterB]
+
+	By(fmt.Sprintf("Creating an Nginx Deployment on on %q", clusterAName))
+	f.NewNginxDeployment(framework.ClusterA)
+
+	By(fmt.Sprintf("Creating a Nginx Headless Service on %q", clusterAName))
+
+	nginxHeadlessClusterA := f.NewNginxHeadlessService(framework.ClusterA)
+
+	f.NewServiceExport(framework.ClusterA, nginxHeadlessClusterA.Name, nginxHeadlessClusterA.Namespace)
+	f.AwaitServiceExportedStatusCondition(framework.ClusterA, nginxHeadlessClusterA.Name, nginxHeadlessClusterA.Namespace)
+
+	By(fmt.Sprintf("Creating an Nginx Deployment on on %q", clusterBName))
+	f.NewNginxDeployment(framework.ClusterB)
+
+	By(fmt.Sprintf("Creating a Nginx Headless Service on %q", clusterBName))
+
+	nginxHeadlessClusterB := f.NewNginxHeadlessService(framework.ClusterB)
+
+	f.NewServiceExport(framework.ClusterB, nginxHeadlessClusterB.Name, nginxHeadlessClusterB.Namespace)
+	f.AwaitServiceExportedStatusCondition(framework.ClusterB, nginxHeadlessClusterB.Name, nginxHeadlessClusterB.Namespace)
+
+	By(fmt.Sprintf("Creating a Netshoot Deployment on %q", clusterAName))
+
+	netshootPodList := f.NewNetShootDeployment(framework.ClusterA)
+
+	ipListClusterA := f.GetEndpointIPs(framework.ClusterA, nginxHeadlessClusterA.Name, nginxHeadlessClusterA.Namespace)
+	ipListClusterB := f.GetEndpointIPs(framework.ClusterB, nginxHeadlessClusterB.Name, nginxHeadlessClusterB.Namespace)
+
+	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterA, netshootPodList, ipListClusterA, checkedDomains,
+		clusterAName, true)
+	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipListClusterB, checkedDomains,
+		clusterBName, true)
 }
 
 func verifyHeadlessIpsWithDig(f *framework.Framework, cluster framework.ClusterIndex, service *corev1.Service, targetPod *corev1.PodList,
-	ipList, domains []string, shouldContain bool) {
+	ipList, domains []string, clusterName string, shouldContain bool) {
 	cmd := []string{"dig", "+short"}
+	var clusterDNSName string
+	if clusterName != "" {
+		clusterDNSName = clusterName + "."
+	}
+
 	for i := range domains {
-		cmd = append(cmd, service.Name+"."+f.Namespace+".svc."+domains[i])
+		cmd = append(cmd, clusterDNSName+service.Name+"."+f.Namespace+".svc."+domains[i])
 	}
 
 	op := "are"

--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -88,12 +88,13 @@ func RunServiceDiscoveryTest(f *lhframework.Framework) {
 
 	netshootPodList := f.NewNetShootDeployment(framework.ClusterA)
 
-	if svc, err := f.GetService(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace); err == nil {
-		nginxServiceClusterB = svc
-		f.AwaitServiceImportIP(framework.ClusterA, nginxServiceClusterB)
-		f.AwaitEndpointSlices(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
-		f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
-	}
+	svc, err := f.GetService(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	Expect(err).NotTo(HaveOccurred())
+
+	nginxServiceClusterB = svc
+	f.AwaitServiceImportIP(framework.ClusterA, nginxServiceClusterB)
+	f.AwaitEndpointSlices(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
+	f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
 
 	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains,
 		"", true)
@@ -140,12 +141,13 @@ func RunServiceDiscoveryLocalTest(f *lhframework.Framework) {
 
 	f.DeleteService(framework.ClusterA, nginxServiceClusterA.Name)
 
-	if svc, err := f.GetService(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace); err == nil {
-		nginxServiceClusterB = svc
-		f.AwaitServiceImportIP(framework.ClusterA, nginxServiceClusterB)
-		f.AwaitEndpointSlices(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
-		f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
-	}
+	svc, err := f.GetService(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	Expect(err).NotTo(HaveOccurred())
+
+	nginxServiceClusterB = svc
+	f.AwaitServiceImportIP(framework.ClusterA, nginxServiceClusterB)
+	f.AwaitEndpointSlices(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
+	f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
 
 	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains,
 		"", true)
@@ -178,12 +180,13 @@ func RunServiceExportTest(f *lhframework.Framework) {
 
 	netshootPodList := f.NewNetShootDeployment(framework.ClusterA)
 
-	if svc, err := f.GetService(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace); err == nil {
-		nginxServiceClusterB = svc
-		f.AwaitServiceImportIP(framework.ClusterA, nginxServiceClusterB)
-		f.AwaitEndpointSlices(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
-		f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
-	}
+	svc, err := f.GetService(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	Expect(err).NotTo(HaveOccurred())
+
+	nginxServiceClusterB = svc
+	f.AwaitServiceImportIP(framework.ClusterA, nginxServiceClusterB)
+	f.AwaitEndpointSlices(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
+	f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
 
 	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains,
 		"", true)
@@ -214,12 +217,13 @@ func RunServicesPodAvailabilityTest(f *lhframework.Framework) {
 
 	netshootPodList := f.NewNetShootDeployment(framework.ClusterA)
 
-	if svc, err := f.GetService(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace); err == nil {
-		nginxServiceClusterB = svc
-		f.AwaitServiceImportIP(framework.ClusterA, nginxServiceClusterB)
-		f.AwaitEndpointSlices(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
-		f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
-	}
+	svc, err := f.GetService(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	Expect(err).NotTo(HaveOccurred())
+
+	nginxServiceClusterB = svc
+	f.AwaitServiceImportIP(framework.ClusterA, nginxServiceClusterB)
+	f.AwaitEndpointSlices(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
+	f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
 
 	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains,
 		"", true)
@@ -232,11 +236,18 @@ func RunServicesPodAvailabilityTest(f *lhframework.Framework) {
 }
 
 func RunServicesPodAvailabilityMutliClusterTest(f *lhframework.Framework) {
+	if len(framework.TestContext.ClusterIDs) < 3 {
+		Skip("Only two clusters are deployed and hence skipping the test")
+		return
+	}
+
 	clusterAName := framework.TestContext.ClusterIDs[framework.ClusterA]
 	clusterBName := framework.TestContext.ClusterIDs[framework.ClusterB]
+	clusterCName := framework.TestContext.ClusterIDs[framework.ClusterC]
 
-	By(fmt.Sprintf("Creating an Nginx Deployment on on %q", clusterBName))
+	By(fmt.Sprintf("Creating an Nginx Deployment on %q", clusterBName))
 	f.NewNginxDeployment(framework.ClusterB)
+
 	By(fmt.Sprintf("Creating a Nginx Service on %q", clusterBName))
 
 	nginxServiceClusterB := f.NewNginxService(framework.ClusterB)
@@ -246,50 +257,50 @@ func RunServicesPodAvailabilityMutliClusterTest(f *lhframework.Framework) {
 
 	f.AwaitServiceExportedStatusCondition(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 
+	By(fmt.Sprintf("Creating an Nginx Deployment on %q", clusterCName))
+	f.NewNginxDeployment(framework.ClusterC)
+
+	By(fmt.Sprintf("Creating a Nginx Service on %q", clusterCName))
+
+	nginxServiceClusterC := f.Framework.NewNginxService(framework.ClusterC)
+
+	f.AwaitGlobalnetIP(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace)
+	f.NewServiceExport(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace)
+
 	By(fmt.Sprintf("Creating a Netshoot Deployment on %q", clusterAName))
 
 	netshootPodList := f.NewNetShootDeployment(framework.ClusterA)
 
-	if svc, err := f.GetService(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace); err == nil {
-		nginxServiceClusterB = svc
-		f.AwaitServiceImportIP(framework.ClusterA, nginxServiceClusterB)
-		f.AwaitEndpointSlices(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
-		f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
-	}
+	svc, err := f.GetService(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace)
+	Expect(err).NotTo(HaveOccurred())
 
-	By(fmt.Sprintf("Creating an Nginx Deployment on on %q", clusterAName))
-	f.NewNginxDeployment(framework.ClusterA)
-	By(fmt.Sprintf("Creating a Nginx Service on %q", clusterAName))
+	nginxServiceClusterC = svc
+	f.AwaitServiceImportIP(framework.ClusterC, nginxServiceClusterC)
+	f.AwaitEndpointSlices(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace, 2, 2)
 
-	nginxServiceClusterA := f.NewNginxService(framework.ClusterA)
+	svc, err = f.GetService(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	Expect(err).NotTo(HaveOccurred())
 
-	f.AwaitGlobalnetIP(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace)
-	f.NewServiceExport(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace)
+	nginxServiceClusterB = svc
+	f.AwaitServiceImportIP(framework.ClusterB, nginxServiceClusterB)
+	f.AwaitEndpointSlices(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 2, 2)
 
-	f.AwaitServiceExportedStatusCondition(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace)
-
-	if svc, err := f.GetService(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace); err == nil {
-		nginxServiceClusterA = svc
-		f.AwaitServiceImportIP(framework.ClusterA, nginxServiceClusterA)
-		f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace, 2, 2)
-	}
-
-	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterA, nginxServiceClusterA, netshootPodList, checkedDomains,
-		"", true)
 	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains,
-		"", false)
+		"", true)
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterC, nginxServiceClusterC, netshootPodList, checkedDomains,
+		"", true)
 
-	f.SetNginxReplicaSet(framework.ClusterA, 0)
+	f.SetNginxReplicaSet(framework.ClusterC, 0)
 
-	f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace, 2, 1)
-	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterA, nginxServiceClusterA, netshootPodList, checkedDomains,
+	f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace, 2, 1)
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterA, nginxServiceClusterC, netshootPodList, checkedDomains,
 		"", false)
 	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains,
 		"", true)
 
 	f.SetNginxReplicaSet(framework.ClusterB, 0)
-	f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace, 2, 0)
-	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterA, nginxServiceClusterA, netshootPodList, checkedDomains,
+	f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace, 2, 0)
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterA, nginxServiceClusterC, netshootPodList, checkedDomains,
 		"", false)
 	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains,
 		"", false)
@@ -325,20 +336,22 @@ func RunServiceDiscoveryClusterNameTest(f *lhframework.Framework) {
 
 	netshootPodList := f.NewNetShootDeployment(framework.ClusterA)
 
-	if svc, err := f.GetService(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace); err == nil {
-		nginxServiceClusterA = svc
-		f.AwaitServiceImportIP(framework.ClusterA, nginxServiceClusterA)
-		f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace, 2, 2)
-	}
+	svc, err := f.GetService(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace)
+	Expect(err).NotTo(HaveOccurred())
+
+	nginxServiceClusterA = svc
+	f.AwaitServiceImportIP(framework.ClusterA, nginxServiceClusterA)
+	f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace, 2, 2)
 
 	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterA, nginxServiceClusterA, netshootPodList, checkedDomains,
 		clusterAName, true)
 
-	if svc, err := f.GetService(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace); err == nil {
-		nginxServiceClusterB = svc
-		f.AwaitServiceImportIP(framework.ClusterA, nginxServiceClusterB)
-		f.AwaitEndpointSlices(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 2, 2)
-	}
+	svc, err = f.GetService(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	Expect(err).NotTo(HaveOccurred())
+
+	nginxServiceClusterB = svc
+	f.AwaitServiceImportIP(framework.ClusterA, nginxServiceClusterB)
+	f.AwaitEndpointSlices(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 2, 2)
 
 	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains,
 		clusterBName, true)
@@ -380,17 +393,19 @@ func RunServiceDiscoveryRoundRobinTest(f *lhframework.Framework) {
 
 	netshootPodList := f.NewNetShootDeployment(framework.ClusterA)
 
-	if svc, err := f.GetService(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace); err == nil {
-		nginxServiceClusterC = svc
-		f.AwaitServiceImportIP(framework.ClusterC, nginxServiceClusterC)
-		f.AwaitEndpointSlices(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace, 2, 2)
-	}
+	svc, err := f.GetService(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace)
+	Expect(err).NotTo(HaveOccurred())
 
-	if svc, err := f.GetService(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace); err == nil {
-		nginxServiceClusterB = svc
-		f.AwaitServiceImportIP(framework.ClusterB, nginxServiceClusterB)
-		f.AwaitEndpointSlices(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 2, 2)
-	}
+	nginxServiceClusterC = svc
+	f.AwaitServiceImportIP(framework.ClusterC, nginxServiceClusterC)
+	f.AwaitEndpointSlices(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace, 2, 2)
+
+	svc, err = f.GetService(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	Expect(err).NotTo(HaveOccurred())
+
+	nginxServiceClusterB = svc
+	f.AwaitServiceImportIP(framework.ClusterB, nginxServiceClusterB)
+	f.AwaitEndpointSlices(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 2, 2)
 
 	var serviceIPList []string
 

--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -66,6 +66,29 @@ var _ = Describe("[discovery] Test Service Discovery Across Clusters", func() {
 			RunServiceDiscoveryRoundRobinTest(f)
 		})
 	})
+
+	When("one of the clusters with a service is not healthy", func() {
+		var healthCheckIP, endpointName string
+
+		BeforeEach(func() {
+			if len(framework.TestContext.ClusterIDs) < 3 {
+				Skip("Only two clusters are deployed and hence skipping the test")
+				return
+			}
+
+			randomIP := "192.168.1.5"
+			endpointName, healthCheckIP = f.GetHealthCheckIPInfo(framework.ClusterC)
+			f.SetHealthCheckIP(framework.ClusterC, randomIP, endpointName)
+		})
+
+		It("should not resolve that cluster's service IP", func() {
+			RunServicesClusterAvailabilityMutliClusterTest(f)
+		})
+
+		AfterEach(func() {
+			f.SetHealthCheckIP(framework.ClusterC, healthCheckIP, endpointName)
+		})
+	})
 })
 
 func RunServiceDiscoveryTest(f *lhframework.Framework) {
@@ -424,6 +447,57 @@ func RunServiceDiscoveryRoundRobinTest(f *lhframework.Framework) {
 	serviceIPList = append(serviceIPList, serviceIPClusterC)
 
 	verifyRoundRobinWithDig(f.Framework, framework.ClusterA, nginxServiceClusterB.Name, serviceIPList, netshootPodList, checkedDomains)
+}
+
+func RunServicesClusterAvailabilityMutliClusterTest(f *lhframework.Framework) {
+	clusterBName := framework.TestContext.ClusterIDs[framework.ClusterB]
+	clusterCName := framework.TestContext.ClusterIDs[framework.ClusterC]
+
+	By(fmt.Sprintf("Creating an Nginx Deployment on on %q", clusterBName))
+	f.NewNginxDeployment(framework.ClusterB)
+	By(fmt.Sprintf("Creating a Nginx Service on %q", clusterBName))
+
+	nginxServiceClusterB := f.NewNginxService(framework.ClusterB)
+
+	f.AwaitGlobalnetIP(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	f.NewServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+
+	f.AwaitServiceExportedStatusCondition(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+
+	By(fmt.Sprintf("Creating a Netshoot Deployment on %q", clusterCName))
+
+	netshootPodList := f.NewNetShootDeployment(framework.ClusterA)
+
+	svc, err := f.GetService(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	Expect(err).NotTo(HaveOccurred())
+
+	nginxServiceClusterB = svc
+	f.AwaitServiceImportIP(framework.ClusterA, nginxServiceClusterB)
+	f.AwaitEndpointSlices(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
+	f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
+
+	By(fmt.Sprintf("Creating an Nginx Deployment on on %q", clusterCName))
+	f.NewNginxDeployment(framework.ClusterC)
+	By(fmt.Sprintf("Creating a Nginx Service on %q", clusterCName))
+
+	nginxServiceClusterC := f.NewNginxService(framework.ClusterC)
+
+	f.AwaitGlobalnetIP(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace)
+	f.NewServiceExport(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace)
+
+	f.AwaitServiceExportedStatusCondition(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace)
+
+	svc, err = f.GetService(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace)
+	Expect(err).NotTo(HaveOccurred())
+
+	nginxServiceClusterC = svc
+	f.AwaitServiceImportIP(framework.ClusterA, nginxServiceClusterC)
+	f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace, 2, 2)
+
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList,
+		checkedDomains, "", true)
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterC, nginxServiceClusterC, netshootPodList,
+		checkedDomains, "", false)
 }
 
 func verifyServiceIpWithDig(f *framework.Framework, srcCluster, targetCluster framework.ClusterIndex, service *corev1.Service,

--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -53,6 +53,11 @@ var _ = Describe("[discovery] Test Service Discovery Across Clusters", func() {
 		})
 	})
 
+	When("a pod tries to resolve a service in a specific remote cluster by its cluster name", func() {
+		It("should resolve the service on the specified cluster", func() {
+			RunServiceDiscoveryClusterNameTest(f)
+		})
+	})
 })
 
 func RunServiceDiscoveryTest(f *lhframework.Framework) {
@@ -82,14 +87,16 @@ func RunServiceDiscoveryTest(f *lhframework.Framework) {
 		f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
 	}
 
-	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains, true)
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains,
+		"", true)
 
 	f.DeleteServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 	f.AwaitServiceImportDelete(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 
 	f.DeleteService(framework.ClusterB, nginxServiceClusterB.Name)
 
-	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains, false)
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains,
+		"", false)
 }
 
 func RunServiceDiscoveryLocalTest(f *lhframework.Framework) {
@@ -121,7 +128,7 @@ func RunServiceDiscoveryLocalTest(f *lhframework.Framework) {
 	clusterADomain := getClusterDomain(f.Framework, framework.ClusterA, netshootPodList)
 
 	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterA, nginxServiceClusterA, netshootPodList,
-		[]string{clusterADomain}, true)
+		[]string{clusterADomain}, "", true)
 
 	f.DeleteService(framework.ClusterA, nginxServiceClusterA.Name)
 
@@ -132,14 +139,16 @@ func RunServiceDiscoveryLocalTest(f *lhframework.Framework) {
 		f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
 	}
 
-	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains, true)
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains,
+		"", true)
 
 	f.DeleteServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 	f.AwaitServiceImportDelete(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 
 	f.DeleteService(framework.ClusterB, nginxServiceClusterB.Name)
 
-	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains, false)
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains,
+		"", false)
 }
 
 func RunServiceExportTest(f *lhframework.Framework) {
@@ -168,12 +177,14 @@ func RunServiceExportTest(f *lhframework.Framework) {
 		f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
 	}
 
-	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains, true)
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains,
+		"", true)
 
 	f.DeleteServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 	f.AwaitServiceImportDelete(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 
-	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains, false)
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains,
+		"", false)
 }
 
 func RunServicesPodAvailabilityTest(f *lhframework.Framework) {
@@ -202,11 +213,14 @@ func RunServicesPodAvailabilityTest(f *lhframework.Framework) {
 		f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 1, 1)
 	}
 
-	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains, true)
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains,
+		"", true)
 	f.SetNginxReplicaSet(framework.ClusterB, 0)
-	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains, false)
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains,
+		"", false)
 	f.SetNginxReplicaSet(framework.ClusterB, 2)
-	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains, true)
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains,
+		"", true)
 }
 
 func RunServicesPodAvailabilityMutliClusterTest(f *lhframework.Framework) {
@@ -252,23 +266,78 @@ func RunServicesPodAvailabilityMutliClusterTest(f *lhframework.Framework) {
 		f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace, 2, 2)
 	}
 
-	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterA, nginxServiceClusterA, netshootPodList, checkedDomains, true)
-	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains, false)
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterA, nginxServiceClusterA, netshootPodList, checkedDomains,
+		"", true)
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains,
+		"", false)
 
 	f.SetNginxReplicaSet(framework.ClusterA, 0)
 
 	f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace, 2, 1)
-	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterA, nginxServiceClusterA, netshootPodList, checkedDomains, false)
-	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains, true)
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterA, nginxServiceClusterA, netshootPodList, checkedDomains,
+		"", false)
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains,
+		"", true)
 
 	f.SetNginxReplicaSet(framework.ClusterB, 0)
 	f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace, 2, 0)
-	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterA, nginxServiceClusterA, netshootPodList, checkedDomains, false)
-	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains, false)
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterA, nginxServiceClusterA, netshootPodList, checkedDomains,
+		"", false)
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains,
+		"", false)
+}
+
+func RunServiceDiscoveryClusterNameTest(f *lhframework.Framework) {
+	clusterAName := framework.TestContext.ClusterIDs[framework.ClusterA]
+	clusterBName := framework.TestContext.ClusterIDs[framework.ClusterB]
+
+	By(fmt.Sprintf("Creating an Nginx Deployment on %q", clusterAName))
+	f.NewNginxDeployment(framework.ClusterA)
+
+	By(fmt.Sprintf("Creating a Nginx Service on %q", clusterAName))
+
+	nginxServiceClusterA := f.Framework.NewNginxService(framework.ClusterA)
+
+	f.AwaitGlobalnetIP(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace)
+	f.NewServiceExport(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace)
+
+	By(fmt.Sprintf("Creating an Nginx Deployment on %q", clusterBName))
+	f.NewNginxDeployment(framework.ClusterB)
+
+	By(fmt.Sprintf("Creating a Nginx Service on %q", clusterBName))
+
+	nginxServiceClusterB := f.NewNginxService(framework.ClusterB)
+
+	f.AwaitGlobalnetIP(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	f.NewServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+
+	f.AwaitServiceExportedStatusCondition(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+
+	By(fmt.Sprintf("Creating a Netshoot Deployment on %q", clusterAName))
+
+	netshootPodList := f.NewNetShootDeployment(framework.ClusterA)
+
+	if svc, err := f.GetService(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace); err == nil {
+		nginxServiceClusterA = svc
+		f.AwaitServiceImportIP(framework.ClusterA, nginxServiceClusterA)
+		f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace, 2, 2)
+	}
+
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterA, nginxServiceClusterA, netshootPodList, checkedDomains,
+		clusterAName, true)
+
+	if svc, err := f.GetService(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace); err == nil {
+		nginxServiceClusterB = svc
+		f.AwaitServiceImportIP(framework.ClusterA, nginxServiceClusterB)
+		f.AwaitEndpointSlices(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 2, 2)
+	}
+
+	verifyServiceIpWithDig(f.Framework, framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains,
+		clusterBName, true)
 }
 
 func verifyServiceIpWithDig(f *framework.Framework, srcCluster, targetCluster framework.ClusterIndex, service *corev1.Service,
-	targetPod *corev1.PodList, domains []string, shouldContain bool) {
+	targetPod *corev1.PodList, domains []string, clusterName string, shouldContain bool) {
 	var serviceIP string
 	var ok bool
 
@@ -278,8 +347,13 @@ func verifyServiceIpWithDig(f *framework.Framework, srcCluster, targetCluster fr
 	}
 
 	cmd := []string{"dig", "+short"}
+	var clusterDNSName string
+	if clusterName != "" {
+		clusterDNSName = clusterName + "."
+	}
+
 	for i := range domains {
-		cmd = append(cmd, service.Name+"."+f.Namespace+".svc."+domains[i])
+		cmd = append(cmd, clusterDNSName+service.Name+"."+f.Namespace+".svc."+domains[i])
 	}
 
 	op := "is"

--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -2,10 +2,12 @@ package discovery
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	lhframework "github.com/submariner-io/lighthouse/test/e2e/framework"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 	corev1 "k8s.io/api/core/v1"
@@ -56,6 +58,12 @@ var _ = Describe("[discovery] Test Service Discovery Across Clusters", func() {
 	When("a pod tries to resolve a service in a specific remote cluster by its cluster name", func() {
 		It("should resolve the service on the specified cluster", func() {
 			RunServiceDiscoveryClusterNameTest(f)
+		})
+	})
+
+	When("a pod tries to resolve a service multiple times", func() {
+		It("should resolve the service from both the clusters in a round robin fashion", func() {
+			RunServiceDiscoveryRoundRobinTest(f)
 		})
 	})
 })
@@ -336,6 +344,73 @@ func RunServiceDiscoveryClusterNameTest(f *lhframework.Framework) {
 		clusterBName, true)
 }
 
+func RunServiceDiscoveryRoundRobinTest(f *lhframework.Framework) {
+	if len(framework.TestContext.ClusterIDs) < 3 {
+		Skip("Only two clusters are deployed and hence skipping the test")
+		return
+	}
+
+	clusterAName := framework.TestContext.ClusterIDs[framework.ClusterA]
+	clusterBName := framework.TestContext.ClusterIDs[framework.ClusterB]
+	clusterCName := framework.TestContext.ClusterIDs[framework.ClusterC]
+
+	By(fmt.Sprintf("Creating an Nginx Deployment on %q", clusterBName))
+	f.NewNginxDeployment(framework.ClusterB)
+
+	By(fmt.Sprintf("Creating a Nginx Service on %q", clusterBName))
+
+	nginxServiceClusterB := f.NewNginxService(framework.ClusterB)
+
+	f.AwaitGlobalnetIP(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	f.NewServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+
+	f.AwaitServiceExportedStatusCondition(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+
+	By(fmt.Sprintf("Creating an Nginx Deployment on %q", clusterCName))
+	f.NewNginxDeployment(framework.ClusterC)
+
+	By(fmt.Sprintf("Creating a Nginx Service on %q", clusterCName))
+
+	nginxServiceClusterC := f.Framework.NewNginxService(framework.ClusterC)
+
+	f.AwaitGlobalnetIP(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace)
+	f.NewServiceExport(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace)
+
+	By(fmt.Sprintf("Creating a Netshoot Deployment on %q", clusterAName))
+
+	netshootPodList := f.NewNetShootDeployment(framework.ClusterA)
+
+	if svc, err := f.GetService(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace); err == nil {
+		nginxServiceClusterC = svc
+		f.AwaitServiceImportIP(framework.ClusterC, nginxServiceClusterC)
+		f.AwaitEndpointSlices(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace, 2, 2)
+	}
+
+	if svc, err := f.GetService(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace); err == nil {
+		nginxServiceClusterB = svc
+		f.AwaitServiceImportIP(framework.ClusterB, nginxServiceClusterB)
+		f.AwaitEndpointSlices(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 2, 2)
+	}
+
+	var serviceIPList []string
+
+	serviceIPClusterB, ok := nginxServiceClusterB.Annotations[submarinerIpamGlobalIp]
+	if !ok {
+		serviceIPClusterB = nginxServiceClusterB.Spec.ClusterIP
+	}
+
+	serviceIPList = append(serviceIPList, serviceIPClusterB)
+
+	serviceIPClusterC, ok := nginxServiceClusterC.Annotations[submarinerIpamGlobalIp]
+	if !ok {
+		serviceIPClusterC = nginxServiceClusterC.Spec.ClusterIP
+	}
+
+	serviceIPList = append(serviceIPList, serviceIPClusterC)
+
+	verifyRoundRobinWithDig(f.Framework, framework.ClusterA, nginxServiceClusterB.Name, serviceIPList, netshootPodList, checkedDomains)
+}
+
 func verifyServiceIpWithDig(f *framework.Framework, srcCluster, targetCluster framework.ClusterIndex, service *corev1.Service,
 	targetPod *corev1.PodList, domains []string, clusterName string, shouldContain bool) {
 	var serviceIP string
@@ -347,6 +422,7 @@ func verifyServiceIpWithDig(f *framework.Framework, srcCluster, targetCluster fr
 	}
 
 	cmd := []string{"dig", "+short"}
+
 	var clusterDNSName string
 	if clusterName != "" {
 		clusterDNSName = clusterName + "."
@@ -389,6 +465,58 @@ func verifyServiceIpWithDig(f *framework.Framework, srcCluster, targetCluster fr
 
 		return true, "", nil
 	})
+}
+
+func verifyRoundRobinWithDig(f *framework.Framework, srcCluster framework.ClusterIndex, serviceName string, serviceIPList []string,
+	targetPod *corev1.PodList, domains []string) {
+	cmd := []string{"dig", "+short"}
+
+	for i := range domains {
+		cmd = append(cmd, serviceName+"."+f.Namespace+".svc."+domains[i])
+	}
+
+	serviceIPMap := make(map[string]int)
+
+	By(fmt.Sprintf("Executing %q to verify IPs %q for service %q are discoverable in a"+
+		" round-robin fashion", strings.Join(cmd, " "), serviceIPList, serviceName))
+
+	var retIPs []string
+
+	for count := 0; count < 10; count++ {
+		framework.AwaitUntil("verify if service IP is discoverable", func() (interface{}, error) {
+			stdout, _, err := f.ExecWithOptions(framework.ExecOptions{
+				Command:       cmd,
+				Namespace:     f.Namespace,
+				PodName:       targetPod.Items[0].Name,
+				ContainerName: targetPod.Items[0].Spec.Containers[0].Name,
+				CaptureStdout: true,
+				CaptureStderr: true,
+			}, srcCluster)
+			if err != nil {
+				return nil, err
+			}
+
+			return stdout, nil
+		}, func(result interface{}) (bool, string, error) {
+			for _, serviceIP := range serviceIPList {
+				if strings.Contains(result.(string), serviceIP) {
+					serviceIPMap[serviceIP]++
+					retIPs = append(retIPs, serviceIP)
+					break
+				}
+			}
+
+			return true, "", nil
+		})
+	}
+
+	By(fmt.Sprintf("Service IP %q was returned %d times and Service IP %q was returned %d times - "+
+		"verifying the difference between them is within the threshold", serviceIPList[0], serviceIPMap[serviceIPList[0]],
+		serviceIPList[1], serviceIPMap[serviceIPList[1]]))
+
+	Expect(int(math.Abs(float64(serviceIPMap[serviceIPList[0]]-serviceIPMap[serviceIPList[1]]))) < 3).To(BeTrue(),
+		"Service IPs were not returned in proper round-robin fashion: Expected IPs: %v,"+
+			" Returned IPs: %v, IP Counts: %v", serviceIPList, retIPs, serviceIPMap)
 }
 
 func getClusterDomain(f *framework.Framework, cluster framework.ClusterIndex, targetPod *corev1.PodList) string {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -70,21 +70,6 @@ func beforeSuite() {
 		EndpointClients = append(EndpointClients, createEndpointClientSet(restConfig))
 	}
 
-	framework.By("Fetching ClusterIDs")
-
-	for idx, kubeClient := range framework.KubeClients {
-		agentDeployment, err :=
-			kubeClient.AppsV1().Deployments(framework.TestContext.SubmarinerNamespace).Get("submariner-lighthouse-agent", metav1.GetOptions{})
-		Expect(err).To(Succeed())
-
-		for _, envVar := range agentDeployment.Spec.Template.Spec.Containers[0].Env {
-			if envVar.Name == "SUBMARINER_CLUSTERID" {
-				framework.TestContext.ClusterIDs[idx] = envVar.Value
-				break
-			}
-		}
-	}
-
 	framework.DetectGlobalnet()
 }
 

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -46,10 +46,11 @@ func NewFramework(baseName string) *Framework {
 	BeforeEach(f.BeforeEach)
 
 	AfterEach(func() {
+		namespace := f.Namespace
 		f.AfterEach()
 
-		f.AwaitEndpointSlices(framework.ClusterB, "", f.Namespace, 0, 0)
-		f.AwaitEndpointSlices(framework.ClusterA, "", f.Namespace, 0, 0)
+		f.AwaitEndpointSlices(framework.ClusterB, "", namespace, 0, 0)
+		f.AwaitEndpointSlices(framework.ClusterA, "", namespace, 0, 0)
 	})
 
 	return f


### PR DESCRIPTION
PR backports for 0.8.1

* #424 (4924193f) During cleanup use proper namespace for EPSlices verification (#424)
* #407 (a8ab4aa5) Add e2e to test DNS request to a specific cluster (#407)
* #422 (28632565) Add e2e to verify round-robin for Service discovery (#422)
* #430 (e990e6de) Fix issues in e2e (#430)
* #429 (9be744d9) E2e to verify lighthouse return cluster-ip from healthy service (#429)
* #435 (8f8fd426) Use the PR base branch as reference when linting (#435)
* #427 (fe9fbbe7) Remove fetching of cluster IDs in E2E (#427)
* #442 (6520558f) Use env var for ClusterId in lighthouse-coredns (#442)
* #443 (d6330df7)  Include port numbers in ServiceImports (#443)
* Bump E2E timeout to 45min
* Bump shipyard image to release-0.8
* Reclaim additional free space, the old way.