### PR TITLE
Fix Service Discovery failures with Globalnet jobs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/gomega v1.10.5
 	github.com/pkg/errors v0.9.1
 	github.com/submariner-io/admiral v0.8.1-0.20210113165042-ee5f8e389614
-	github.com/submariner-io/shipyard v0.8.0
+	github.com/submariner-io/shipyard v0.8.1-0.20210223164031-11c810e2a977
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2
 	k8s.io/client-go v11.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -716,6 +716,8 @@ github.com/submariner-io/admiral v0.8.1-0.20210113165042-ee5f8e389614 h1:cOaELyV
 github.com/submariner-io/admiral v0.8.1-0.20210113165042-ee5f8e389614/go.mod h1:z3cqLnFjYlmtJDZwnbw0wwaV2Xwlf1i4pdlQ4+D3L3A=
 github.com/submariner-io/shipyard v0.8.0 h1:HKvVDJ4VbEz2CFK5h7fhBCz0z421hoykp7Al7j3kE3Y=
 github.com/submariner-io/shipyard v0.8.0/go.mod h1:kPqFCYY2F9vMEzEr6YwYQ1dhwL+uXgezG0aLey5rXD0=
+github.com/submariner-io/shipyard v0.8.1-0.20210223164031-11c810e2a977 h1:yACZtQJPJLYGzm3ufmH23jxvYVPKq1vqZgKm78f+aeo=
+github.com/submariner-io/shipyard v0.8.1-0.20210223164031-11c810e2a977/go.mod h1:XL69zONy2SW6O9duwGX3riLC04GWtx+JwGn5ZtqLu6U=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/timewasted/linode v0.0.0-20160829202747-37e84520dcf7/go.mod h1:imsgLplxEC/etjIhdr3dNzV3JeT27LbVu5pYWm0JCBY=
 github.com/tinylib/msgp v1.1.2 h1:gWmO7n0Ys2RBEb7GPYB9Ujq8Mk5p2U08lRnmMcGy6BQ=

--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -117,10 +117,10 @@ func RunServiceDiscoveryTest(f *lhframework.Framework) {
 
 	nginxServiceClusterB := f.NewNginxService(framework.ClusterB)
 
-	f.AwaitGlobalnetIP(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 	f.NewServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 
 	f.AwaitServiceExportedStatusCondition(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	f.AwaitGlobalnetIP(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 
 	By(fmt.Sprintf("Creating a Netshoot Deployment on %q", clusterAName))
 
@@ -164,10 +164,10 @@ func RunServiceDiscoveryLocalTest(f *lhframework.Framework) {
 
 	nginxServiceClusterB := f.NewNginxService(framework.ClusterB)
 
-	f.AwaitGlobalnetIP(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 	f.NewServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 
 	f.AwaitServiceExportedStatusCondition(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	f.AwaitGlobalnetIP(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 
 	By(fmt.Sprintf("Creating a Netshoot Deployment on %q", clusterAName))
 
@@ -246,10 +246,10 @@ func RunServicesPodAvailabilityTest(f *lhframework.Framework) {
 
 	nginxServiceClusterB := f.NewNginxService(framework.ClusterB)
 
-	f.AwaitGlobalnetIP(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 	f.NewServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 
 	f.AwaitServiceExportedStatusCondition(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	f.AwaitGlobalnetIP(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 
 	By(fmt.Sprintf("Creating a Netshoot Deployment on %q", clusterAName))
 
@@ -290,10 +290,10 @@ func RunServicesPodAvailabilityMutliClusterTest(f *lhframework.Framework) {
 
 	nginxServiceClusterB := f.NewNginxService(framework.ClusterB)
 
-	f.AwaitGlobalnetIP(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 	f.NewServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 
 	f.AwaitServiceExportedStatusCondition(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	f.AwaitGlobalnetIP(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 
 	By(fmt.Sprintf("Creating an Nginx Deployment on %q", clusterCName))
 	f.NewNginxDeployment(framework.ClusterC)
@@ -302,8 +302,8 @@ func RunServicesPodAvailabilityMutliClusterTest(f *lhframework.Framework) {
 
 	nginxServiceClusterC := f.Framework.NewNginxService(framework.ClusterC)
 
-	f.AwaitGlobalnetIP(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace)
 	f.NewServiceExport(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace)
+	f.AwaitGlobalnetIP(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace)
 
 	By(fmt.Sprintf("Creating a Netshoot Deployment on %q", clusterAName))
 
@@ -355,8 +355,8 @@ func RunServiceDiscoveryClusterNameTest(f *lhframework.Framework) {
 
 	nginxServiceClusterA := f.Framework.NewNginxService(framework.ClusterA)
 
-	f.AwaitGlobalnetIP(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace)
 	f.NewServiceExport(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace)
+	f.AwaitGlobalnetIP(framework.ClusterA, nginxServiceClusterA.Name, nginxServiceClusterA.Namespace)
 
 	By(fmt.Sprintf("Creating an Nginx Deployment on %q", clusterBName))
 	f.NewNginxDeployment(framework.ClusterB)
@@ -365,10 +365,10 @@ func RunServiceDiscoveryClusterNameTest(f *lhframework.Framework) {
 
 	nginxServiceClusterB := f.NewNginxService(framework.ClusterB)
 
-	f.AwaitGlobalnetIP(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 	f.NewServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 
 	f.AwaitServiceExportedStatusCondition(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	f.AwaitGlobalnetIP(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 
 	By(fmt.Sprintf("Creating a Netshoot Deployment on %q", clusterAName))
 
@@ -412,10 +412,10 @@ func RunServiceDiscoveryRoundRobinTest(f *lhframework.Framework) {
 
 	nginxServiceClusterB := f.NewNginxService(framework.ClusterB)
 
-	f.AwaitGlobalnetIP(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 	f.NewServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 
 	f.AwaitServiceExportedStatusCondition(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	f.AwaitGlobalnetIP(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 
 	By(fmt.Sprintf("Creating an Nginx Deployment on %q", clusterCName))
 	f.NewNginxDeployment(framework.ClusterC)
@@ -424,8 +424,8 @@ func RunServiceDiscoveryRoundRobinTest(f *lhframework.Framework) {
 
 	nginxServiceClusterC := f.Framework.NewNginxService(framework.ClusterC)
 
-	f.AwaitGlobalnetIP(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace)
 	f.NewServiceExport(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace)
+	f.AwaitGlobalnetIP(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace)
 
 	By(fmt.Sprintf("Creating a Netshoot Deployment on %q", clusterAName))
 
@@ -474,10 +474,10 @@ func RunServicesClusterAvailabilityMutliClusterTest(f *lhframework.Framework) {
 
 	nginxServiceClusterB := f.NewNginxService(framework.ClusterB)
 
-	f.AwaitGlobalnetIP(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 	f.NewServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 
 	f.AwaitServiceExportedStatusCondition(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	f.AwaitGlobalnetIP(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
 
 	By(fmt.Sprintf("Creating a Netshoot Deployment on %q", clusterCName))
 
@@ -497,10 +497,10 @@ func RunServicesClusterAvailabilityMutliClusterTest(f *lhframework.Framework) {
 
 	nginxServiceClusterC := f.NewNginxService(framework.ClusterC)
 
-	f.AwaitGlobalnetIP(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace)
 	f.NewServiceExport(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace)
 
 	f.AwaitServiceExportedStatusCondition(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace)
+	f.AwaitGlobalnetIP(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace)
 
 	svc, err = f.GetService(framework.ClusterC, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Recently Globalnet was updated to annotate only exported services and
Shipyard e2e framework was modified to export a service once its created.
This PR modifies the reference to shipyard to pull the latest codebase.

Fixes issue: https://github.com/submariner-io/lighthouse/issues/471
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>