### PR TITLE
Format expected values with fmt.Sprintf

### DIFF
--- a/plugin/lighthouse/handler_test.go
+++ b/plugin/lighthouse/handler_test.go
@@ -19,7 +19,7 @@ package lighthouse
 
 import (
 	"context"
-	"strconv"
+	"fmt"
 
 	v1 "k8s.io/api/core/v1"
 
@@ -50,9 +50,9 @@ const (
 	endpointIP2 = "100.96.157.102"
 	portName1   = "http"
 	portName2   = "dns"
-	protcol1    = v1.ProtocolTCP
+	protocol1   = v1.ProtocolTCP
 	portNumber1 = int32(8080)
-	protcol2    = v1.ProtocolUDP
+	protocol2   = v1.ProtocolUDP
 	portNumber2 = int32(53)
 	hostName1   = "hostName1"
 	hostName2   = "hostName2"
@@ -147,37 +147,38 @@ func testWithoutFallback() {
 	})
 
 	When("DNS query for an existing service", func() {
+		qname := fmt.Sprintf("%s.%s.svc.clusterset.local.", service1, namespace1)
 		It("of Type A record should succeed and write an A record response", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.A(service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    A    " + serviceIP),
+					test.A(fmt.Sprintf("%s    5    IN    A    %s", qname, serviceIP)),
 				},
 			})
 		})
 		It("of Type SRV should succeed and write an SRV record response", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.SRV(service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    SRV 0 50 " +
-						strconv.Itoa(int(portNumber1)) + " " + service1 + "." + namespace1 + ".svc.clusterset.local."),
+					test.SRV(fmt.Sprintf("%s    5    IN    SRV 0 50 %d %s", qname, portNumber1, qname)),
 				},
 			})
 		})
 	})
 
 	When("DNS query for an existing service in specific cluster", func() {
+		qname := fmt.Sprintf("%s.%s.%s.svc.clusterset.local.", clusterID, service1, namespace1)
 		It("of Type A record should succeed and write an A record response", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: clusterID + "." + service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Rcode: dns.RcodeSuccess,
 				Qtype: dns.TypeA,
 				Answer: []dns.RR{
-					test.A(clusterID + "." + service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    A    " + serviceIP),
+					test.A(fmt.Sprintf("%s    5    IN    A    %s", qname, serviceIP)),
 				},
 			})
 		})
@@ -185,55 +186,55 @@ func testWithoutFallback() {
 		It("of Type SRV should succeed and write an SRV record response", func() {
 			executeTestCase(lh, rec, test.Case{
 				Qtype: dns.TypeSRV,
-				Qname: clusterID + "." + service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.SRV(clusterID + "." + service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    SRV 0 50 " +
-						strconv.Itoa(int(portNumber1)) + " " + clusterID + "." + service1 + "." + namespace1 + ".svc.clusterset.local."),
+					test.SRV(fmt.Sprintf("%s    5    IN    SRV 0 50 %d %s", qname, portNumber1, qname)),
 				},
 			})
 		})
 	})
 
 	When("DNS query for an existing service with a different namespace", func() {
+		qname := fmt.Sprintf("%s.%s.svc.clusterset.local.", service1, namespace2)
 		It("of Type A record should succeed and write an A record response", func() {
 			lh.serviceImports.Put(newServiceImport(namespace2, service1, clusterID, serviceIP, portName1,
-				portNumber1, protcol1, mcsv1a1.ClusterSetIP))
+				portNumber1, protocol1, mcsv1a1.ClusterSetIP))
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace2 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.A(service1 + "." + namespace2 + ".svc.clusterset.local.    5    IN    A    " + serviceIP),
+					test.A(fmt.Sprintf("%s    5    IN    A    %s", qname, serviceIP)),
 				},
 			})
 		})
 		It("of Type SRV should succeed and write an SRV record response", func() {
 			lh.serviceImports.Put(newServiceImport(namespace2, service1, clusterID, serviceIP, portName1, portNumber1,
-				protcol1, mcsv1a1.ClusterSetIP))
+				protocol1, mcsv1a1.ClusterSetIP))
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace2 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.SRV(service1 + "." + namespace2 + ".svc.clusterset.local.    5    IN    SRV 0 50 " +
-						strconv.Itoa(int(portNumber1)) + " " + service1 + "." + namespace2 + ".svc.clusterset.local."),
+					test.SRV(fmt.Sprintf("%s    5    IN    SRV 0 50 %d %s", qname, portNumber1, qname)),
 				},
 			})
 		})
 	})
 
 	When("DNS query for a non-existent service", func() {
+		qname := fmt.Sprintf("unknown.%s.svc.clusterset.local.", namespace1)
 		It("of Type A record should return RcodeNameError for A record query", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: "unknown." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeNameError,
 			})
 		})
 		It("of Type SRV should return RcodeNameError for SRV record query", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: "unknown." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeNameError,
 			})
@@ -241,16 +242,17 @@ func testWithoutFallback() {
 	})
 
 	When("DNS query for a non-existent service with a different namespace", func() {
+		qname := fmt.Sprintf("%s.%s.svc.clusterset.local.", service1, namespace2)
 		It("of Type A record should return RcodeNameError for A record query ", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace2 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeNameError,
 			})
 		})
 		It("of Type SRV should return RcodeNameError for SRV record query ", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace2 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeNameError,
 			})
@@ -258,16 +260,17 @@ func testWithoutFallback() {
 	})
 
 	When("DNS query for a pod", func() {
+		qname := fmt.Sprintf("%s.%s.pod.clusterset.local.", service1, namespace1)
 		It("of Type A record should return RcodeNameError for A record query", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".pod.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeNameError,
 			})
 		})
 		It("of Type SRV should return RcodeNameError for SRV record query", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".pod.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeNameError,
 			})
@@ -275,16 +278,17 @@ func testWithoutFallback() {
 	})
 
 	When("DNS query for a non-existent zone", func() {
+		qname := fmt.Sprintf("%s.%s.svc.cluster.east.", service1, namespace2)
 		It("of Type A record should return RcodeNameError for A record query", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace2 + ".svc.cluster.east.",
+				Qname: qname,
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeNotZone,
 			})
 		})
 		It("of Type SRV should return RcodeNameError for SRV record query", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace2 + ".svc.cluster.east.",
+				Qname: qname,
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeNotZone,
 			})
@@ -292,9 +296,10 @@ func testWithoutFallback() {
 	})
 
 	When("type AAAA DNS query", func() {
+		qname := fmt.Sprintf("%s.%s.svc.clusterset.local.", service1, namespace1)
 		It("should return empty record", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname:  service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname:  qname,
 				Qtype:  dns.TypeAAAA,
 				Rcode:  dns.RcodeSuccess,
 				Answer: []dns.RR{},
@@ -307,9 +312,10 @@ func testWithoutFallback() {
 			rec = dnstest.NewRecorder(&FailingResponseWriter{errorMsg: "write failed"})
 		})
 
+		qname := fmt.Sprintf("%s.%s.svc.clusterset.local.", service1, namespace1)
 		It("should return error RcodeServerFailure", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeServerFailure,
 			})
@@ -347,10 +353,11 @@ func testWithFallback() {
 	})
 
 	When("type A DNS query for a non-matching lighthouse zone and matching fallthrough zone", func() {
+		qname := fmt.Sprintf("%s.%s.svc.cluster.east.", service1, namespace1)
 		It("should invoke the next plugin", func() {
 			lh.Fall = fall.F{Zones: []string{"clusterset.local.", "cluster.east."}}
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".svc.cluster.east.",
+				Qname: qname,
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeBadCookie,
 			})
@@ -358,9 +365,10 @@ func testWithFallback() {
 	})
 
 	When("type A DNS query for a non-matching lighthouse zone and non-matching fallthrough zone", func() {
+		qname := fmt.Sprintf("%s.%s.svc.cluster.east.", service1, namespace1)
 		It("should not invoke the next plugin", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".svc.cluster.east.",
+				Qname: qname,
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeNotZone,
 			})
@@ -368,9 +376,10 @@ func testWithFallback() {
 	})
 
 	When("type AAAA DNS query", func() {
+		qname := fmt.Sprintf("%s.%s.svc.clusterset.local.", service1, namespace1)
 		It("should return empty record", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname:  service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname:  qname,
 				Qtype:  dns.TypeAAAA,
 				Rcode:  dns.RcodeSuccess,
 				Answer: []dns.RR{},
@@ -379,9 +388,10 @@ func testWithFallback() {
 	})
 
 	When("type A DNS query for a pod", func() {
+		qname := fmt.Sprintf("%s.%s.pod.clusterset.local.", service1, namespace1)
 		It("should invoke the next plugin", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".pod.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeBadCookie,
 			})
@@ -391,7 +401,7 @@ func testWithFallback() {
 	When("type A DNS query for a non-existent service", func() {
 		It("should invoke the next plugin", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: "unknown." + namespace1 + ".svc.clusterset.local.",
+				Qname: fmt.Sprintf("unknown.%s.svc.clusterset.local.", namespace1),
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeBadCookie,
 			})
@@ -402,7 +412,7 @@ func testWithFallback() {
 		It("should invoke the next plugin", func() {
 			lh.Fall = fall.F{Zones: []string{"clusterset.local.", "cluster.east."}}
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".svc.cluster.east.",
+				Qname: fmt.Sprintf("%s.%s.svc.cluster.east.", service1, namespace1),
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeBadCookie,
 			})
@@ -412,7 +422,7 @@ func testWithFallback() {
 	When("type SRV DNS query for a non-matching lighthouse zone and non-matching fallthrough zone", func() {
 		It("should not invoke the next plugin", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".svc.cluster.east.",
+				Qname: fmt.Sprintf("%s.%s.svc.cluster.east.", service1, namespace1),
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeNotZone,
 			})
@@ -422,7 +432,7 @@ func testWithFallback() {
 	When("type SRV DNS query for a pod", func() {
 		It("should invoke the next plugin", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".pod.clusterset.local.",
+				Qname: fmt.Sprintf("%s.%s.pod.clusterset.local.", service1, namespace1),
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeBadCookie,
 			})
@@ -432,7 +442,7 @@ func testWithFallback() {
 	When("type SRV DNS query for a non-existent service", func() {
 		It("should invoke the next plugin", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: "unknown." + namespace1 + ".svc.clusterset.local.",
+				Qname: fmt.Sprintf("unknown.%s.svc.clusterset.local.", namespace1),
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeBadCookie,
 			})
@@ -465,31 +475,31 @@ func testClusterStatus() {
 			ttl:             defaultTTL,
 		}
 		lh.serviceImports.Put(newServiceImport(namespace1, service1, clusterID2, serviceIP2, portName2,
-			portNumber2, protcol2, mcsv1a1.ClusterSetIP))
+			portNumber2, protocol2, mcsv1a1.ClusterSetIP))
 
 		rec = dnstest.NewRecorder(&test.ResponseWriter{})
 	})
 
 	When("service is in two clusters and specific cluster is requested", func() {
+		qname := fmt.Sprintf("%s.%s.%s.svc.clusterset.local.", clusterID2, service1, namespace1)
 		It("should succeed and write that cluster's IP as A record response", func() {
 			executeTestCase(lh, rec, test.Case{
 				Qtype: dns.TypeA,
-				Qname: clusterID2 + "." + service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.A(clusterID2 + "." + service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    A    " + serviceIP2),
+					test.A(fmt.Sprintf("%s    5    IN    A    %s", qname, serviceIP2)),
 				},
 			})
 		})
 
 		It("should succeed and write that cluster's IP as SRV record response", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: clusterID2 + "." + service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.SRV(clusterID2 + "." + service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    SRV 0 50 " +
-						strconv.Itoa(int(portNumber2)) + " " + clusterID2 + "." + service1 + "." + namespace1 + ".svc.clusterset.local."),
+					test.SRV(fmt.Sprintf("%s    5    IN    SRV 0 50 %d %s", qname, portNumber2, qname)),
 				},
 			})
 		})
@@ -499,26 +509,26 @@ func testClusterStatus() {
 		JustBeforeEach(func() {
 			lh.serviceImports = setupServiceImportMap()
 			lh.serviceImports.Put(newServiceImport(namespace1, service1, clusterID2, serviceIP2, portName2,
-				portNumber2, protcol2, ""))
+				portNumber2, protocol2, ""))
 		})
+		qname := fmt.Sprintf("%s.%s.svc.clusterset.local.", service1, namespace1)
 		It("should succeed and write an A record response with the available IP", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.A(service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    A    " + serviceIP),
+					test.A(fmt.Sprintf("%s    5    IN    A    %s", qname, serviceIP)),
 				},
 			})
 		})
 		It("should succeed and write that cluster's IP as SRV record response", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.SRV(service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    SRV 0 50 " +
-						strconv.Itoa(int(portNumber1)) + " " + service1 + "." + namespace1 + ".svc.clusterset.local."),
+					test.SRV(fmt.Sprintf("%s    5    IN    SRV 0 50 %d %s", qname, portNumber1, qname)),
 				},
 			})
 		})
@@ -528,24 +538,24 @@ func testClusterStatus() {
 		JustBeforeEach(func() {
 			mockCs.clusterStatusMap[clusterID] = false
 		})
+		qname := fmt.Sprintf("%s.%s.svc.clusterset.local.", service1, namespace1)
 		It("should succeed and write an A record response", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.A(service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    A    " + serviceIP2),
+					test.A(fmt.Sprintf("%s    5    IN    A    %s", qname, serviceIP2)),
 				},
 			})
 		})
 		It("should succeed and write an SRV record response", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.SRV(service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    SRV 0 50 " +
-						strconv.Itoa(int(portNumber2)) + " " + service1 + "." + namespace1 + ".svc.clusterset.local."),
+					test.SRV(fmt.Sprintf("%s    5    IN    SRV 0 50 %d %s", qname, portNumber2, qname)),
 				},
 			})
 		})
@@ -556,9 +566,10 @@ func testClusterStatus() {
 			mockCs.clusterStatusMap[clusterID] = false
 			mockCs.clusterStatusMap[clusterID2] = false
 		})
+		qname := fmt.Sprintf("%s.%s.svc.clusterset.local.", service1, namespace1)
 		It("should return empty response (NODATA) for A record query", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname:  service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname:  qname,
 				Qtype:  dns.TypeA,
 				Rcode:  dns.RcodeSuccess,
 				Answer: []dns.RR{},
@@ -566,7 +577,7 @@ func testClusterStatus() {
 		})
 		It("should return empty response (NODATA) for SRV record query", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname:  service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname:  qname,
 				Qtype:  dns.TypeSRV,
 				Rcode:  dns.RcodeSuccess,
 				Answer: []dns.RR{},
@@ -580,9 +591,10 @@ func testClusterStatus() {
 			delete(mockCs.clusterStatusMap, clusterID2)
 			lh.serviceImports = setupServiceImportMap()
 		})
+		qname := fmt.Sprintf("%s.%s.svc.clusterset.local.", service1, namespace1)
 		It("should return empty response (NODATA) for A record query", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname:  service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname:  qname,
 				Qtype:  dns.TypeA,
 				Rcode:  dns.RcodeSuccess,
 				Answer: []dns.RR{},
@@ -590,7 +602,7 @@ func testClusterStatus() {
 		})
 		It("should return empty response (NODATA) for SRV record query", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname:  service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname:  qname,
 				Qtype:  dns.TypeSRV,
 				Rcode:  dns.RcodeSuccess,
 				Answer: []dns.RR{},
@@ -631,12 +643,13 @@ func testHeadlessService() {
 	When("headless service has no IPs", func() {
 		JustBeforeEach(func() {
 			lh.serviceImports.Put(newServiceImport(namespace1, service1, clusterID, "", portName1,
-				portNumber1, protcol1, mcsv1a1.Headless))
-			lh.endpointSlices.Put(newEndpointSlice(namespace1, service1, clusterID, portName1, []string{}, []string{}, portNumber1, protcol1))
+				portNumber1, protocol1, mcsv1a1.Headless))
+			lh.endpointSlices.Put(newEndpointSlice(namespace1, service1, clusterID, portName1, []string{}, []string{}, portNumber1, protocol1))
 		})
+		qname := fmt.Sprintf("%s.%s.svc.clusterset.local.", service1, namespace1)
 		It("should succeed and return empty response (NODATA)", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname:  service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname:  qname,
 				Qtype:  dns.TypeA,
 				Rcode:  dns.RcodeSuccess,
 				Answer: []dns.RR{},
@@ -644,7 +657,7 @@ func testHeadlessService() {
 		})
 		It("should succeed and return empty response (NODATA)", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname:  service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname:  qname,
 				Qtype:  dns.TypeSRV,
 				Rcode:  dns.RcodeSuccess,
 				Answer: []dns.RR{},
@@ -654,41 +667,39 @@ func testHeadlessService() {
 	When("headless service has one IP", func() {
 		JustBeforeEach(func() {
 			lh.serviceImports.Put(newServiceImport(namespace1, service1, clusterID, "", portName1,
-				portNumber1, protcol1, mcsv1a1.Headless))
+				portNumber1, protocol1, mcsv1a1.Headless))
 			lh.endpointSlices.Put(newEndpointSlice(namespace1, service1, clusterID, portName1, []string{hostName1}, []string{endpointIP},
-				portNumber1, protcol1))
+				portNumber1, protocol1))
 		})
+		qname := fmt.Sprintf("%s.%s.svc.clusterset.local.", service1, namespace1)
 		It("should succeed and write an A record response", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.A(service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    A    " + endpointIP),
+					test.A(fmt.Sprintf("%s    5    IN    A    %s", qname, endpointIP)),
 				},
 			})
 		})
 		It("should succeed and write an SRV record response", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.SRV(service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    SRV  0 50 " +
-						strconv.Itoa(int(portNumber1)) + " " + hostName1 + "." + clusterID + "." + service1 + "." +
-						namespace1 + ".svc.clusterset.local."),
+					test.SRV(fmt.Sprintf("%s    5    IN    SRV 0 50 %d %s.%s.%s", qname, portNumber1, hostName1, clusterID, qname)),
 				},
 			})
 		})
 		It("should succeed and write an SRV record response for query with cluster name", func() {
+			qname = fmt.Sprintf("%s.%s.%s.svc.clusterset.local.", clusterID, service1, namespace1)
 			executeTestCase(lh, rec, test.Case{
-				Qname: clusterID + "." + service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.SRV(clusterID + "." + service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    SRV  0 50 " +
-						strconv.Itoa(int(portNumber1)) + " " + hostName1 + "." + clusterID + "." + service1 + "." + namespace1 +
-						".svc.clusterset.local."),
+					test.SRV(fmt.Sprintf("%s    5    IN    SRV  0 50 %d %s.%s", qname, portNumber1, hostName1, qname)),
 				},
 			})
 		})
@@ -696,63 +707,60 @@ func testHeadlessService() {
 
 	When("headless service has two IPs", func() {
 		JustBeforeEach(func() {
-			lh.serviceImports.Put(newServiceImport(namespace1, service1, clusterID, "", portName1, portNumber1, protcol1,
+			lh.serviceImports.Put(newServiceImport(namespace1, service1, clusterID, "", portName1, portNumber1, protocol1,
 				mcsv1a1.Headless))
 			lh.endpointSlices.Put(newEndpointSlice(namespace1, service1, clusterID, portName1, []string{hostName1, hostName2},
 				[]string{endpointIP, endpointIP2},
-				portNumber1, protcol1))
+				portNumber1, protocol1))
 		})
+		qname := fmt.Sprintf("%s.%s.svc.clusterset.local.", service1, namespace1)
 		It("should succeed and write two A records as response", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.A(service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    A    " + endpointIP),
-					test.A(service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    A    " + endpointIP2),
+					test.A(fmt.Sprintf("%s    5    IN    A    %s", qname, endpointIP)),
+					test.A(fmt.Sprintf("%s    5    IN    A    %s", qname, endpointIP2)),
 				},
 			})
 		})
 		It("should succeed and write an SRV record response", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.SRV(service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    SRV  0 50 " +
-						strconv.Itoa(int(portNumber1)) + " " + hostName1 + "." + clusterID + "." + service1 + "." + namespace1 + ".svc.clusterset.local."),
-					test.SRV(service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    SRV  0 50 " +
-						strconv.Itoa(int(portNumber1)) + " " + hostName2 + "." + clusterID + "." + service1 + "." + namespace1 + ".svc.clusterset.local."),
+					test.SRV(fmt.Sprintf("%s    5    IN    SRV  0 50 %d %s.%s.%s", qname, portNumber1, hostName1, clusterID, qname)),
+					test.SRV(fmt.Sprintf("%s    5    IN    SRV  0 50 %d %s.%s.%s", qname, portNumber1, hostName2, clusterID, qname)),
 				},
 			})
 		})
 		It("should succeed and write an SRV record response when port and protocol is queried", func() {
+			qname = fmt.Sprintf("%s.%s.%s.%s.svc.clusterset.local.", portName1, protocol1, service1, namespace1)
 			executeTestCase(lh, rec, test.Case{
-				Qname: portName1 + "." + string(protcol1) + "." + service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.SRV(portName1 + "." + string(protcol1) + "." + service1 + "." + namespace1 + ".svc.clusterset.local." +
-						"    5    IN    SRV  0 50 " + strconv.Itoa(int(portNumber1)) + " " + hostName1 + "." + clusterID + "." + service1 + "." +
-						namespace1 + ".svc.clusterset.local."),
-					test.SRV(portName1 + "." + string(protcol1) + "." + service1 + "." + namespace1 + ".svc.clusterset.local." +
-						"    5    IN    SRV  0 50 " + strconv.Itoa(int(portNumber1)) + " " + hostName2 + "." + clusterID + "." + service1 + "." +
-						namespace1 + ".svc.clusterset.local."),
+					test.SRV(fmt.Sprintf("%s    5    IN    SRV  0 50 %d %s.%s.%s.%s.svc.clusterset.local.",
+						qname, portNumber1, hostName1, clusterID, service1, namespace1)),
+					test.SRV(fmt.Sprintf("%s    5    IN    SRV  0 50 %d %s.%s.%s.%s.svc.clusterset.local.",
+						qname, portNumber1, hostName2, clusterID, service1, namespace1)),
 				},
 			})
 		})
 		It("should succeed and write an SRV record response when port and protocol is queried with underscore prefix", func() {
+			qname = fmt.Sprintf("_%s._%s.%s.%s.svc.clusterset.local.", portName1, protocol1, service1, namespace1)
 			executeTestCase(lh, rec, test.Case{
-				Qname: "_" + portName1 + "." + "_" + string(protcol1) + "." + service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.SRV("_" + portName1 + "." + "_" + string(protcol1) + "." + service1 + "." + namespace1 + ".svc.clusterset.local." +
-						"    5    IN    SRV  0 50 " + strconv.Itoa(int(portNumber1)) + " " + hostName1 + "." + clusterID + "." + service1 + "." +
-						namespace1 + ".svc.clusterset.local."),
-					test.SRV("_" + portName1 + "." + "_" + string(protcol1) + "." + service1 + "." + namespace1 + ".svc.clusterset.local." +
-						"    5    IN    SRV  0 50 " + strconv.Itoa(int(portNumber1)) + " " + hostName2 + "." + clusterID + "." + service1 + "." +
-						namespace1 + ".svc.clusterset.local."),
+					test.SRV(fmt.Sprintf("%s    5    IN    SRV  0 50 %d %s.%s.%s.%s.svc.clusterset.local.",
+						qname, portNumber1, hostName1, clusterID, service1, namespace1)),
+					test.SRV(fmt.Sprintf("%s    5    IN    SRV  0 50 %d %s.%s.%s.%s.svc.clusterset.local.",
+						qname, portNumber1, hostName2, clusterID, service1, namespace1)),
 				},
 			})
 		})
@@ -761,36 +769,38 @@ func testHeadlessService() {
 	When("headless service is present in two clusters", func() {
 		JustBeforeEach(func() {
 			lh.serviceImports.Put(newServiceImport(namespace1, service1, clusterID, "", portName1,
-				portNumber1, protcol1, mcsv1a1.Headless))
+				portNumber1, protocol1, mcsv1a1.Headless))
 			lh.serviceImports.Put(newServiceImport(namespace1, service1, clusterID2, "", portName1,
-				portNumber1, protcol1, mcsv1a1.Headless))
+				portNumber1, protocol1, mcsv1a1.Headless))
 			lh.endpointSlices.Put(newEndpointSlice(namespace1, service1, clusterID, portName1, []string{hostName1}, []string{endpointIP},
-				portNumber1, protcol1))
+				portNumber1, protocol1))
 			lh.endpointSlices.Put(newEndpointSlice(namespace1, service1, clusterID2, portName1, []string{hostName2}, []string{endpointIP2},
-				portNumber1, protcol1))
+				portNumber1, protocol1))
 			mockCs.clusterStatusMap[clusterID2] = true
 		})
 		When("no cluster is requested", func() {
+			qname := fmt.Sprintf("%s.%s.svc.clusterset.local.", service1, namespace1)
 			It("should succeed and write all IPs as A records in response", func() {
 				executeTestCase(lh, rec, test.Case{
-					Qname: service1 + "." + namespace1 + ".svc.clusterset.local.",
+					Qname: qname,
 					Qtype: dns.TypeA,
 					Rcode: dns.RcodeSuccess,
 					Answer: []dns.RR{
-						test.A(service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    A    " + endpointIP),
-						test.A(service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    A    " + endpointIP2),
+						test.A(fmt.Sprintf("%s    5    IN    A    %s", qname, endpointIP)),
+						test.A(fmt.Sprintf("%s    5    IN    A    %s", qname, endpointIP2)),
 					},
 				})
 			})
 		})
 		When("requested for a specific cluster", func() {
+			qname := fmt.Sprintf("%s.%s.%s.svc.clusterset.local.", clusterID, service1, namespace1)
 			It("should succeed and write the cluster's IP as A record in response", func() {
 				executeTestCase(lh, rec, test.Case{
-					Qname: clusterID + "." + service1 + "." + namespace1 + ".svc.clusterset.local.",
+					Qname: qname,
 					Qtype: dns.TypeA,
 					Rcode: dns.RcodeSuccess,
 					Answer: []dns.RR{
-						test.A(clusterID + "." + service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    A    " + endpointIP),
+						test.A(fmt.Sprintf("%s    5    IN    A    %s", qname, endpointIP)),
 					},
 				})
 			})
@@ -819,7 +829,7 @@ func testLocalService() {
 			Ports: []mcsv1a1.ServicePort{
 				{
 					Name:        portName1,
-					Protocol:    protcol1,
+					Protocol:    protocol1,
 					AppProtocol: nil,
 					Port:        portNumber1,
 				},
@@ -836,64 +846,64 @@ func testLocalService() {
 			ttl:             defaultTTL,
 		}
 		lh.serviceImports.Put(newServiceImport(namespace1, service1, clusterID2, serviceIP2, portName2, portNumber2,
-			protcol2, mcsv1a1.ClusterSetIP))
+			protocol2, mcsv1a1.ClusterSetIP))
 
 		rec = dnstest.NewRecorder(&test.ResponseWriter{})
 	})
 
 	When("service is in local and remote clusters", func() {
+		qname := fmt.Sprintf("%s.%s.svc.clusterset.local.", service1, namespace1)
 		It("should succeed and write local cluster's IP as A record response", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.A(service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    A    " + serviceIP),
+					test.A(fmt.Sprintf("%s    5    IN    A    %s", qname, serviceIP)),
 				},
 			})
 			// Execute again to make sure not round robin
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.A(service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    A    " + serviceIP),
+					test.A(fmt.Sprintf("%s    5    IN    A    %s", qname, serviceIP)),
 				},
 			})
 		})
 		It("should succeed and write local cluster's IP as SRV record response", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.SRV(service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    SRV 0 50 " +
-						strconv.Itoa(int(portNumber1)) + " " + service1 + "." + namespace1 + ".svc.clusterset.local."),
+					test.SRV(fmt.Sprintf("%s    5    IN    SRV 0 50 %d %s", qname, portNumber1, qname)),
 				},
 			})
 		})
 	})
 
 	When("service is in local and remote clusters, and remote cluster is requested", func() {
+		qname := fmt.Sprintf("%s.%s.%s.svc.clusterset.local.", clusterID2, service1, namespace1)
 		It("should succeed and write remote cluster's IP as A record response", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: clusterID2 + "." + service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.A(clusterID2 + "." + service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    A    " + serviceIP2),
+					test.A(fmt.Sprintf("%s    5    IN    A    %s", qname, serviceIP2)),
 				},
 			})
 		})
 
 		It("should succeed and write remote cluster's IP as SRV record response", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: clusterID2 + "." + service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.SRV(clusterID2 + "." + service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    SRV 0 50 " +
-						strconv.Itoa(int(portNumber2)) + " " + clusterID2 + "." + service1 + "." + namespace1 + ".svc.clusterset.local."),
+					test.SRV(fmt.Sprintf("%s    5    IN    SRV 0 50 %d %s", qname, portNumber2, qname)),
 				},
 			})
 		})
@@ -906,24 +916,24 @@ func testLocalService() {
 			mockEs.endpointStatusMap[clusterID2] = true
 			lh.endpointsStatus = mockEs
 		})
+		qname := fmt.Sprintf("%s.%s.svc.clusterset.local.", service1, namespace1)
 		It("should succeed and write remote cluster's IP as A record response", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeA,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.A(service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    A    " + serviceIP2),
+					test.A(fmt.Sprintf("%s    5    IN    A    %s", qname, serviceIP2)),
 				},
 			})
 		})
 		It("should succeed and write remote cluster's IP as SRV record response", func() {
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.SRV(service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    SRV 0 50 " +
-						strconv.Itoa(int(portNumber2)) + " " + service1 + "." + namespace1 + ".svc.clusterset.local."),
+					test.SRV(fmt.Sprintf("%s    5    IN    SRV 0 50 %d %s", qname, portNumber2, qname)),
 				},
 			})
 		})
@@ -949,13 +959,13 @@ func testSRVMultiplePorts() {
 			Ports: []mcsv1a1.ServicePort{
 				{
 					Name:        portName1,
-					Protocol:    protcol1,
+					Protocol:    protocol1,
 					AppProtocol: nil,
 					Port:        portNumber1,
 				},
 				{
 					Name:        portName2,
-					Protocol:    protcol2,
+					Protocol:    protocol2,
 					AppProtocol: nil,
 					Port:        portNumber2,
 				},
@@ -977,64 +987,59 @@ func testSRVMultiplePorts() {
 
 	When("DNS query of type SRV", func() {
 		It("without portName should return all the ports", func() {
+			qname := fmt.Sprintf("%s.%s.svc.clusterset.local.", service1, namespace1)
 			executeTestCase(lh, rec, test.Case{
-				Qname: service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.SRV(service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    SRV 0 50 " +
-						strconv.Itoa(int(portNumber2)) + " " + service1 + "." + namespace1 + ".svc.clusterset.local."),
-					test.SRV(service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    SRV 0 50 " +
-						strconv.Itoa(int(portNumber1)) + " " + service1 + "." + namespace1 + ".svc.clusterset.local."),
+					test.SRV(fmt.Sprintf("%s    5    IN    SRV 0 50 %d %s", qname, portNumber2, qname)),
+					test.SRV(fmt.Sprintf("%s    5    IN    SRV 0 50 %d %s", qname, portNumber1, qname)),
 				},
 			})
 		})
 		It("with  HTTP portname  should return TCP port", func() {
+			qname := fmt.Sprintf("%s.%s.%s.%s.svc.clusterset.local.", portName1, protocol1, service1, namespace1)
 			executeTestCase(lh, rec, test.Case{
-				Qname: portName1 + "." + string(protcol1) + "." + service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.SRV(portName1 + "." + string(protcol1) + "." + service1 + "." + namespace1 +
-						".svc.clusterset.local.    5    IN    SRV 0 50 " + strconv.Itoa(int(portNumber1)) + " " + service1 + "." +
-						namespace1 + ".svc.clusterset.local."),
+					test.SRV(fmt.Sprintf("%s    5    IN    SRV 0 50 %d %s.%s.svc.clusterset.local.", qname, portNumber1, service1, namespace1)),
 				},
 			})
 		})
 		It("with  DNS portname  should return UDP port", func() {
+			qname := fmt.Sprintf("%s.%s.%s.%s.svc.clusterset.local.", portName2, protocol2, service1, namespace1)
 			executeTestCase(lh, rec, test.Case{
-				Qname: portName2 + "." + string(protcol2) + "." + service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.SRV(portName2 + "." + string(protcol2) + "." + service1 + "." + namespace1 +
-						".svc.clusterset.local.    5    IN    SRV 0 50 " + strconv.Itoa(int(portNumber2)) + " " + service1 + "." +
-						namespace1 + ".svc.clusterset.local."),
+					test.SRV(fmt.Sprintf("%s    5    IN    SRV 0 50 %d %s.%s.svc.clusterset.local.", qname, portNumber2, service1, namespace1)),
 				},
 			})
 		})
 		It("with  cluster name should return all the ports from the cluster", func() {
+			qname := fmt.Sprintf("%s.%s.%s.svc.clusterset.local.", clusterID, service1, namespace1)
 			executeTestCase(lh, rec, test.Case{
-				Qname: clusterID + "." + service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.SRV(clusterID + "." + service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    SRV 0 50 " +
-						" " + strconv.Itoa(int(portNumber2)) + " " + clusterID + "." + service1 + "." + namespace1 + ".svc.clusterset.local."),
-					test.SRV(clusterID + "." + service1 + "." + namespace1 + ".svc.clusterset.local.    5    IN    SRV 0 50 " +
-						" " + strconv.Itoa(int(portNumber1)) + " " + clusterID + "." + service1 + "." + namespace1 + ".svc.clusterset.local."),
+					test.SRV(fmt.Sprintf("%s    5    IN    SRV 0 50 %d %s", qname, portNumber2, qname)),
+					test.SRV(fmt.Sprintf("%s    5    IN    SRV 0 50 %d %s", qname, portNumber1, qname)),
 				},
 			})
 		})
 		It("with  HTTP portname  should return TCP port with underscore prefix", func() {
+			qname := fmt.Sprintf("_%s._%s.%s.%s.svc.clusterset.local.", portName1, protocol1, service1, namespace1)
 			executeTestCase(lh, rec, test.Case{
-				Qname: "_" + portName1 + "." + "_" + string(protcol1) + "." + service1 + "." + namespace1 + ".svc.clusterset.local.",
+				Qname: qname,
 				Qtype: dns.TypeSRV,
 				Rcode: dns.RcodeSuccess,
 				Answer: []dns.RR{
-					test.SRV("_" + portName1 + "." + "_" + string(protcol1) + "." + service1 + "." + namespace1 +
-						".svc.clusterset.local.    5    IN    SRV 0 50 " + strconv.Itoa(int(portNumber1)) + " " + service1 + "." +
-						namespace1 + ".svc.clusterset.local."),
+					test.SRV(fmt.Sprintf("%s    5    IN    SRV 0 50 %d %s.%s.svc.clusterset.local.", qname, portNumber1, service1, namespace1)),
 				},
 			})
 		})
@@ -1056,14 +1061,14 @@ func executeTestCase(lh *Lighthouse, rec *dnstest.Recorder, tc test.Case) {
 
 func setupServiceImportMap() *serviceimport.Map {
 	siMap := serviceimport.NewMap()
-	siMap.Put(newServiceImport(namespace1, service1, clusterID, serviceIP, portName1, portNumber1, protcol1, mcsv1a1.ClusterSetIP))
+	siMap.Put(newServiceImport(namespace1, service1, clusterID, serviceIP, portName1, portNumber1, protocol1, mcsv1a1.ClusterSetIP))
 
 	return siMap
 }
 
 func setupEndpointSliceMap() *endpointslice.Map {
 	esMap := endpointslice.NewMap()
-	esMap.Put(newEndpointSlice(namespace1, service1, clusterID, portName1, []string{hostName1}, []string{endpointIP}, portNumber1, protcol1))
+	esMap.Put(newEndpointSlice(namespace1, service1, clusterID, portName1, []string{hostName1}, []string{endpointIP}, portNumber1, protocol1))
 
 	return esMap
 }


### PR DESCRIPTION
Instead of relying on manual concatenation and value conversion, use
fmt.Sprintf(). With some additional qname wrangling, this allows the
string patterns to be more visible.

While we're at it, fix the "protcol" typo.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
