### PR TITLE
Hide mutexes

### DIFF
--- a/pkg/endpointslice/map.go
+++ b/pkg/endpointslice/map.go
@@ -40,15 +40,15 @@ type clusterInfo struct {
 
 type Map struct {
 	epMap map[string]*endpointInfo
-	sync.RWMutex
+	mutex sync.RWMutex
 }
 
 func (m *Map) GetDNSRecords(hostname, cluster, namespace, name string, checkCluster func(string) bool) ([]serviceimport.DNSRecord, bool) {
 	key := keyFunc(name, namespace)
 
 	clusterInfos := func() map[string]*clusterInfo {
-		m.RLock()
-		defer m.RUnlock()
+		m.mutex.RLock()
+		defer m.mutex.RUnlock()
 
 		result, ok := m.epMap[key]
 		if !ok {
@@ -105,8 +105,8 @@ func (m *Map) Put(es *discovery.EndpointSlice) {
 		return
 	}
 
-	m.Lock()
-	defer m.Unlock()
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
 
 	epInfo, ok := m.epMap[key]
 	if !ok {
@@ -171,8 +171,8 @@ func (m *Map) Remove(es *discovery.EndpointSlice) {
 			return
 		}
 
-		m.Lock()
-		defer m.Unlock()
+		m.mutex.Lock()
+		defer m.mutex.Unlock()
 
 		epInfo, ok := m.epMap[key]
 		if !ok {
@@ -185,8 +185,8 @@ func (m *Map) Remove(es *discovery.EndpointSlice) {
 }
 
 func (m *Map) Get(key string) *endpointInfo {
-	m.RLock()
-	defer m.RUnlock()
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
 	endpointInfo := m.epMap[key]
 
 	return endpointInfo

--- a/pkg/serviceimport/map.go
+++ b/pkg/serviceimport/map.go
@@ -60,7 +60,7 @@ func (si *serviceInfo) resetLoadBalancing() {
 
 type Map struct {
 	svcMap map[string]*serviceInfo
-	sync.RWMutex
+	mutex  sync.RWMutex
 }
 
 func (m *Map) selectIP(si *serviceInfo, name, namespace string, checkCluster func(string) bool,
@@ -81,8 +81,8 @@ func (m *Map) selectIP(si *serviceInfo, name, namespace string, checkCluster fun
 
 func (m *Map) GetIP(namespace, name, cluster, localCluster string, checkCluster func(string) bool,
 	checkEndpoint func(string, string, string) bool) (record *DNSRecord, found, isLocal bool) {
-	m.RLock()
-	defer m.RUnlock()
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
 
 	si, ok := m.svcMap[keyFunc(namespace, name)]
 	if !ok || si.isHeadless {
@@ -129,8 +129,8 @@ func (m *Map) Put(serviceImport *mcsv1a1.ServiceImport) {
 		namespace := serviceImport.Annotations["origin-namespace"]
 		key := keyFunc(namespace, name)
 
-		m.Lock()
-		defer m.Unlock()
+		m.mutex.Lock()
+		defer m.mutex.Unlock()
 
 		remoteService, ok := m.svcMap[key]
 
@@ -169,8 +169,8 @@ func (m *Map) Remove(serviceImport *mcsv1a1.ServiceImport) {
 		namespace := serviceImport.Annotations["origin-namespace"]
 		key := keyFunc(namespace, name)
 
-		m.Lock()
-		defer m.Unlock()
+		m.mutex.Lock()
+		defer m.mutex.Unlock()
 
 		remoteService, ok := m.svcMap[key]
 		if !ok {


### PR DESCRIPTION
This is flagged by the latest gocritic:
https://go-critic.com/overview.html#exposedSyncMutex-ref

This patch avoids exposing the mutex functions on the containing
struct.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
