### PR TITLE
dependabot: ignore controller-runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,6 @@ updates:
         versions:
           - "> 0.17.0"
       - dependency-name: github.com/submariner-io/*
+      - dependency-name: sigs.k8s.io/controller-runtime
+        versions:
+          - ">= 0.7.0"


### PR DESCRIPTION
... except (hopefully) for updates in the 0.6.x series.

Signed-off-by: Stephen Kitt <skitt@redhat.com>