### PR TITLE
Enable Globalnet v2 and e2e

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/submariner-io/admiral v0.10.0-m2
-	github.com/submariner-io/shipyard v0.10.0-m2
+	github.com/submariner-io/shipyard v0.10.0-m2.0.20210615173434-f15404d75718
 	go.uber.org/zap v1.15.0 // indirect
 	k8s.io/api v0.21.0
 	k8s.io/apimachinery v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -698,9 +698,9 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/submariner-io/admiral v0.10.0-m2 h1:udiPxHOZSxhi0xnLcFqUfb5vmqIKSyTX+PQPVU0nOB8=
-github.com/submariner-io/admiral v0.10.0-m2/go.mod h1:UP2oUxGyHdcixfPXI/1JMaASI38ILSyytb1b+pn/ru8=
-github.com/submariner-io/shipyard v0.10.0-m2 h1:ZE1x6FW2I21O+koM/FTuj8RuZtB4kzevasuZJSlEEj4=
-github.com/submariner-io/shipyard v0.10.0-m2/go.mod h1:V1PwrxWoEphrHjMjtYjWKYmI9DHDNH8gV3LscuraYJw=
+github.com/submariner-io/admiral v0.10.0-m2/go.mod h1:UP2oUxGyHdcixfPXI/1JMaASI38ILSyytb1b+pn/ru8=github.com/submariner-io/shipyard v0.10.0-m1/go.mod h1:xzQRVCfdpFNqyRvjsj9c7/uhm1JZS0/Zce/0bt++tOg=
+github.com/submariner-io/shipyard v0.10.0-m2.0.20210615173434-f15404d75718 h1:aJEWCnTiw22tf8KQI8kjkUv4aq91aVkhppAmsMRQ0dE=
+github.com/submariner-io/shipyard v0.10.0-m2.0.20210615173434-f15404d75718/go.mod h1:V1PwrxWoEphrHjMjtYjWKYmI9DHDNH8gV3LscuraYJw=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/timewasted/linode v0.0.0-20160829202747-37e84520dcf7/go.mod h1:imsgLplxEC/etjIhdr3dNzV3JeT27LbVu5pYWm0JCBY=
 github.com/tinylib/msgp v1.1.2 h1:gWmO7n0Ys2RBEb7GPYB9Ujq8Mk5p2U08lRnmMcGy6BQ=

--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -45,10 +45,9 @@ import (
 )
 
 const (
-	submarinerIPAMGlobalIP = "submariner.io/globalIp"
-	serviceUnavailable     = "ServiceUnavailable"
-	invalidServiceType     = "UnsupportedServiceType"
-	clusterIP              = "cluster-ip"
+	serviceUnavailable = "ServiceUnavailable"
+	invalidServiceType = "UnsupportedServiceType"
+	clusterIP          = "cluster-ip"
 )
 
 type AgentConfig struct {
@@ -550,18 +549,6 @@ func getIPsFromEndpoint(endpoint *corev1.Endpoints) []string {
 	return ipList
 }
 
-// TODO: Remove this for v2
-func (a *Controller) getGlobalIPFromService(service *corev1.Service) string {
-	if service != nil {
-		annotations := service.GetAnnotations()
-		if annotations != nil {
-			return annotations[submarinerIPAMGlobalIP]
-		}
-	}
-
-	return ""
-}
-
 func (a *Controller) remoteEndpointSliceToLocal(obj runtime.Object, numRequeues int, op syncer.Operation) (runtime.Object, bool) {
 	endpointSlice := obj.(*discovery.EndpointSlice)
 	endpointSlice.Namespace = endpointSlice.GetObjectMeta().GetLabels()[lhconstants.LabelSourceNamespace]
@@ -582,11 +569,6 @@ func (a *Controller) filterLocalEndpointSlices(obj runtime.Object, numRequeues i
 
 func (a *Controller) getGlobalIP(service *corev1.Service) (ip, reason, msg string) {
 	if a.globalnetEnabled {
-		ip = a.getGlobalIPFromService(service)
-		if ip != "" {
-			return ip, "", ""
-		}
-
 		ingressIP, found, err := a.getIngressIP(service.Name, service.Namespace)
 		if err != nil {
 			return "", "GlobalIngressIPRetrievalFailed", err.Error()

--- a/pkg/agent/controller/globalnet_test.go
+++ b/pkg/agent/controller/globalnet_test.go
@@ -55,17 +55,6 @@ var _ = Describe("Globalnet enabled", func() {
 					t.awaitServiceExported(globalIP, 0)
 				})
 			})
-
-			// TODO: Remove once we switch to globalnet V2
-			Context("via an annotation", func() {
-				BeforeEach(func() {
-					t.service.SetAnnotations(map[string]string{"submariner.io/globalIp": globalIP})
-				})
-
-				It("should sync a ServiceImport with the global IP", func() {
-					t.awaitServiceExported(globalIP, 0)
-				})
-			})
 		})
 
 		Context("and it does not initially have a global IP", func() {


### PR DESCRIPTION
* Remove code that uses old annotations
* Modify e2e to use GlobalIngressIPs instead of annotations

Fixes #559 

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
