### PR TITLE
Bump to the latest Shipyard, fixing CI issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/gomega v1.10.5
 	github.com/pkg/errors v0.9.1
 	github.com/submariner-io/admiral v0.8.1-0.20210113165042-ee5f8e389614
-	github.com/submariner-io/shipyard v0.8.0
+	github.com/submariner-io/shipyard v0.8.1-0.20210209163001-044f4913ad9b
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2
 	k8s.io/client-go v11.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -716,6 +716,8 @@ github.com/submariner-io/admiral v0.8.1-0.20210113165042-ee5f8e389614 h1:cOaELyV
 github.com/submariner-io/admiral v0.8.1-0.20210113165042-ee5f8e389614/go.mod h1:z3cqLnFjYlmtJDZwnbw0wwaV2Xwlf1i4pdlQ4+D3L3A=
 github.com/submariner-io/shipyard v0.8.0 h1:HKvVDJ4VbEz2CFK5h7fhBCz0z421hoykp7Al7j3kE3Y=
 github.com/submariner-io/shipyard v0.8.0/go.mod h1:kPqFCYY2F9vMEzEr6YwYQ1dhwL+uXgezG0aLey5rXD0=
+github.com/submariner-io/shipyard v0.8.1-0.20210209163001-044f4913ad9b h1:AJVvoixTe7o4aR8SWsOnPuEVTfytgk6JL7v2IBmHpWw=
+github.com/submariner-io/shipyard v0.8.1-0.20210209163001-044f4913ad9b/go.mod h1:XL69zONy2SW6O9duwGX3riLC04GWtx+JwGn5ZtqLu6U=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/timewasted/linode v0.0.0-20160829202747-37e84520dcf7/go.mod h1:imsgLplxEC/etjIhdr3dNzV3JeT27LbVu5pYWm0JCBY=
 github.com/tinylib/msgp v1.1.2 h1:gWmO7n0Ys2RBEb7GPYB9Ujq8Mk5p2U08lRnmMcGy6BQ=


### PR DESCRIPTION
This should fix the Globalnet e2e errors. See
https://github.com/submariner-io/submariner-operator/issues/1086 for
details.

Signed-off-by: Stephen Kitt <skitt@redhat.com>