### PR TITLE
Optimize GlobalIngressIP retrieval

### DIFF
--- a/pkg/agent/controller/controller_suite_test.go
+++ b/pkg/agent/controller/controller_suite_test.go
@@ -222,6 +222,14 @@ func (t *testDriver) newGlobalIngressIP(name, ip string) *unstructured.Unstructu
 	return ingressIP
 }
 
+func (t *testDriver) newHeadlessGlobalIngressIP(name, ip string) *unstructured.Unstructured {
+	ingressIP := t.newGlobalIngressIP("pod"+"-"+name, ip)
+	Expect(unstructured.SetNestedField(ingressIP.Object, controller.HeadlessServicePod, "spec", "target")).To(Succeed())
+	Expect(unstructured.SetNestedField(ingressIP.Object, name, "spec", "podRef", "name")).To(Succeed())
+
+	return ingressIP
+}
+
 func (t *testDriver) justBeforeEach() {
 	t.cluster1.start(t, *t.syncerConfig)
 	t.cluster2.start(t, *t.syncerConfig)
@@ -518,9 +526,9 @@ func (t *testDriver) createGlobalIngressIP(ingressIP *unstructured.Unstructured)
 
 func (t *testDriver) createEndpointIngressIPs() {
 	t.endpointGlobalIPs = []string{globalIP1, globalIP2, globalIP3}
-	t.createGlobalIngressIP(t.newGlobalIngressIP("pod-one", globalIP1))
-	t.createGlobalIngressIP(t.newGlobalIngressIP("pod-two", globalIP2))
-	t.createGlobalIngressIP(t.newGlobalIngressIP("pod-not-ready", globalIP3))
+	t.createGlobalIngressIP(t.newHeadlessGlobalIngressIP("one", globalIP1))
+	t.createGlobalIngressIP(t.newHeadlessGlobalIngressIP("two", globalIP2))
+	t.createGlobalIngressIP(t.newHeadlessGlobalIngressIP("not-ready", globalIP3))
 }
 
 func (t *testDriver) dynamicServiceClient() dynamic.ResourceInterface {

--- a/pkg/agent/controller/global_ingressip_cache.go
+++ b/pkg/agent/controller/global_ingressip_cache.go
@@ -1,0 +1,109 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controller
+
+import (
+	"sync"
+
+	"github.com/submariner-io/admiral/pkg/watcher"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func newGlobalIngressIPCache(config watcher.Config) (*globalIngressIPCache, error) {
+	c := &globalIngressIPCache{}
+
+	config.ResourceConfigs = []watcher.ResourceConfig{
+		{
+			Name:         "GlobalIngressIP watcher",
+			ResourceType: GetGlobalIngressIPObj(),
+			Handler: watcher.EventHandlerFuncs{
+				OnCreateFunc: func(obj runtime.Object, numRequeues int) bool {
+					c.onCreateOrUpdate(obj.(*unstructured.Unstructured))
+					return false
+				},
+				OnUpdateFunc: func(obj runtime.Object, numRequeues int) bool {
+					c.onCreateOrUpdate(obj.(*unstructured.Unstructured))
+					return false
+				},
+				OnDeleteFunc: func(obj runtime.Object, numRequeues int) bool {
+					c.onDelete(obj.(*unstructured.Unstructured))
+					return false
+				},
+			},
+			SourceNamespace: metav1.NamespaceAll,
+		},
+	}
+
+	var err error
+
+	c.watcher, err = watcher.New(&config)
+
+	return c, err
+}
+
+func (c *globalIngressIPCache) start(stopCh <-chan struct{}) error {
+	return c.watcher.Start(stopCh)
+}
+
+func (c *globalIngressIPCache) onCreateOrUpdate(obj *unstructured.Unstructured) {
+	c.applyToCache(obj, func(to *sync.Map, key string, obj *unstructured.Unstructured) {
+		to.Store(key, obj)
+	})
+}
+
+func (c *globalIngressIPCache) onDelete(obj *unstructured.Unstructured) {
+	c.applyToCache(obj, func(to *sync.Map, key string, obj *unstructured.Unstructured) {
+		to.Delete(key)
+	})
+}
+
+func (c *globalIngressIPCache) applyToCache(obj *unstructured.Unstructured,
+	apply func(to *sync.Map, key string, obj *unstructured.Unstructured)) {
+	target, _, _ := unstructured.NestedString(obj.Object, "spec", "target")
+	switch target {
+	case ClusterIPService:
+		name, _, _ := unstructured.NestedString(obj.Object, "spec", "serviceRef", "name")
+		apply(&c.byService, c.key(obj.GetNamespace(), name), obj)
+	case HeadlessServicePod:
+		name, _, _ := unstructured.NestedString(obj.Object, "spec", "podRef", "name")
+		apply(&c.byPod, c.key(obj.GetNamespace(), name), obj)
+	}
+}
+
+func (c *globalIngressIPCache) getForService(namespace, name string) (*unstructured.Unstructured, bool) {
+	return c.get(&c.byService, namespace, name)
+}
+
+func (c *globalIngressIPCache) getForPod(namespace, name string) (*unstructured.Unstructured, bool) {
+	return c.get(&c.byPod, namespace, name)
+}
+
+func (c *globalIngressIPCache) get(from *sync.Map, namespace, name string) (*unstructured.Unstructured, bool) {
+	v, found := from.Load(c.key(namespace, name))
+	if !found {
+		return nil, false
+	}
+
+	return v.(*unstructured.Unstructured), true
+}
+
+func (c *globalIngressIPCache) key(ns, n string) string {
+	return ns + "/" + n
+}

--- a/pkg/agent/controller/globalingressip.go
+++ b/pkg/agent/controller/globalingressip.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	ClusterIPService           = "ClusterIPService"
-	headlessServicePod         = "HeadlessServicePod"
+	HeadlessServicePod         = "HeadlessServicePod"
 	defaultReasonIPUnavailable = "ServiceGlobalIPUnavailable"
 	defaultMsgIPUnavailable    = "Service doesn't have a global IP yet"
 )
@@ -32,8 +32,6 @@ const (
 type IngressIP struct {
 	namespace         string
 	target            string
-	svcName           string
-	podName           string
 	allocatedIP       string
 	unallocatedReason string
 	unallocatedMsg    string
@@ -51,20 +49,6 @@ func parseIngressIP(obj *unstructured.Unstructured) *IngressIP {
 	if !found || err != nil {
 		klog.Errorf("target field not found in spec %#v", obj.Object)
 		return nil
-	}
-
-	gip.svcName, found, err = unstructured.NestedString(obj.Object, "spec", "serviceRef", "name")
-	if !found || err != nil {
-		klog.Errorf("ServiceRef not found in spec %#v", obj.Object)
-		return nil
-	}
-
-	if gip.target == headlessServicePod {
-		gip.podName, found, err = unstructured.NestedString(obj.Object, "spec", "podRef", "name")
-		if !found || err != nil {
-			klog.Errorf("Expected PodRef in spec %#v", obj.Object)
-			return nil
-		}
 	}
 
 	gip.allocatedIP, _, _ = unstructured.NestedString(obj.Object, "status", "allocatedIP")


### PR DESCRIPTION
Use a resource watcher to maintain a cache instead of reading on demand.
