### PR TITLE
golangci-lint: switch to fieldalignment

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,10 +8,11 @@ linters-settings:
       - style
   gocyclo:
     min-complexity: 15
+  govet:
+    enable:
+      - fieldalignment
   lll:
     line-length: 140
-  maligned:
-    suggest-new: true
 linters:
   disable-all: true
   enable:
@@ -37,7 +38,6 @@ linters:
     - ineffassign
     - interfacer
     - lll
-    - maligned
     - misspell
     - nakedret
     - prealloc
@@ -70,3 +70,9 @@ issues:
         - stylecheck
       path: test/*
       text: "ST1001: should not use dot imports"
+
+    # Ignore pointer bytes in struct alignment tests (this is a very
+    # minor optimisation)
+    - linters:
+        - govet
+      text: "pointer bytes could be"


### PR DESCRIPTION
fieldalignment replaces maligned. Errors related to pointer ordering
(for GC) are ignored; see https://github.com/golang/go/issues/44877
for details.

Signed-off-by: Stephen Kitt <skitt@redhat.com>