### PR TITLE
Add GlobalIngressIP syncer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/onsi/gomega v1.13.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
-	github.com/submariner-io/admiral v0.10.0-m1
+	github.com/submariner-io/admiral v0.10.0-m1.0.20210602113843-3b8dfd67945b
 	github.com/submariner-io/shipyard v0.10.0-m1
 	go.uber.org/zap v1.15.0 // indirect
 	k8s.io/api v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -701,8 +701,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/submariner-io/admiral v0.10.0-m1 h1:uHEnUPFUcf8hCWSrjiGJNgSwPkSM/u++iOiSo+ck4Ss=
-github.com/submariner-io/admiral v0.10.0-m1/go.mod h1:2kkQieEpnEAMHDw4e1wSKUQ5Z3ArycrfD3B6gXaSTDo=
+github.com/submariner-io/admiral v0.10.0-m1.0.20210602113843-3b8dfd67945b h1:OM2iJnKPtaJjLChHcmOpM9j3tFasSVEWDKGVVYfqvn8=
+github.com/submariner-io/admiral v0.10.0-m1.0.20210602113843-3b8dfd67945b/go.mod h1:oE3hQZJMvB8j9wHyLBZYmupCZK/G83z36QMgTn2vUlE=
 github.com/submariner-io/shipyard v0.10.0-m1 h1:ZpjnIaGkg0F++pFKbAgtbyfKDukimlOKiXhurrjB50w=
 github.com/submariner-io/shipyard v0.10.0-m1/go.mod h1:xzQRVCfdpFNqyRvjsj9c7/uhm1JZS0/Zce/0bt++tOg=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/pkg/agent/controller/globalingressip.go
+++ b/pkg/agent/controller/globalingressip.go
@@ -1,0 +1,92 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controller
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/klog"
+)
+
+const (
+	ClusterIPService           = "ClusterIPService"
+	headlessServicePod         = "HeadlessServicePod"
+	defaultReasonIPUnavailable = "ServiceGlobalIPUnavailable"
+	defaultMsgIPUnavailable    = "Service doesn't have a global IP yet"
+)
+
+type IngressIP struct {
+	namespace         string
+	target            string
+	svcName           string
+	podName           string
+	allocatedIP       string
+	unallocatedReason string
+	unallocatedMsg    string
+}
+
+func parseIngressIP(obj *unstructured.Unstructured) *IngressIP {
+	var (
+		found bool
+		err   error
+	)
+
+	gip := &IngressIP{}
+	gip.namespace = obj.GetNamespace()
+	gip.target, found, err = unstructured.NestedString(obj.Object, "spec", "target")
+	if !found || err != nil {
+		klog.Errorf("target field not found in spec %#v", obj.Object)
+		return nil
+	}
+
+	gip.svcName, found, err = unstructured.NestedString(obj.Object, "spec", "serviceRef", "name")
+	if !found || err != nil {
+		klog.Errorf("ServiceRef not found in spec %#v", obj.Object)
+		return nil
+	}
+
+	if gip.target == headlessServicePod {
+		gip.podName, found, err = unstructured.NestedString(obj.Object, "spec", "podRef", "name")
+		if !found || err != nil {
+			klog.Errorf("Expected PodRef in spec %#v", obj.Object)
+			return nil
+		}
+	}
+
+	gip.allocatedIP, _, _ = unstructured.NestedString(obj.Object, "status", "allocatedIP")
+	conditions, _, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if gip.allocatedIP == "" {
+		if len(conditions) > 0 {
+			latestCondition := conditions[len(conditions)-1].(map[string]interface{})
+			gip.unallocatedMsg = latestCondition["message"].(string)
+			gip.unallocatedReason = latestCondition["reason"].(string)
+		} else {
+			gip.unallocatedMsg = defaultMsgIPUnavailable
+			gip.unallocatedReason = defaultReasonIPUnavailable
+		}
+	}
+
+	return gip
+}
+
+func GetGlobalIngressIPObj() *unstructured.Unstructured {
+	gip := &unstructured.Unstructured{}
+	gip.SetKind("GlobalIngressIP")
+	gip.SetAPIVersion("submariner.io/v1")
+
+	return gip
+}

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -41,6 +41,7 @@ type Controller struct {
 	endpointSliceSyncer     *broker.Syncer
 	serviceSyncer           syncer.Interface
 	serviceImportController *ServiceImportController
+	ingressIPClient         dynamic.NamespaceableResourceInterface
 }
 
 type AgentSpecification struct {


### PR DESCRIPTION
Initial changes to support Globalnetv2

* Adds a GlobalIngressIP syncer

Fixes #551

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
