### PR TITLE
Globalnet v2 support for headless services

### DIFF
--- a/pkg/agent/controller/endpoint.go
+++ b/pkg/agent/controller/endpoint.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -75,6 +76,8 @@ func startEndpointController(localClient dynamic.Interface, restMapper meta.REST
 	}
 
 	controller.localClient = localClient
+	gvr, _ := schema.ParseResourceArg("globalingressips.v1.submariner.io")
+	controller.ingressIPClient = localClient.Resource(*gvr)
 
 	return controller, nil
 }
@@ -122,10 +125,11 @@ func (e *EndpointController) endpointsToEndpointSlice(obj runtime.Object, numReq
 		klog.V(log.TRACE).Infof("Endpoints %s/%s updated", endPoints.Namespace, endPoints.Name)
 	}
 
-	return e.endpointSliceFromEndpoints(endPoints, op), false
+	return e.endpointSliceFromEndpoints(endPoints, op)
 }
 
-func (e *EndpointController) endpointSliceFromEndpoints(endpoints *corev1.Endpoints, op syncer.Operation) *discovery.EndpointSlice {
+func (e *EndpointController) endpointSliceFromEndpoints(endpoints *corev1.Endpoints, op syncer.Operation) (
+	*discovery.EndpointSlice, bool) {
 	endpointSlice := &discovery.EndpointSlice{}
 
 	endpointSlice.Name = endpoints.Name + "-" + e.clusterID
@@ -153,9 +157,19 @@ func (e *EndpointController) endpointSliceFromEndpoints(endpoints *corev1.Endpoi
 			endpointSlice.AddressType = discovery.AddressTypeIPv6
 		}
 
-		endpointSlice.Endpoints = append(endpointSlice.Endpoints, getEndpointsFromAddresses(subset.Addresses, endpointSlice.AddressType, true)...)
-		endpointSlice.Endpoints = append(endpointSlice.Endpoints, getEndpointsFromAddresses(subset.NotReadyAddresses,
-			endpointSlice.AddressType, false)...)
+		newEndpoints, retry := e.getEndpointsFromAddresses(subset.Addresses, endpointSlice.AddressType, true)
+		if retry {
+			return nil, true
+		}
+
+		endpointSlice.Endpoints = append(endpointSlice.Endpoints, newEndpoints...)
+		newEndpoints, retry = e.getEndpointsFromAddresses(subset.NotReadyAddresses, endpointSlice.AddressType, false)
+		if retry {
+			// TODO: We may not want unready endpoints at all
+			return nil, true
+		}
+
+		endpointSlice.Endpoints = append(endpointSlice.Endpoints, newEndpoints...)
 	}
 
 	if op == syncer.Create {
@@ -164,30 +178,42 @@ func (e *EndpointController) endpointSliceFromEndpoints(endpoints *corev1.Endpoi
 		klog.V(log.TRACE).Infof("Returning EndpointSlice: %#v", endpointSlice)
 	}
 
-	return endpointSlice
+	return endpointSlice, false
 }
 
-func getEndpointsFromAddresses(addresses []corev1.EndpointAddress, addressType discovery.AddressType, ready bool) []discovery.Endpoint {
+func (e *EndpointController) getEndpointsFromAddresses(addresses []corev1.EndpointAddress, addressType discovery.AddressType,
+	ready bool) ([]discovery.Endpoint, bool) {
 	endpoints := []discovery.Endpoint{}
 	isIPv6AddressType := addressType == discovery.AddressTypeIPv6
 
 	for _, address := range addresses {
 		if utilnet.IsIPv6String(address.IP) == isIPv6AddressType {
-			endpoints = append(endpoints, endpointFromAddress(address, ready))
+			endpoint, retry := e.endpointFromAddress(address, ready)
+			if retry {
+				return nil, true
+			}
+
+			endpoints = append(endpoints, *endpoint)
 		}
 	}
 
-	return endpoints
+	return endpoints, false
 }
 
-func endpointFromAddress(address corev1.EndpointAddress, ready bool) discovery.Endpoint {
+func (e *EndpointController) endpointFromAddress(address corev1.EndpointAddress, ready bool) (*discovery.Endpoint, bool) {
 	topology := map[string]string{}
 	if address.NodeName != nil {
 		topology["kubernetes.io/hostname"] = *address.NodeName
 	}
 
-	endpoint := discovery.Endpoint{
-		Addresses:  []string{address.IP},
+	ip := e.getIP(address)
+
+	if ip == "" {
+		return nil, true
+	}
+
+	endpoint := &discovery.Endpoint{
+		Addresses:  []string{ip},
 		Conditions: discovery.EndpointConditions{Ready: &ready},
 		Topology:   topology,
 	}
@@ -206,7 +232,7 @@ func endpointFromAddress(address corev1.EndpointAddress, ready bool) discovery.E
 		endpoint.Hostname = &address.TargetRef.Name
 	}
 
-	return endpoint
+	return endpoint, false
 }
 
 func allAddressesIPv6(addresses []corev1.EndpointAddress) bool {
@@ -221,4 +247,25 @@ func allAddressesIPv6(addresses []corev1.EndpointAddress) bool {
 	}
 
 	return true
+}
+
+func (e *EndpointController) getIP(address corev1.EndpointAddress) string {
+	if e.isHeadless && e.globalnetEnabled {
+		var ip string
+
+		name := "pod-" + address.TargetRef.Name
+		// TODO: Replace with a syncer.GetResource() to reduce API calls
+		obj, err := e.ingressIPClient.Namespace(e.serviceImportSourceNameSpace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err == nil {
+			ip, _, _ = unstructured.NestedString(obj.Object, "status", "allocatedIP")
+		}
+
+		if ip == "" {
+			klog.Infof("GlobalIP for %s not allocated yet", name)
+		}
+
+		return ip
+	}
+
+	return address.IP
 }

--- a/pkg/agent/controller/globalnet_test.go
+++ b/pkg/agent/controller/globalnet_test.go
@@ -108,9 +108,11 @@ var _ = Describe("Globalnet enabled", func() {
 		})
 	})
 
+	/* TODO: Modify tests for headless service
 	When("a headless Service is exported", func() {
 		BeforeEach(func() {
 			t.service.Spec.ClusterIP = corev1.ClusterIPNone
+			t.createGlobalIngressIP()
 		})
 
 		It("should update the ServiceExport status and not sync a ServiceImport", func() {
@@ -120,4 +122,5 @@ var _ = Describe("Globalnet enabled", func() {
 			t.awaitNoServiceImport(t.brokerServiceImportClient)
 		})
 	})
+	 */
 })

--- a/pkg/agent/controller/globalnet_test.go
+++ b/pkg/agent/controller/globalnet_test.go
@@ -18,10 +18,13 @@ limitations under the License.
 package controller_test
 
 import (
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
@@ -45,14 +48,20 @@ var _ = Describe("Globalnet enabled", func() {
 	})
 
 	When("a ClusterIP Service is exported", func() {
+		var ingressIP *unstructured.Unstructured
+
+		BeforeEach(func() {
+			ingressIP = t.newGlobalIngressIP(t.service.Name, globalIP1)
+		})
+
 		Context("and it has a global IP", func() {
 			Context("via a GlobalIngressIP", func() {
 				BeforeEach(func() {
-					t.createGlobalIngressIP()
+					t.createGlobalIngressIP(ingressIP)
 				})
 
 				It("should sync a ServiceImport with the global IP", func() {
-					t.awaitServiceExported(globalIP, 0)
+					t.awaitServiceExported(globalIP1, 0)
 				})
 			})
 		})
@@ -63,25 +72,25 @@ var _ = Describe("Globalnet enabled", func() {
 					t.awaitServiceExportStatus(0, newServiceExportCondition(mcsv1a1.ServiceExportValid,
 						corev1.ConditionFalse, "ServiceGlobalIPUnavailable"))
 
-					t.createGlobalIngressIP()
-					t.awaitServiceExported(globalIP, 1)
+					t.createGlobalIngressIP(ingressIP)
+					t.awaitServiceExported(globalIP1, 1)
 				})
 			})
 
 			Context("due to no AllocatedIP in the GlobalIngressIP", func() {
 				BeforeEach(func() {
-					setIngressAllocatedIP(t.ingressIP, "")
-					setIngressIPConditions(t.ingressIP)
-					t.createGlobalIngressIP()
+					setIngressAllocatedIP(ingressIP, "")
+					setIngressIPConditions(ingressIP)
+					t.createGlobalIngressIP(ingressIP)
 				})
 
 				It("should update the ServiceExport status appropriately and eventually sync a ServiceImport", func() {
 					t.awaitServiceExportStatus(0, newServiceExportCondition(mcsv1a1.ServiceExportValid,
 						corev1.ConditionFalse, "ServiceGlobalIPUnavailable"))
 
-					setIngressAllocatedIP(t.ingressIP, globalIP)
-					test.UpdateResource(t.cluster1.localIngressIPClient, t.ingressIP)
-					t.awaitServiceExported(globalIP, 1)
+					setIngressAllocatedIP(ingressIP, globalIP1)
+					test.UpdateResource(t.cluster1.localIngressIPClient, ingressIP)
+					t.awaitServiceExported(globalIP1, 1)
 				})
 			})
 		})
@@ -95,9 +104,9 @@ var _ = Describe("Globalnet enabled", func() {
 			}
 
 			BeforeEach(func() {
-				setIngressAllocatedIP(t.ingressIP, "")
-				setIngressIPConditions(t.ingressIP, condition)
-				t.createGlobalIngressIP()
+				setIngressAllocatedIP(ingressIP, "")
+				setIngressIPConditions(ingressIP, condition)
+				t.createGlobalIngressIP(ingressIP)
 			})
 
 			It("should update the ServiceExport status with the condition details", func() {
@@ -108,19 +117,36 @@ var _ = Describe("Globalnet enabled", func() {
 		})
 	})
 
-	/* TODO: Modify tests for headless service
 	When("a headless Service is exported", func() {
 		BeforeEach(func() {
 			t.service.Spec.ClusterIP = corev1.ClusterIPNone
-			t.createGlobalIngressIP()
 		})
 
-		It("should update the ServiceExport status and not sync a ServiceImport", func() {
-			t.awaitServiceExportStatus(0, newServiceExportCondition(mcsv1a1.ServiceExportValid,
-				corev1.ConditionFalse, "UnsupportedServiceType"))
+		JustBeforeEach(func() {
+			t.createEndpoints()
+		})
 
-			t.awaitNoServiceImport(t.brokerServiceImportClient)
+		Context("and it has a global IP for all endpoint addresses", func() {
+			BeforeEach(func() {
+				t.createEndpointIngressIPs()
+			})
+
+			It("should sync a ServiceImport and EndpointSlice with the global IPs", func() {
+				t.awaitHeadlessServiceImport("")
+				t.awaitEndpointSlice()
+			})
+		})
+
+		Context("and it initially does not have a global IP for all endpoint addresses", func() {
+			It("should eventually sync a ServiceImport and EndpointSlice with the global IPs", func() {
+				time.Sleep(time.Millisecond * 300)
+				t.awaitNoEndpointSlice(t.cluster1.localEndpointSliceClient)
+
+				t.createEndpointIngressIPs()
+
+				t.awaitHeadlessServiceImport("")
+				t.awaitEndpointSlice()
+			})
 		})
 	})
-	 */
 })

--- a/pkg/agent/controller/reconciliation_test.go
+++ b/pkg/agent/controller/reconciliation_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Reconciliation", func() {
 
 		It("should delete the ServiceImport and EndpointSlice on reconciliation", func() {
 			serviceImport := t.cluster1.awaitServiceImport(t.service, mcsv1a1.Headless, "")
-			endpointSlice := t.cluster1.awaitEndpointSlice(t.endpoints, t.service)
+			endpointSlice := t.cluster1.awaitEndpointSlice(t)
 
 			t.afterEach()
 			t = newTestDiver()
@@ -143,7 +143,7 @@ var _ = Describe("Reconciliation", func() {
 		})
 
 		It("should delete it from the local datastore on reconciliation", func() {
-			endpointSlice := t.cluster2.awaitEndpointSlice(t.endpoints, t.service)
+			endpointSlice := t.cluster2.awaitEndpointSlice(t)
 
 			t.afterEach()
 			t = newTestDiver()

--- a/pkg/agent/controller/service_export_failures_test.go
+++ b/pkg/agent/controller/service_export_failures_test.go
@@ -21,10 +21,8 @@ import (
 	"errors"
 
 	. "github.com/onsi/ginkgo"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
 var _ = Describe("Service export failures", func() {
@@ -43,20 +41,6 @@ var _ = Describe("Service export failures", func() {
 
 	AfterEach(func() {
 		t.afterEach()
-	})
-
-	When("Endpoints retrieval initially fails", func() {
-		BeforeEach(func() {
-			t.service.Spec.ClusterIP = corev1.ClusterIPNone
-			t.cluster1.endpointsReactor.SetFailOnGet(errors.New("fake Get error"))
-		})
-
-		It("should update the ServiceExport status and eventually sync a ServiceImport", func() {
-			t.awaitServiceExportStatus(0, newServiceExportCondition(mcsv1a1.ServiceExportValid,
-				corev1.ConditionUnknown, "ServiceRetrievalFailed"))
-			t.cluster1.endpointsReactor.SetResetOnFailure(true)
-			t.awaitHeadlessServiceImport("")
-		})
 	})
 
 	When("a conflict initially occurs when updating the ServiceExport status", func() {

--- a/pkg/agent/controller/serviceimport.go
+++ b/pkg/agent/controller/serviceimport.go
@@ -34,11 +34,12 @@ import (
 func newServiceImportController(spec *AgentSpecification, serviceSyncer syncer.Interface, restMapper meta.RESTMapper,
 	localClient dynamic.Interface, scheme *runtime.Scheme) (*ServiceImportController, error) {
 	controller := &ServiceImportController{
-		serviceSyncer: serviceSyncer,
-		localClient:   localClient,
-		restMapper:    restMapper,
-		clusterID:     spec.ClusterID,
-		scheme:        scheme,
+		serviceSyncer:    serviceSyncer,
+		localClient:      localClient,
+		restMapper:       restMapper,
+		clusterID:        spec.ClusterID,
+		scheme:           scheme,
+		globalnetEnabled: spec.GlobalnetEnabled,
 	}
 
 	var err error
@@ -117,6 +118,9 @@ func (c *ServiceImportController) serviceImportCreatedOrUpdated(serviceImport *m
 		klog.Errorf(err.Error())
 		return true
 	}
+
+	endpointController.globalnetEnabled = c.globalnetEnabled
+	endpointController.isHeadless = serviceImport.Spec.Type == mcsv1a1.Headless
 
 	c.endpointControllers.Store(key, endpointController)
 

--- a/pkg/agent/controller/serviceimport.go
+++ b/pkg/agent/controller/serviceimport.go
@@ -113,14 +113,11 @@ func (c *ServiceImportController) serviceImportCreatedOrUpdated(serviceImport *m
 	}
 
 	endpointController, err := startEndpointController(c.localClient, c.restMapper, c.scheme,
-		serviceImport.ObjectMeta.UID, serviceImport.ObjectMeta.Name, serviceNameSpace, serviceName, c.clusterID)
+		serviceImport, serviceNameSpace, serviceName, c.clusterID, c.globalnetEnabled)
 	if err != nil {
 		klog.Errorf(err.Error())
 		return true
 	}
-
-	endpointController.globalnetEnabled = c.globalnetEnabled
-	endpointController.isHeadless = serviceImport.Spec.Type == mcsv1a1.Headless
 
 	c.endpointControllers.Store(key, endpointController)
 

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -61,6 +61,7 @@ type ServiceImportController struct {
 	endpointControllers sync.Map
 	clusterID           string
 	scheme              *runtime.Scheme
+	globalnetEnabled    bool
 }
 
 // Each EndpointController listens for the endpoints that backs a service and have a ServiceImport
@@ -74,4 +75,7 @@ type EndpointController struct {
 	serviceImportSourceNameSpace string
 	stopCh                       chan struct{}
 	localClient                  dynamic.Interface
+	ingressIPClient              dynamic.NamespaceableResourceInterface
+	isHeadless                   bool
+	globalnetEnabled             bool
 }


### PR DESCRIPTION
* Add globalnet support for headless services
* Remove unused old code

Fixes #558 

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
