### PR TITLE
DNS Query Counter

### DIFF
--- a/pkg/serviceimport/map.go
+++ b/pkg/serviceimport/map.go
@@ -144,11 +144,14 @@ func (m *Map) Put(serviceImport *mcsv1a1.ServiceImport) {
 		}
 
 		if serviceImport.Spec.Type == mcsv1a1.ClusterSetIP {
-			record := &DNSRecord{
-				IP:    serviceImport.Spec.IPs[0],
-				Ports: serviceImport.Spec.Ports,
-			}
 			clusterName := serviceImport.GetLabels()[lhconstants.LabelSourceCluster]
+
+			record := &DNSRecord{
+				IP:          serviceImport.Spec.IPs[0],
+				Ports:       serviceImport.Spec.Ports,
+				ClusterName: clusterName,
+			}
+
 			remoteService.records[clusterName] = &clusterInfo{
 				name:   clusterName,
 				record: record,

--- a/plugin/lighthouse/handler.go
+++ b/plugin/lighthouse/handler.go
@@ -99,6 +99,12 @@ func (lh *Lighthouse) getDNSRecord(zone string, state request.Request, ctx conte
 		return lh.emptyResponse(state)
 	}
 
+	// Count records
+	localClusterID := lh.clusterStatus.LocalClusterID()
+	for _, record := range dnsRecords {
+		incDNSQueryCounter(localClusterID, record.ClusterName, pReq.service, pReq.namespace, record.IP)
+	}
+
 	records := make([]dns.RR, 0)
 
 	if state.QType() == dns.TypeA {

--- a/plugin/lighthouse/metrics.go
+++ b/plugin/lighthouse/metrics.go
@@ -1,0 +1,67 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package lighthouse
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/klog"
+)
+
+const (
+	srcClusterKey      = "source_cluster"
+	dstClusterKey      = "destination_cluster"
+	dstSvcNameKey      = "destination_service_name"
+	dstSvcIPKey        = "destination_service_ip"
+	dstSvcNamespaceKey = "destination_service_namespace"
+
+	ServiceDiscoveryQueryCounterName = "submariner_service_discovery_query_counter"
+)
+
+var dnsQueryCounter *prometheus.GaugeVec
+
+func initLighthouseMetrics() {
+	klog.Infof("Initializing dns query counter")
+
+	dnsQueryCounter = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: ServiceDiscoveryQueryCounterName,
+			Help: "Count the numebr of dns queries",
+		},
+		[]string{srcClusterKey, dstClusterKey, dstSvcNameKey, dstSvcNamespaceKey, dstSvcIPKey},
+	)
+
+	if err := prometheus.Register(dnsQueryCounter); err != nil {
+		klog.Errorf("Failed to register: %s with prometheus due to: %v", ServiceDiscoveryQueryCounterName, err)
+	}
+}
+
+func incDNSQueryCounter(srcCluster, dstCluster, dstSvcName, dstSvcNamespace, dstSvcIP string) {
+	if dnsQueryCounter == nil {
+		initLighthouseMetrics()
+	}
+
+	labels := prometheus.Labels{
+		srcClusterKey:      srcCluster,
+		dstClusterKey:      dstCluster,
+		dstSvcNameKey:      dstSvcName,
+		dstSvcNamespaceKey: dstSvcNamespace,
+		dstSvcIPKey:        dstSvcIP,
+	}
+
+	dnsQueryCounter.With(labels).Inc()
+}

--- a/plugin/lighthouse/metrics.go
+++ b/plugin/lighthouse/metrics.go
@@ -34,7 +34,7 @@ const (
 
 var dnsQueryCounter *prometheus.GaugeVec
 
-func initLighthouseMetrics() {
+func init() {
 	klog.Infof("Initializing dns query counter")
 
 	dnsQueryCounter = prometheus.NewGaugeVec(
@@ -51,10 +51,6 @@ func initLighthouseMetrics() {
 }
 
 func incDNSQueryCounter(srcCluster, dstCluster, dstSvcName, dstSvcNamespace, dstSvcIP string) {
-	if dnsQueryCounter == nil {
-		initLighthouseMetrics()
-	}
-
 	labels := prometheus.Labels{
 		srcClusterKey:      srcCluster,
 		dstClusterKey:      dstCluster,

--- a/plugin/lighthouse/metrics.go
+++ b/plugin/lighthouse/metrics.go
@@ -29,7 +29,7 @@ const (
 	dstSvcIPKey        = "destination_service_ip"
 	dstSvcNamespaceKey = "destination_service_namespace"
 
-	ServiceDiscoveryQueryCounterName = "submariner_service_discovery_query_counter"
+	ServiceDiscoveryQueryCounterName = "submariner_service_discovery_query"
 )
 
 var dnsQueryCounter *prometheus.GaugeVec
@@ -40,14 +40,12 @@ func init() {
 	dnsQueryCounter = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: ServiceDiscoveryQueryCounterName,
-			Help: "Count the numebr of dns queries",
+			Help: "Count DNS queries",
 		},
 		[]string{srcClusterKey, dstClusterKey, dstSvcNameKey, dstSvcNamespaceKey, dstSvcIPKey},
 	)
 
-	if err := prometheus.Register(dnsQueryCounter); err != nil {
-		klog.Errorf("Failed to register: %s with prometheus due to: %v", ServiceDiscoveryQueryCounterName, err)
-	}
+	prometheus.MustRegister(dnsQueryCounter)
 }
 
 func incDNSQueryCounter(srcCluster, dstCluster, dstSvcName, dstSvcNamespace, dstSvcIP string) {

--- a/plugin/lighthouse/setup.go
+++ b/plugin/lighthouse/setup.go
@@ -94,7 +94,7 @@ func lighthouseParse(c *caddy.Controller) (*Lighthouse, error) {
 		return nil, fmt.Errorf("error starting the Gateway controller: %v", err)
 	}
 
-	svcController := service.NewController()
+	svcController := service.NewController(gwController.LocalClusterID())
 	err = svcController.Start(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("error starting the Service controller: %v", err)


### PR DESCRIPTION
Signed-off-by: I <danibachar89@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->

Adding custom metrics for DNS queries served with the lighthouse plugin.
As the [basic CoreDNS Prometheus metrics](https://coredns.io/plugins/metrics/) don’t suffice  - note that even though CoreDNS have the `coredns_dns_requests_total ` and `coredns_dns_responses_total ` they don't hold all the information we need.

In addition, I added the `ClusterName` property to the DNSRecords returned from the ServiceImport and Service controllers (the EndpointSlice one already had that info added to the record) - I thought of having it in a separate PR but it seems an overkill - if separation is needed please let me know.
