### PR TITLE
Add check to for healthcheck enable in e2e

### DIFF
--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -93,6 +93,12 @@ var _ = Describe("[discovery] Test Service Discovery Across Clusters", func() {
 			}
 
 			randomIP := "192.168.1.5"
+			healthCheckEnabled := f.GetHealthCheckEnabledInfo(framework.ClusterC)
+			if !healthCheckEnabled {
+				Skip("Healthcheck is not enabled hence skipping the test")
+				return
+			}
+
 			endpointName, healthCheckIP = f.GetHealthCheckIPInfo(framework.ClusterC)
 			f.SetHealthCheckIP(framework.ClusterC, randomIP, endpointName)
 		})


### PR DESCRIPTION
In lighthouse e2e where it modifies healthcheck enabled
check is added to see if healthcheck is enabled before trying
to get it.

Signed-off-by: Aswin Surayanarayanan <asuryana@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
