### PR TITLE
Track framework.ExecWithOptions changes in shipyard

### DIFF
--- a/test/e2e/discovery/headless_services.go
+++ b/test/e2e/discovery/headless_services.go
@@ -256,7 +256,7 @@ func verifyHeadlessIpsWithDig(f *framework.Framework, cluster framework.ClusterI
 
 	By(fmt.Sprintf("Executing %q to verify IPs %v for service %q %q discoverable", strings.Join(cmd, " "), ipList, service.Name, op))
 	framework.AwaitUntil(" service IP verification", func() (interface{}, error) {
-		stdout, _, err := f.ExecWithOptions(framework.ExecOptions{
+		stdout, _, err := f.ExecWithOptions(&framework.ExecOptions{
 			Command:       cmd,
 			Namespace:     f.Namespace,
 			PodName:       targetPod.Items[0].Name,
@@ -306,7 +306,7 @@ func verifyHeadlessSRVRecordsWithDig(f *framework.Framework, cluster framework.C
 			By(fmt.Sprintf("Executing %q to verify hostNames %v for service %q %q discoverable",
 				strings.Join(cmd, " "), hostNameList, service.Name, op))
 			framework.AwaitUntil(" service IP verification", func() (interface{}, error) {
-				stdout, _, err := f.ExecWithOptions(framework.ExecOptions{
+				stdout, _, err := f.ExecWithOptions(&framework.ExecOptions{
 					Command:       cmd,
 					Namespace:     f.Namespace,
 					PodName:       targetPod.Items[0].Name,

--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -549,7 +549,7 @@ func verifySRVWithDig(f *framework.Framework, srcCluster framework.ClusterIndex,
 			By(fmt.Sprintf("Executing %q to verify SRV record for service %q %q discoverable", strings.Join(cmd, " "),
 				service.Name, op))
 			framework.AwaitUntil("verify if service Ports is discoverable", func() (interface{}, error) {
-				stdout, _, err := f.ExecWithOptions(framework.ExecOptions{
+				stdout, _, err := f.ExecWithOptions(&framework.ExecOptions{
 					Command:       cmd,
 					Namespace:     f.Namespace,
 					PodName:       targetPod.Items[0].Name,
@@ -604,7 +604,7 @@ func verifyRoundRobinWithDig(f *framework.Framework, srcCluster framework.Cluste
 
 	for count := 0; count < 10; count++ {
 		framework.AwaitUntil("verify if service IP is discoverable", func() (interface{}, error) {
-			stdout, _, err := f.ExecWithOptions(framework.ExecOptions{
+			stdout, _, err := f.ExecWithOptions(&framework.ExecOptions{
 				Command:       cmd,
 				Namespace:     f.Namespace,
 				PodName:       targetPod.Items[0].Name,
@@ -646,7 +646,7 @@ func getClusterDomain(f *framework.Framework, cluster framework.ClusterIndex, ta
 	*/
 	cmd := []string{"cat", "/etc/resolv.conf"}
 
-	if stdout, _, err := f.ExecWithOptions(framework.ExecOptions{
+	if stdout, _, err := f.ExecWithOptions(&framework.ExecOptions{
 		Command:       cmd,
 		Namespace:     f.Namespace,
 		PodName:       targetPod.Items[0].Name,

--- a/test/e2e/discovery/statefulsets.go
+++ b/test/e2e/discovery/statefulsets.go
@@ -225,7 +225,7 @@ func verifyEndpointsWithDig(f *framework.Framework, targetCluster framework.Clus
 
 	By(fmt.Sprintf("Executing %q to verify IPs %v for pod %q %q discoverable", strings.Join(cmd, " "), endpoint.Addresses, query, op))
 	framework.AwaitUntil(" service IP verification", func() (interface{}, error) {
-		stdout, _, err := f.ExecWithOptions(framework.ExecOptions{
+		stdout, _, err := f.ExecWithOptions(&framework.ExecOptions{
 			Command:       cmd,
 			Namespace:     f.Namespace,
 			PodName:       targetPod.Items[0].Name,

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -570,7 +570,7 @@ func (f *Framework) VerifyIPWithDig(srcCluster framework.ClusterIndex, service *
 
 	By(fmt.Sprintf("Executing %q to verify IP %q for service %q %q discoverable", strings.Join(cmd, " "), serviceIP, service.Name, op))
 	framework.AwaitUntil("verify if service IP is discoverable", func() (interface{}, error) {
-		stdout, _, err := f.ExecWithOptions(framework.ExecOptions{
+		stdout, _, err := f.ExecWithOptions(&framework.ExecOptions{
 			Command:       cmd,
 			Namespace:     f.Namespace,
 			PodName:       targetPod.Items[0].Name,


### PR DESCRIPTION
Shipyard's definition changed to accept pointer, not struct (large struct lint error),
reflecting this change into lighthouse

Signed-off-by: Etai Lev Ran <etail@il.ibm.com>