### PR TITLE
Adjust to Shipyard framework changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/submariner-io/admiral v0.12.0-m3.0.20220211050139-69a40598bdd6
-	github.com/submariner-io/shipyard v0.12.0-m3
+	github.com/submariner-io/shipyard v0.12.0-m3.0.20220217165059-b87e9080b8d1
 	github.com/uw-labs/lichen v0.1.5
 	k8s.io/api v0.21.0
 	k8s.io/apimachinery v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -750,8 +750,9 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/submariner-io/admiral v0.12.0-m3.0.20220211050139-69a40598bdd6 h1:RMgMytzHKdn4giyMDnu9oFmT40ea0NX75HcttQCoL/U=
 github.com/submariner-io/admiral v0.12.0-m3.0.20220211050139-69a40598bdd6/go.mod h1:hFPcxH0gAr559/qK7ri10Yh1wyeK6yzow1PIqtBk+30=
-github.com/submariner-io/shipyard v0.12.0-m3 h1:kMVYrEPLEH9KyAHp49bmVEVsukfrIWWIqgsqgNII4nc=
 github.com/submariner-io/shipyard v0.12.0-m3/go.mod h1:el/lH6ed/1BN1FvEXlptiib7qT2cTwEQ4AMceH3js9g=
+github.com/submariner-io/shipyard v0.12.0-m3.0.20220217165059-b87e9080b8d1 h1:MY/4ZJfGgw1NN02toflab3k6s5cFtpXwDjlXZy3Bqyw=
+github.com/submariner-io/shipyard v0.12.0-m3.0.20220217165059-b87e9080b8d1/go.mod h1:i3KjrLOHgG1uL+OeYolFNV1BmaOGlh2jEMQfNKtXOAo=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/timewasted/linode v0.0.0-20160829202747-37e84520dcf7/go.mod h1:imsgLplxEC/etjIhdr3dNzV3JeT27LbVu5pYWm0JCBY=
 github.com/tinylib/msgp v1.1.2 h1:gWmO7n0Ys2RBEb7GPYB9Ujq8Mk5p2U08lRnmMcGy6BQ=

--- a/test/e2e/discovery/headless_services.go
+++ b/test/e2e/discovery/headless_services.go
@@ -256,7 +256,7 @@ func verifyHeadlessIpsWithDig(f *framework.Framework, cluster framework.ClusterI
 
 	By(fmt.Sprintf("Executing %q to verify IPs %v for service %q %q discoverable", strings.Join(cmd, " "), ipList, service.Name, op))
 	framework.AwaitUntil(" service IP verification", func() (interface{}, error) {
-		stdout, _, err := f.ExecWithOptions(framework.ExecOptions{
+		stdout, _, err := f.ExecWithOptions(&framework.ExecOptions{
 			Command:       cmd,
 			Namespace:     f.Namespace,
 			PodName:       targetPod.Items[0].Name,
@@ -306,7 +306,7 @@ func verifyHeadlessSRVRecordsWithDig(f *framework.Framework, cluster framework.C
 			By(fmt.Sprintf("Executing %q to verify hostNames %v for service %q %q discoverable",
 				strings.Join(cmd, " "), hostNameList, service.Name, op))
 			framework.AwaitUntil(" service IP verification", func() (interface{}, error) {
-				stdout, _, err := f.ExecWithOptions(framework.ExecOptions{
+				stdout, _, err := f.ExecWithOptions(&framework.ExecOptions{
 					Command:       cmd,
 					Namespace:     f.Namespace,
 					PodName:       targetPod.Items[0].Name,

--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -549,7 +549,7 @@ func verifySRVWithDig(f *framework.Framework, srcCluster framework.ClusterIndex,
 			By(fmt.Sprintf("Executing %q to verify SRV record for service %q %q discoverable", strings.Join(cmd, " "),
 				service.Name, op))
 			framework.AwaitUntil("verify if service Ports is discoverable", func() (interface{}, error) {
-				stdout, _, err := f.ExecWithOptions(framework.ExecOptions{
+				stdout, _, err := f.ExecWithOptions(&framework.ExecOptions{
 					Command:       cmd,
 					Namespace:     f.Namespace,
 					PodName:       targetPod.Items[0].Name,
@@ -604,7 +604,7 @@ func verifyRoundRobinWithDig(f *framework.Framework, srcCluster framework.Cluste
 
 	for count := 0; count < 10; count++ {
 		framework.AwaitUntil("verify if service IP is discoverable", func() (interface{}, error) {
-			stdout, _, err := f.ExecWithOptions(framework.ExecOptions{
+			stdout, _, err := f.ExecWithOptions(&framework.ExecOptions{
 				Command:       cmd,
 				Namespace:     f.Namespace,
 				PodName:       targetPod.Items[0].Name,
@@ -646,7 +646,7 @@ func getClusterDomain(f *framework.Framework, cluster framework.ClusterIndex, ta
 	*/
 	cmd := []string{"cat", "/etc/resolv.conf"}
 
-	if stdout, _, err := f.ExecWithOptions(framework.ExecOptions{
+	if stdout, _, err := f.ExecWithOptions(&framework.ExecOptions{
 		Command:       cmd,
 		Namespace:     f.Namespace,
 		PodName:       targetPod.Items[0].Name,

--- a/test/e2e/discovery/statefulsets.go
+++ b/test/e2e/discovery/statefulsets.go
@@ -225,7 +225,7 @@ func verifyEndpointsWithDig(f *framework.Framework, targetCluster framework.Clus
 
 	By(fmt.Sprintf("Executing %q to verify IPs %v for pod %q %q discoverable", strings.Join(cmd, " "), endpoint.Addresses, query, op))
 	framework.AwaitUntil(" service IP verification", func() (interface{}, error) {
-		stdout, _, err := f.ExecWithOptions(framework.ExecOptions{
+		stdout, _, err := f.ExecWithOptions(&framework.ExecOptions{
 			Command:       cmd,
 			Namespace:     f.Namespace,
 			PodName:       targetPod.Items[0].Name,

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -570,7 +570,7 @@ func (f *Framework) VerifyIPWithDig(srcCluster framework.ClusterIndex, service *
 
 	By(fmt.Sprintf("Executing %q to verify IP %q for service %q %q discoverable", strings.Join(cmd, " "), serviceIP, service.Name, op))
 	framework.AwaitUntil("verify if service IP is discoverable", func() (interface{}, error) {
-		stdout, _, err := f.ExecWithOptions(framework.ExecOptions{
+		stdout, _, err := f.ExecWithOptions(&framework.ExecOptions{
 			Command:       cmd,
 			Namespace:     f.Namespace,
 			PodName:       targetPod.Items[0].Name,


### PR DESCRIPTION
Shipyard commit f506ea3c ("Enabled gocritic, fix issues") changed
ExecWithOptions to expect options as a pointer.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
