### PR TITLE
Change default debug level for agent

### DIFF
--- a/pkg/agent/main.go
+++ b/pkg/agent/main.go
@@ -53,7 +53,7 @@ func main() {
 	} else if verbosity := os.Getenv("SUBMARINER_VERBOSITY"); verbosity != "" {
 		os.Args = append(os.Args, fmt.Sprintf("-v=%s", verbosity))
 	} else {
-		os.Args = append(os.Args, "-v=1")
+		os.Args = append(os.Args, "-v=2")
 	}
 
 	klog.InitFlags(nil)


### PR DESCRIPTION
Change `lighthouse-agent` default debug level from `1` to `2`,
similar to other submariner services. This will help with
troubleshooting.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>