### PR TITLE
Build Lighthouse images for x86-64 and ARM64

### DIFF
--- a/.github/workflows/multiarch.yml
+++ b/.github/workflows/multiarch.yml
@@ -1,0 +1,19 @@
+---
+name: Multi-arch Builds
+
+on:
+  pull_request:
+
+jobs:
+  check-multiarch:
+    name: Check the multi-arch builds
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - name: Set up QEMU (to support building on non-native architectures)
+        uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8
+      - name: Build the multi-arch images
+        run: make multiarch-images
+      - name: Check that we actually build multi-arch images
+        run: bash -c '[ "$(echo package/*.tar)" != "package/*.tar" ]'

--- a/package/Dockerfile.lighthouse-agent
+++ b/package/Dockerfile.lighthouse-agent
@@ -1,20 +1,20 @@
 ARG BASE_BRANCH
 ARG SOURCE=/go/src/github.com/submariner-io/lighthouse
-ARG TARGETPLATFORM=linux/amd64
 
-FROM quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder
+FROM --platform=${BUILDPLATFORM} quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder
 ARG SOURCE
 ARG TARGETPLATFORM
 
 COPY . ${SOURCE}
 
-RUN make -C ${SOURCE} LOCAL_BUILD=1 bin/lighthouse-agent
+RUN make -C ${SOURCE} LOCAL_BUILD=1 bin/${TARGETPLATFORM}/lighthouse-agent
 
-FROM scratch
+FROM --platform=${TARGETPLATFORM} scratch
 ARG SOURCE
+ARG TARGETPLATFORM
 
 WORKDIR /var/submariner
 
-COPY --from=builder ${SOURCE}/bin/lighthouse-agent /usr/local/bin/
+COPY --from=builder ${SOURCE}/bin/${TARGETPLATFORM}/lighthouse-agent /usr/local/bin/
 
 ENTRYPOINT ["/usr/local/bin/lighthouse-agent", "-alsologtostderr"]

--- a/package/Dockerfile.lighthouse-coredns
+++ b/package/Dockerfile.lighthouse-coredns
@@ -1,25 +1,26 @@
 ARG BASE_BRANCH
 ARG SOURCE=/go/src/github.com/submariner-io/lighthouse
-ARG TARGETPLATFORM=linux/amd64
 
-FROM quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder
+FROM --platform=${BUILDPLATFORM} quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder
 ARG SOURCE
 ARG TARGETPLATFORM
 
 COPY . ${SOURCE}
 
-RUN make -C ${SOURCE} LOCAL_BUILD=1 bin/lighthouse-coredns
+RUN make -C ${SOURCE} LOCAL_BUILD=1 bin/${TARGETPLATFORM}/lighthouse-coredns
 
-FROM debian:stable-slim AS certificates
+FROM --platform=${TARGETPLATFORM} debian:stable-slim AS certificates
 ARG SOURCE
+ARG TARGETPLATFORM
 
 RUN apt-get update && apt-get -y install ca-certificates && update-ca-certificates
 
-FROM scratch
+FROM --platform=${TARGETPLATFORM} scratch
 ARG SOURCE
+ARG TARGETPLATFORM
 
 COPY --from=certificates /etc/ssl/certs /etc/ssl/certs
-COPY --from=builder ${SOURCE}/bin/lighthouse-coredns /usr/local/bin/
+COPY --from=builder ${SOURCE}/bin/${TARGETPLATFORM}/lighthouse-coredns /usr/local/bin/
 
 EXPOSE 53 53/udp
 EXPOSE 9153 9153/tcp


### PR DESCRIPTION
This relies on cross-building support in the Shipyard base image and
project Makefiles to avoid having to provide a native Shipyard base
image (and slower compilation using QEMU). The final image build stage
relies on support for the target architecture however.

The TARGETPLATFORM default is dropped from the container definitions;
it is expected to be provided by the build environment (buildx
currently), and setting it prevents us from actually building foreign
images.

Depends on https://github.com/submariner-io/lighthouse/pull/683
Depends on https://github.com/submariner-io/shipyard/pull/721
Depends on https://github.com/submariner-io/shipyard/pull/728
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
