### PR TITLE
Replace `klog` with `zerolog` for human-friendly logging in Lighthouse Agent

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -692,6 +692,7 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
+github.com/rs/zerolog v1.26.1 h1:/ihwxqH+4z8UxyI70wM1z9yCvkWcfz/a3mj48k/Zngc=
 github.com/rs/zerolog v1.26.1/go.mod h1:/wSSJWX7lVrsOwlbyTRSOJvqRlc+WjWlfes+CiJ+tmc=
 github.com/russross/blackfriday v0.0.0-20170610170232-067529f716f4/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=

--- a/pkg/agent/controller/controller_suite_test.go
+++ b/pkg/agent/controller/controller_suite_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"crypto/rand"
 	"errors"
+	"flag"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -32,6 +33,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 	"github.com/submariner-io/admiral/pkg/fake"
+	"github.com/submariner-io/admiral/pkg/log/kzerolog"
 	"github.com/submariner-io/admiral/pkg/syncer/broker"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
 	"github.com/submariner-io/lighthouse/pkg/agent/controller"
@@ -48,7 +50,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	fakeKubeClient "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/klog"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
@@ -69,7 +70,12 @@ var (
 )
 
 func init() {
-	klog.InitFlags(nil)
+	// set logging verbosity of agent in unit test to DEBUG
+	flags := flag.NewFlagSet("kzerolog", flag.ExitOnError)
+	kzerolog.AddFlags(flags)
+	// nolint:errcheck // Ignore errors; CommandLine is set for ExitOnError.
+	flags.Parse([]string{"-v=2"})
+	kzerolog.InitK8sLogging()
 
 	err := mcsv1a1.AddToScheme(scheme.Scheme)
 	if err != nil {

--- a/pkg/agent/controller/globalingressip.go
+++ b/pkg/agent/controller/globalingressip.go
@@ -19,7 +19,6 @@ package controller
 
 import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/klog"
 )
 
 const (
@@ -48,7 +47,7 @@ func parseIngressIP(obj *unstructured.Unstructured) *IngressIP {
 
 	gip.target, found, err = unstructured.NestedString(obj.Object, "spec", "target")
 	if !found || err != nil {
-		klog.Errorf("target field not found in spec %#v", obj.Object)
+		logger.Error(nil, "target field not found in spec", "value", obj.Object)
 		return nil
 	}
 

--- a/pkg/agent/controller/serviceimport.go
+++ b/pkg/agent/controller/serviceimport.go
@@ -18,6 +18,8 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/federate"
 	"github.com/submariner-io/admiral/pkg/log"
@@ -28,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
@@ -85,7 +86,7 @@ func (c *ServiceImportController) start(stopCh <-chan struct{}) error {
 			return true
 		})
 
-		klog.Infof("ServiceImport Controller stopped")
+		logger.Info("ServiceImport Controller stopped")
 	}()
 
 	if err := c.serviceImportSyncer.Start(stopCh); err != nil {
@@ -97,7 +98,7 @@ func (c *ServiceImportController) start(stopCh <-chan struct{}) error {
 
 func (c *ServiceImportController) serviceImportCreatedOrUpdated(serviceImport *mcsv1a1.ServiceImport, key string) bool {
 	if _, found := c.endpointControllers.Load(key); found {
-		klog.V(log.DEBUG).Infof("The endpoint controller is already running for %q", key)
+		logger.V(log.DEBUG).Info("The endpoint controller is already running", "key", key)
 		return false
 	}
 
@@ -112,7 +113,7 @@ func (c *ServiceImportController) serviceImportCreatedOrUpdated(serviceImport *m
 	endpointController, err := startEndpointController(c.localClient, c.restMapper, c.scheme,
 		serviceImport, serviceNameSpace, serviceName, c.clusterID, c.globalIngressIPCache)
 	if err != nil {
-		klog.Errorf(err.Error())
+		logger.Error(err, "Failed to start endpoint controller")
 		return true
 	}
 
@@ -138,7 +139,7 @@ func (c *ServiceImportController) serviceImportToEndpointController(obj runtime.
 	serviceImport := obj.(*mcsv1a1.ServiceImport)
 	key, _ := cache.MetaNamespaceKeyFunc(serviceImport)
 
-	klog.V(log.DEBUG).Infof("ServiceImport %q %sd", key, op)
+	logger.V(log.DEBUG).Info(fmt.Sprintf("ServiceImport %s %sd", key, op))
 
 	if op == syncer.Create || op == syncer.Update {
 		return nil, c.serviceImportCreatedOrUpdated(serviceImport, key)

--- a/pkg/agent/main.go
+++ b/pkg/agent/main.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/submariner-io/admiral/pkg/log"
+	"github.com/submariner-io/admiral/pkg/log/kzerolog"
 	"github.com/submariner-io/admiral/pkg/syncer/broker"
 	"github.com/submariner-io/admiral/pkg/util"
 	"github.com/submariner-io/lighthouse/pkg/agent/controller"
@@ -35,6 +37,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
@@ -42,60 +45,75 @@ import (
 var (
 	masterURL  string
 	kubeConfig string
+	help       = false
+	logger     = logf.Log.WithName("main")
 )
 
-func main() {
-	agentSpec := controller.AgentSpecification{}
+func init() {
+	flag.BoolVar(&help, "help", help, "Print usage options")
+}
 
+func exitOnError(err error, reason string) {
+	if err == nil {
+		return
+	}
+
+	logger.Error(err, "Failed to initialize.", "reason", reason)
+	os.Exit(255)
+}
+
+func main() {
 	// Handle environment variables:
 	// SUBMARINER_VERBOSITY determines the verbosity level (1 by default)
 	// SUBMARINER_DEBUG, if set to true, sets the verbosity level to 3
 	if debug := os.Getenv("SUBMARINER_DEBUG"); debug == "true" {
-		os.Args = append(os.Args, "-v=3")
+		os.Args = append(os.Args, fmt.Sprintf("-v=%d", log.LIBDEBUG))
 	} else if verbosity := os.Getenv("SUBMARINER_VERBOSITY"); verbosity != "" {
 		os.Args = append(os.Args, fmt.Sprintf("-v=%s", verbosity))
 	} else {
-		os.Args = append(os.Args, "-v=2")
+		os.Args = append(os.Args, fmt.Sprintf("-v=%d", log.DEBUG))
 	}
 
-	klog.InitFlags(nil)
-
+	kzerolog.AddFlags(nil)
 	flag.Parse()
 
-	err := envconfig.Process("submariner", &agentSpec)
-	if err != nil {
-		klog.Fatal(err)
+	if help {
+		flag.PrintDefaults()
+		return
 	}
 
-	klog.Infof("Arguments: %v", os.Args)
-	klog.Infof("AgentSpec: %v", agentSpec)
+	kzerolog.InitK8sLogging()
+
+	// initialize klog as well, since some internal k8s packages still log with klog directly
+	// we want at least the verbosity level to match what was requested
+	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
+	klog.InitFlags(klogFlags)
+	// nolint:errcheck // Ignore errors; CommandLine is set for ExitOnError.
+	klogFlags.Parse(os.Args[1:])
+
+	logger.Info("Arguments", "value", os.Args)
+
+	agentSpec := controller.AgentSpecification{}
+	err := envconfig.Process("submariner", &agentSpec)
+	exitOnError(err, "Error processing env config for agent spec")
+	logger.Info("AgentSpec", "value", agentSpec)
 
 	err = mcsv1a1.AddToScheme(scheme.Scheme)
-	if err != nil {
-		klog.Exitf("Error adding Multicluster v1alpha1 to the scheme: %v", err)
-	}
+	exitOnError(err, "Error adding Multicluster v1alpha1 to the scheme")
 
 	cfg, err := clientcmd.BuildConfigFromFlags(masterURL, kubeConfig)
-	if err != nil {
-		klog.Fatalf("Error building kubeconfig: %s", err.Error())
-	}
+	exitOnError(err, "Error building kubeconfig")
 
 	kubeClientSet, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		klog.Fatalf("Error building clientset: %s", err.Error())
-	}
+	exitOnError(err, "Error building clientset")
 
 	restMapper, err := util.BuildRestMapper(cfg)
-	if err != nil {
-		klog.Fatal(err.Error())
-	}
+	exitOnError(err, "Error building rest mapper")
 
 	localClient, err := dynamic.NewForConfig(cfg)
-	if err != nil {
-		klog.Fatalf("error creating dynamic client: %v", err)
-	}
+	exitOnError(err, "Error creating dynamic client")
 
-	klog.Infof("Starting submariner-lighthouse-agent %v", agentSpec)
+	logger.Info("Starting submariner-lighthouse-agent")
 
 	// set up signals so we handle the first shutdown signal gracefully
 	ctx := signals.SetupSignalHandler()
@@ -110,33 +128,28 @@ func main() {
 			ServiceImportCounterName: "submariner_service_import",
 			ServiceExportCounterName: "submariner_service_export",
 		})
-	if err != nil {
-		klog.Fatalf("Failed to create lighthouse agent: %v", err)
-	}
+	exitOnError(err, "Failed to create lighthouse agent")
 
 	if agentSpec.Uninstall {
-		klog.Info("Uninstalling lighthouse")
+		logger.Info("Uninstalling lighthouse")
 
 		err := lightHouseAgent.Cleanup()
-		if err != nil {
-			klog.Fatalf("Error cleaning up the lighthouse agent controller: %+v", err)
-		}
+		exitOnError(err, "Error cleaning up the lighthouse agent controller")
 
 		return
 	}
 
-	if err := lightHouseAgent.Start(ctx.Done()); err != nil {
-		klog.Fatalf("Failed to start lighthouse agent: %v", err)
-	}
+	err = lightHouseAgent.Start(ctx.Done())
+	exitOnError(err, "Failed to start lighthouse agent")
 
 	httpServer := startHTTPServer()
 
 	<-ctx.Done()
 
-	klog.Info("All controllers stopped or exited. Stopping main loop")
+	logger.Info("All controllers stopped or exited. Stopping main loop")
 
 	if err := httpServer.Shutdown(context.TODO()); err != nil {
-		klog.Errorf("Error shutting down metrics HTTP server: %v", err)
+		logger.Error(err, "Error shutting down metrics HTTP server")
 	}
 }
 
@@ -153,7 +166,7 @@ func startHTTPServer() *http.Server {
 
 	go func() {
 		if err := srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-			klog.Errorf("Error starting metrics server: %v", err)
+			logger.Error(err, "Error starting metrics server")
 		}
 	}()
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/27995472/155492526-f43052e3-165d-4c81-af72-49906db00033.png)

Using `kzerolog` package from `admiral`
All log prints in the agent  were translated manually to use the  [logr](https://github.com/go-logr/logr) interface that is used in [contoller-runtime](https://github.com/kubernetes-sigs/controller-runtime/blob/master/TMP-LOGGING.md).
This required some adaptations since `logr` API is minimalistic and structured (no FATAL level, no WARN level, no format strings..)

Note: some internal k8s packages uses `klog` directly, so few logs may still be printed in the klog format as seen in the image above. 

