### PR TITLE
Add Multiple ports to ServiceImport

### DIFF
--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -427,14 +427,12 @@ func (a *Controller) getIPsAndPortsForService(service *corev1.Service, siType mc
 	[]string, []mcsv1a1.ServicePort, error) {
 	var mcsPorts []mcsv1a1.ServicePort
 
-	if len(service.Spec.Ports) > 0 {
-		mcsPorts = []mcsv1a1.ServicePort{
-			{
-				Name:     service.Spec.Ports[0].Name,
-				Protocol: service.Spec.Ports[0].Protocol,
-				Port:     service.Spec.Ports[0].Port,
-			},
-		}
+	for _, port := range service.Spec.Ports {
+		mcsPorts = append(mcsPorts, mcsv1a1.ServicePort{
+			Name:     port.Name,
+			Protocol: port.Protocol,
+			Port:     port.Port,
+		})
 	}
 
 	if siType == mcsv1a1.ClusterSetIP {

--- a/pkg/agent/controller/agent_test.go
+++ b/pkg/agent/controller/agent_test.go
@@ -182,6 +182,11 @@ var _ = Describe("ServiceImport syncing", func() {
 					Protocol: corev1.ProtocolTCP,
 					Port:     123,
 				},
+				{
+					Name:     "eth1",
+					Protocol: corev1.ProtocolTCP,
+					Port:     1234,
+				},
 			}
 		})
 


### PR DESCRIPTION
If service has multiple ports, add them all to ServiceImport,
not just first one.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>