### PR TITLE
Run full E2E matrix only when PR approved

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -1,0 +1,37 @@
+---
+name: End to End Full
+
+on:
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
+
+jobs:
+  e2e:
+    name: E2E
+    if: contains(github.event.pull_request.labels.*.name, 'ready-to-test')
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        deploytool: ['operator', 'helm']
+        globalnet: ['', 'globalnet']
+        k8s_version: ['1.17.17']
+        include:
+          # Recentness of K8s versions are limited by kindest/node image releases
+          - k8s_version: 1.18.15
+          - k8s_version: 1.19.7
+          - k8s_version: 1.20.2
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Run E2E deployment and tests
+        uses: submariner-io/shipyard/gh-actions/e2e@devel
+        with:
+          k8s_version: ${{ matrix.k8s_version }}
+          using: ${{ matrix.deploytool }} ${{ matrix.globalnet }}
+
+      - name: Post mortem
+        if: failure()
+        uses: submariner-io/shipyard/gh-actions/post-mortem@devel

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,5 @@
 ---
-name: End to End Tests
+name: End to End Default
 
 on:
   pull_request:
@@ -9,26 +9,12 @@ jobs:
     name: E2E
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        deploytool: ['operator', 'helm']
-        globalnet: ['', 'globalnet']
-        k8s_version: ['1.17.17']
-        include:
-          # Recentness of K8s versions are limited by kindest/node image releases
-          - k8s_version: 1.18.15
-          - k8s_version: 1.19.7
-          - k8s_version: 1.20.2
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2
 
       - name: Run E2E deployment and tests
         uses: submariner-io/shipyard/gh-actions/e2e@devel
-        with:
-          k8s_version: ${{ matrix.k8s_version }}
-          using: ${{ matrix.deploytool }} ${{ matrix.globalnet }}
 
       - name: Post mortem
         if: failure()

--- a/.github/workflows/label-ready-approved.yml
+++ b/.github/workflows/label-ready-approved.yml
@@ -1,0 +1,13 @@
+on: pull_request_review
+name: Label Ready to Test
+jobs:
+  label:
+    name: When Approved
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label when approved
+        uses: abinoda/label-when-approved-action@v1.0.7
+        env:
+          APPROVALS: "2"
+          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
+          ADD_LABEL: "ready-to-test"


### PR DESCRIPTION
There's no need to run the full E2E test matrix before a PR is approved
for testing, so adding a default test for most of the time and changing
the matrix job to run only when the `ready-to-test` label is present.

The label will be applied once 2 approvals are given on the PR, but can
also be added (or removed) manually as needed.

Resolves: #512 

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>