### PR TITLE
Add reload-images makefile target

### DIFF
--- a/scripts/reload-images
+++ b/scripts/reload-images
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+## Process command line flags ##
+
+source ${SCRIPTS_DIR}/lib/shflags
+DEFINE_string 'restart' 'all' "Which lighthouse pods to restart: none, all, agent, coredns"
+FLAGS "$@" || exit $?
+eval set -- "${FLAGS_ARGV}"
+
+restart="${FLAGS_restart}"
+
+echo "Running with: restart=${restart}"
+
+set -em
+
+source ${SCRIPTS_DIR}/lib/debug_functions
+source ${SCRIPTS_DIR}/lib/deploy_funcs
+source ${SCRIPTS_DIR}/lib/utils
+source ${SCRIPTS_DIR}/lib/cluster_settings
+source ${DAPPER_SOURCE}/scripts/cluster_settings
+
+import_image quay.io/submariner/lighthouse-agent
+import_image quay.io/submariner/lighthouse-coredns
+
+declare_kubeconfig
+
+case "${restart}" in
+	agent|coredns)
+		run_subm_clusters reload_pods deployment submariner-lighthouse-${restart}
+		;;
+	all)
+		run_subm_clusters reload_pods deployment submariner-lighthouse-agent
+		run_subm_clusters reload_pods deployment submariner-lighthouse-coredns
+		;;
+	none)
+		;;
+	*)
+		echo "restart must be one of: none, agent, coredns or all (default)"
+		exit 1
+		;;
+esac


### PR DESCRIPTION
`reload-images` target will push images to localhost registry
on the clusters and then restart target pods. So the developer can set
imagePullPolicy to always on desired resource and force it to reload.
This allows for a quicker and easier dev cycle.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
