### PR TITLE
Test K8s 1.17-1.20 in flake finder

### DIFF
--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -15,6 +15,12 @@ jobs:
       matrix:
         globalnet: ['', 'globalnet']
         deploytool: ['operator', 'helm']
+        k8s_version: ['1.17.17']
+        include:
+          # Recentness of K8s versions are limited by kindest/node image releases
+          - k8s_version: 1.18.15
+          - k8s_version: 1.19.7
+          - k8s_version: 1.20.2
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Add Kubernetes versions to the flake finder E2E test matrix.

Test all versions from the current default (1.17) to the latest
available (1.20), with default E2E settings otherwise.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>