### PR TITLE
Test K8s versions 1.18, 1.19, and 1.20 in E2E

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,8 +12,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        globalnet: ['', 'globalnet']
         deploytool: ['operator', 'helm']
+        globalnet: ['', 'globalnet']
+        k8s_version: ['1.17.17']
+        include:
+          # Recentness of K8s versions are limited by kindest/node image releases
+          - k8s_version: 1.18.15
+          - k8s_version: 1.19.7
+          - k8s_version: 1.20.2
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2
@@ -21,6 +27,7 @@ jobs:
       - name: Run E2E deployment and tests
         uses: submariner-io/shipyard/gh-actions/e2e@devel
         with:
+          k8s_version: ${{ matrix.k8s_version }}
           using: ${{ matrix.deploytool }} ${{ matrix.globalnet }}
 
       - name: Post mortem


### PR DESCRIPTION
Use the new ability of the shared E2E GHA to configure the Kubernetes
version. Add jobs that cover the latest available patch versions
(limited by kind images) from the three most recent minor versions.

Only run one E2E job with all-default configuration per K8s version, for
some coverage with minimal overhead.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>