### PR TITLE
Make services without selectors resolvable across clusterset

### DIFF
--- a/pkg/agent/controller/serviceimport.go
+++ b/pkg/agent/controller/serviceimport.go
@@ -24,7 +24,6 @@ import (
 	"github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/watcher"
 	lhconstants "github.com/submariner-io/lighthouse/pkg/constants"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
@@ -109,23 +108,6 @@ func (c *ServiceImportController) serviceImportCreatedOrUpdated(serviceImport *m
 	annotations := serviceImport.ObjectMeta.Annotations
 	serviceNameSpace := annotations[lhconstants.OriginNamespace]
 	serviceName := annotations[lhconstants.OriginName]
-
-	obj, found, err := c.serviceSyncer.GetResource(serviceName, serviceNameSpace)
-	if err != nil {
-		klog.Errorf("Error retrieving the service  %q from the namespace %q : %v", serviceName, serviceNameSpace, err)
-
-		return true
-	}
-
-	if !found {
-		return false
-	}
-
-	service := obj.(*corev1.Service)
-	if service.Spec.Selector == nil {
-		klog.Errorf("The service %s/%s without a Selector is not supported", serviceNameSpace, serviceName)
-		return false
-	}
 
 	endpointController, err := startEndpointController(c.localClient, c.restMapper, c.scheme,
 		serviceImport, serviceNameSpace, serviceName, c.clusterID, c.globalIngressIPCache)


### PR DESCRIPTION
Fixes https://github.com/submariner-io/lighthouse/issues/603

The lighthouse code was explicitly checking for and preventing
services from being advertised if they didn't have a selector.
This commit removes that check.

Note: services without selectors are not reachble from other
clusters when using Globalnet until the following issue is
fixed: https://github.com/submariner-io/submariner/issues/1693
However, the above issue description provides a work-around.

Signed-off-by: Andre Fredette <afredette@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
