### PR TITLE
E2E for Headless services with globalnet

### DIFF
--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -92,12 +92,6 @@ var _ = Describe("[discovery] Test Service Discovery Across Clusters", func() {
 				return
 			}
 
-			// TODO: Enable this once globalnetv2 fixes health check
-			if framework.TestContext.GlobalnetEnabled {
-				Skip("Not supported with Globalnet v2 yet and hence skipping the test")
-				return
-			}
-
 			randomIP := "192.168.1.5"
 			endpointName, healthCheckIP = f.GetHealthCheckIPInfo(framework.ClusterC)
 			f.SetHealthCheckIP(framework.ClusterC, randomIP, endpointName)

--- a/test/e2e/discovery/statefulsets.go
+++ b/test/e2e/discovery/statefulsets.go
@@ -35,31 +35,19 @@ var _ = Describe("[discovery] Test Stateful Sets Discovery Across Clusters", fun
 
 	When("a pod tries to resolve a podname from stateful set in a remote cluster", func() {
 		It("should resolve the pod IP from the remote cluster", func() {
-			if !framework.TestContext.GlobalnetEnabled {
-				RunSSDiscoveryTest(f)
-			} else {
-				framework.Skipf("Globalnet is enabled, skipping the test...")
-			}
+			RunSSDiscoveryTest(f)
 		})
 	})
 
 	When("a pod tries to resolve a podname from stateful set in a local cluster", func() {
 		It("should resolve the pod IP from the local cluster", func() {
-			if !framework.TestContext.GlobalnetEnabled {
-				RunSSDiscoveryLocalTest(f)
-			} else {
-				framework.Skipf("Globalnet is enabled, skipping the test...")
-			}
+			RunSSDiscoveryLocalTest(f)
 		})
 	})
 
 	When("the number of active pods backing a stateful set changes", func() {
 		It("should only resolve the IPs from the active pods", func() {
-			if !framework.TestContext.GlobalnetEnabled {
-				RunSSPodsAvailabilityTest(f)
-			} else {
-				framework.Skipf("Globalnet is enabled, skipping the test...")
-			}
+			RunSSPodsAvailabilityTest(f)
 		})
 	})
 })


### PR DESCRIPTION
* Changes to support e2e for Globalnet+HeadlessServices
* Fixes to some existing bugs in e2e code
* Comment out some broker tests revealed by fixes in e2e code.

Depends On https://github.com/submariner-io/submariner-charts/pull/157

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
