### PR TITLE
Weight annotations for ServiceExport -> ServiceImport

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -18,10 +18,11 @@ limitations under the License.
 package constants
 
 const (
-	OriginName           = "origin-name"
-	OriginNamespace      = "origin-namespace"
-	LabelSourceName      = "lighthouse.submariner.io/sourceName"
-	LabelSourceNamespace = "lighthouse.submariner.io/sourceNamespace"
-	LabelSourceCluster   = "lighthouse.submariner.io/sourceCluster"
-	LabelValueManagedBy  = "lighthouse-agent.submariner.io"
+	OriginName                         = "origin-name"
+	OriginNamespace                    = "origin-namespace"
+	LoadBalancerWeightAnnotationPrefix = "lighthouse-load-balancer.submariner.io/weight"
+	LabelSourceName                    = "lighthouse.submariner.io/sourceName"
+	LabelSourceNamespace               = "lighthouse.submariner.io/sourceNamespace"
+	LabelSourceCluster                 = "lighthouse.submariner.io/sourceCluster"
+	LabelValueManagedBy                = "lighthouse-agent.submariner.io"
 )

--- a/pkg/serviceimport/map.go
+++ b/pkg/serviceimport/map.go
@@ -59,8 +59,9 @@ func (si *serviceInfo) resetLoadBalancing() {
 }
 
 type Map struct {
-	svcMap map[string]*serviceInfo
-	mutex  sync.RWMutex
+	svcMap         map[string]*serviceInfo
+	localClusterID string
+	mutex          sync.RWMutex
 }
 
 func (m *Map) selectIP(si *serviceInfo, name, namespace string, checkCluster func(string) bool,
@@ -120,9 +121,10 @@ func (m *Map) GetIP(namespace, name, cluster, localCluster string, checkCluster 
 	return nil, true, false
 }
 
-func NewMap() *Map {
+func NewMap(localClusterID string) *Map {
 	return &Map{
-		svcMap: make(map[string]*serviceInfo),
+		svcMap:         make(map[string]*serviceInfo),
+		localClusterID: localClusterID,
 	}
 }
 
@@ -157,7 +159,7 @@ func (m *Map) Put(serviceImport *mcsv1a1.ServiceImport) {
 			remoteService.records[clusterName] = &clusterInfo{
 				name:   clusterName,
 				record: record,
-				weight: getServiceWeightFrom(serviceImport, clusterName),
+				weight: getServiceWeightFrom(serviceImport, m.localClusterID),
 			}
 		}
 
@@ -195,14 +197,14 @@ func (m *Map) Remove(serviceImport *mcsv1a1.ServiceImport) {
 }
 
 func getServiceWeightFrom(si *mcsv1a1.ServiceImport, forClusterName string) int64 {
-	weightKey := "load-balancer.submariner.io/weight/" + forClusterName
-	if val, ok := si.Annotations[weightKey]; ok {
+	weightKey := lhconstants.LoadBalancerWeightAnnotationPrefix + "/" + forClusterName
+	if val, ok := si.GetAnnotations()[weightKey]; ok {
 		f, err := strconv.ParseInt(val, 0, 64)
 		if err != nil {
 			return f
 		}
 
-		klog.Errorf("Error: %v parsing the \"load-balancer.submariner.io/weight\" annotation from ServiceImport %q", err, si.Name)
+		klog.Errorf("Error: %v parsing the %q annotation from ServiceImport %q", err, weightKey, si.Name)
 	}
 
 	return 1 // Zero will cause no selection

--- a/pkg/serviceimport/map_test.go
+++ b/pkg/serviceimport/map_test.go
@@ -25,15 +25,16 @@ import (
 
 var _ = Describe("ServiceImport Map", func() {
 	const (
-		service1   = "service1"
-		namespace1 = "namespace1"
-		namespace2 = "namespace2"
-		serviceIP1 = "192.168.56.21"
-		serviceIP2 = "192.168.56.22"
-		serviceIP3 = "192.168.56.23"
-		clusterID1 = "clusterID1"
-		clusterID2 = "clusterID2"
-		clusterID3 = "clusterID3"
+		service1       = "service1"
+		namespace1     = "namespace1"
+		namespace2     = "namespace2"
+		serviceIP1     = "192.168.56.21"
+		serviceIP2     = "192.168.56.22"
+		serviceIP3     = "192.168.56.23"
+		localClusterID = "local"
+		clusterID1     = "clusterID1"
+		clusterID2     = "clusterID2"
+		clusterID3     = "clusterID3"
 	)
 
 	var (
@@ -44,7 +45,7 @@ var _ = Describe("ServiceImport Map", func() {
 
 	BeforeEach(func() {
 		clusterStatusMap = map[string]bool{clusterID1: true, clusterID2: true, clusterID3: true}
-		serviceImportMap = serviceimport.NewMap()
+		serviceImportMap = serviceimport.NewMap(localClusterID)
 		endpointStatusMap = map[string]bool{clusterID1: true, clusterID2: true, clusterID3: true}
 	})
 

--- a/plugin/lighthouse/handler_test.go
+++ b/plugin/lighthouse/handler_test.go
@@ -39,23 +39,24 @@ import (
 )
 
 const (
-	service1    = "service1"
-	namespace1  = "namespace1"
-	namespace2  = "namespace2"
-	serviceIP   = "100.96.156.101"
-	serviceIP2  = "100.96.156.102"
-	clusterID   = "cluster1"
-	clusterID2  = "cluster2"
-	endpointIP  = "100.96.157.101"
-	endpointIP2 = "100.96.157.102"
-	portName1   = "http"
-	portName2   = "dns"
-	protocol1   = v1.ProtocolTCP
-	portNumber1 = int32(8080)
-	protocol2   = v1.ProtocolUDP
-	portNumber2 = int32(53)
-	hostName1   = "hostName1"
-	hostName2   = "hostName2"
+	service1       = "service1"
+	namespace1     = "namespace1"
+	namespace2     = "namespace2"
+	serviceIP      = "100.96.156.101"
+	serviceIP2     = "100.96.156.102"
+	localClusterID = "local"
+	clusterID      = "cluster1"
+	clusterID2     = "cluster2"
+	endpointIP     = "100.96.157.101"
+	endpointIP2    = "100.96.157.102"
+	portName1      = "http"
+	portName2      = "dns"
+	protocol1      = v1.ProtocolTCP
+	portNumber1    = int32(8080)
+	protocol2      = v1.ProtocolUDP
+	portNumber2    = int32(53)
+	hostName1      = "hostName1"
+	hostName2      = "hostName2"
 )
 
 var _ = Describe("Lighthouse DNS plugin Handler", func() {
@@ -1016,7 +1017,7 @@ func (t *handlerTestDriver) executeTestCase(rec *dnstest.Recorder, tc test.Case)
 }
 
 func setupServiceImportMap() *serviceimport.Map {
-	siMap := serviceimport.NewMap()
+	siMap := serviceimport.NewMap(localClusterID)
 	siMap.Put(newServiceImport(namespace1, service1, clusterID, serviceIP, portName1, portNumber1, protocol1, mcsv1a1.ClusterSetIP))
 
 	return siMap

--- a/plugin/lighthouse/setup.go
+++ b/plugin/lighthouse/setup.go
@@ -73,7 +73,14 @@ func lighthouseParse(c *caddy.Controller) (*Lighthouse, error) {
 		return nil, errors.Wrap(err, "error building kubeconfig")
 	}
 
-	siMap := serviceimport.NewMap()
+	gwController := gateway.NewController()
+
+	err = gwController.Start(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "error starting the Gateway controller")
+	}
+
+	siMap := serviceimport.NewMap(gwController.LocalClusterID())
 	siController := serviceimport.NewController(siMap)
 
 	err = siController.Start(cfg)
@@ -87,13 +94,6 @@ func lighthouseParse(c *caddy.Controller) (*Lighthouse, error) {
 	err = epController.Start(cfg)
 	if err != nil {
 		return nil, errors.Wrap(err, "error starting the EndpointSlice controller")
-	}
-
-	gwController := gateway.NewController()
-
-	err = gwController.Start(cfg)
-	if err != nil {
-		return nil, errors.Wrap(err, "error starting the Gateway controller")
 	}
 
 	svcController := service.NewController(gwController.LocalClusterID())


### PR DESCRIPTION
Signed-off-by: Daniel Bachar <danibachar89@gmail.com>

After debating a bit in the group I have decided to remove the need for a new CRD and support weights distribution through the ServiceExport annotations as was originally suggested.

The explanation is described in the EP - https://github.com/submariner-io/enhancements/pull/2
Link to the explanation - https://github.com/danibachar/enhancements/blob/feature/lighthouse/lighthouse/service-selection/multi-cluster-service-selection.md#serviceweightpolicy-distribution

TL;DR - I based the idea on the Istio LocalityLoadBalancerSetting https://istio.io/latest/docs/reference/config/networking/destination-rule/#LocalityLoadBalancerSetting

This PR makes - https://github.com/submariner-io/lighthouse/pull/648 - obsolete and it will be closed

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
