### PR TITLE
Tag released image with branch name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - release-*
 
 jobs:
   e2e:
@@ -49,5 +50,6 @@ jobs:
         env:
           QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
           QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
-          RELEASE_ARGS: lighthouse-agent lighthouse-coredns
-        run: make release
+          IMAGES: lighthouse-agent lighthouse-coredns
+        # Pass RELEASE_ARGS on the call, since GITHUB_REF set in the `env` directive doesn't get properly expanded
+        run: make release RELEASE_ARGS="$IMAGES --tag '${GITHUB_REF##*/}'"


### PR DESCRIPTION
This will ensure that stable branches have images tagged correctly.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>
(cherry picked from commit 600f16516f00183ec9f238a4b9fb8ff81af037b0)