### PR TITLE
Build images without Dapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ bin/lighthouse-coredns: coredns/vendor/modules.txt $(shell find coredns)
 	cd coredns && ${SCRIPTS_DIR}/compile.sh $@ . $(BUILD_ARGS)
 	mv coredns/$@ $@
 
+e2e: vendor/modules.txt
+
 licensecheck: BUILD_ARGS=--noupx
 licensecheck: $(BINARIES) bin/lichen
 	bin/lichen -c .lichen.yaml $(BINARIES)

--- a/package/Dockerfile.lighthouse-agent
+++ b/package/Dockerfile.lighthouse-agent
@@ -1,7 +1,20 @@
+ARG BASE_BRANCH
+ARG SOURCE=/go/src/github.com/submariner-io/lighthouse
+ARG TARGETPLATFORM=linux/amd64
+
+FROM quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder
+ARG SOURCE
+ARG TARGETPLATFORM
+
+COPY . ${SOURCE}
+
+RUN make -C ${SOURCE} LOCAL_BUILD=1 bin/lighthouse-agent
+
 FROM scratch
+ARG SOURCE
 
 WORKDIR /var/submariner
 
-COPY bin/lighthouse-agent /usr/local/bin/
+COPY --from=builder ${SOURCE}/bin/lighthouse-agent /usr/local/bin/
 
 ENTRYPOINT ["/usr/local/bin/lighthouse-agent", "-alsologtostderr"]

--- a/package/Dockerfile.lighthouse-coredns
+++ b/package/Dockerfile.lighthouse-coredns
@@ -1,11 +1,25 @@
-FROM debian:stable-slim
+ARG BASE_BRANCH
+ARG SOURCE=/go/src/github.com/submariner-io/lighthouse
+ARG TARGETPLATFORM=linux/amd64
+
+FROM quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder
+ARG SOURCE
+ARG TARGETPLATFORM
+
+COPY . ${SOURCE}
+
+RUN make -C ${SOURCE} LOCAL_BUILD=1 bin/lighthouse-coredns
+
+FROM debian:stable-slim AS certificates
+ARG SOURCE
 
 RUN apt-get update && apt-get -y install ca-certificates && update-ca-certificates
 
 FROM scratch
+ARG SOURCE
 
-COPY --from=0 /etc/ssl/certs /etc/ssl/certs
-COPY bin/lighthouse-coredns /usr/local/bin/
+COPY --from=certificates /etc/ssl/certs /etc/ssl/certs
+COPY --from=builder ${SOURCE}/bin/lighthouse-coredns /usr/local/bin/
 
 EXPOSE 53 53/udp
 EXPOSE 9153 9153/tcp


### PR DESCRIPTION
We can achieve the same effect as running with Dapper, without Dapper,
by building images in multiple stages. The first stage runs in a
container built from our Shipyard base image, and subsequent stages
build our deliverable images.

This gives us more flexibility when changing build systems (building
containers within containers doesn't work well everywhere). It also
allows us to build the right binaries for multi-arch builds (since the
binary is built inside the container on the target platform).

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
