### PR TITLE
Fix YAML linting errors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 updates:
   - package-ecosystem: gomod

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -17,7 +17,7 @@ on:
       - reopened
       - synchronize
   schedule:
-    - cron: '0 0/6 * * *' # every 6 hours
+    - cron: '0 0/6 * * *'  # every 6 hours
 
 jobs:
   check:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@ linters-settings:
     enabled-tags:
       - diagnostic
       - opinionated
-      #- performance
+      # - performance
       - style
   gocyclo:
     min-complexity: 15

--- a/.lichen.yaml
+++ b/.lichen.yaml
@@ -1,3 +1,4 @@
+---
 # Licenses other than Apache-2.0 are governed by
 # https://github.com/cncf/foundation/blob/master/allowed-third-party-license-policy.md#approved-licenses-for-allowlist
 # Note that Allowlist also requires that projects were created

--- a/.submarinerbot.yaml
+++ b/.submarinerbot.yaml
@@ -1,3 +1,4 @@
+---
 label-approved:
   approvals: 2
   label: ready-to-test


### PR DESCRIPTION
It's unclear why these errors were not flagged in CI, but they are being
flagged now by CI and can be reproduced locally. Something similar
happened in the submariner-operator repo.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
