### PR TITLE
Add packagedoc-lint linting, fix errors

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -94,6 +94,15 @@ jobs:
       - name: Run markdownlint
         run: make markdownlint
 
+  packagedoc-lint:
+    name: Package Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+      - name: Run packagedoc-lint
+        run: make packagedoc-lint
+
   yaml-lint:
     name: YAML
     runs-on: ubuntu-latest

--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/agent/controller/controller_suite_test.go
+++ b/pkg/agent/controller/controller_suite_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller_test
 
 import (

--- a/pkg/agent/controller/endpoint.go
+++ b/pkg/agent/controller/endpoint.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/agent/controller/global_ingressip_cache.go
+++ b/pkg/agent/controller/global_ingressip_cache.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/agent/controller/globalingressip.go
+++ b/pkg/agent/controller/globalingressip.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/agent/controller/globalnet_test.go
+++ b/pkg/agent/controller/globalnet_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller_test
 
 import (

--- a/pkg/agent/controller/headless_service_test.go
+++ b/pkg/agent/controller/headless_service_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller_test
 
 import (

--- a/pkg/agent/controller/reconciliation_test.go
+++ b/pkg/agent/controller/reconciliation_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller_test
 
 import (

--- a/pkg/agent/controller/service_export_failures_test.go
+++ b/pkg/agent/controller/service_export_failures_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller_test
 
 import (

--- a/pkg/agent/controller/service_import_sync_test.go
+++ b/pkg/agent/controller/service_import_sync_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller_test
 
 import (

--- a/pkg/agent/controller/serviceimport.go
+++ b/pkg/agent/controller/serviceimport.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package controller
 
 import (

--- a/pkg/agent/main.go
+++ b/pkg/agent/main.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package main
 
 import (

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package constants
 
 const (

--- a/pkg/coredns/main.go
+++ b/pkg/coredns/main.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package main
 
 // build with external golang source code

--- a/pkg/endpointslice/controller.go
+++ b/pkg/endpointslice/controller.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package endpointslice
 
 import (

--- a/pkg/endpointslice/controller_test.go
+++ b/pkg/endpointslice/controller_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package endpointslice_test
 
 import (

--- a/pkg/endpointslice/map.go
+++ b/pkg/endpointslice/map.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package endpointslice
 
 import (

--- a/pkg/endpointslice/map_test.go
+++ b/pkg/endpointslice/map_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package endpointslice_test
 
 import (

--- a/pkg/endpointslice/suite_test.go
+++ b/pkg/endpointslice/suite_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package endpointslice_test
 
 import (

--- a/pkg/gateway/controller.go
+++ b/pkg/gateway/controller.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package gateway
 
 import (

--- a/pkg/gateway/controller_test.go
+++ b/pkg/gateway/controller_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package gateway_test
 
 import (

--- a/pkg/loadbalancer/balancer.go
+++ b/pkg/loadbalancer/balancer.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package loadbalancer
 
 // Interface - general interface explaining the API of all load balancers available in the package.

--- a/pkg/loadbalancer/smooth_weighted_round_robin.go
+++ b/pkg/loadbalancer/smooth_weighted_round_robin.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package loadbalancer
 
 import (

--- a/pkg/loadbalancer/smooth_weighted_round_robin_test.go
+++ b/pkg/loadbalancer/smooth_weighted_round_robin_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package loadbalancer_test
 
 import (

--- a/pkg/loadbalancer/suite_test.go
+++ b/pkg/loadbalancer/suite_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package loadbalancer_test
 
 import (

--- a/pkg/service/controller.go
+++ b/pkg/service/controller.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package service
 
 import (

--- a/pkg/serviceimport/controller.go
+++ b/pkg/serviceimport/controller.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package serviceimport
 
 import (

--- a/pkg/serviceimport/controller_test.go
+++ b/pkg/serviceimport/controller_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package serviceimport_test
 
 import (

--- a/pkg/serviceimport/map.go
+++ b/pkg/serviceimport/map.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package serviceimport
 
 import (

--- a/pkg/serviceimport/map_test.go
+++ b/pkg/serviceimport/map_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package serviceimport_test
 
 import (

--- a/pkg/serviceimport/store.go
+++ b/pkg/serviceimport/store.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package serviceimport
 
 import mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"

--- a/pkg/serviceimport/suite_test.go
+++ b/pkg/serviceimport/suite_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package serviceimport_test
 
 import (

--- a/plugin/lighthouse/handler.go
+++ b/plugin/lighthouse/handler.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package lighthouse
 
 import (

--- a/plugin/lighthouse/handler_test.go
+++ b/plugin/lighthouse/handler_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package lighthouse_test
 
 import (

--- a/plugin/lighthouse/lighthouse.go
+++ b/plugin/lighthouse/lighthouse.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package lighthouse
 
 import (

--- a/plugin/lighthouse/metrics.go
+++ b/plugin/lighthouse/metrics.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package lighthouse
 
 import (

--- a/plugin/lighthouse/parse.go
+++ b/plugin/lighthouse/parse.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package lighthouse
 
 import (

--- a/plugin/lighthouse/parse_internal_test.go
+++ b/plugin/lighthouse/parse_internal_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package lighthouse
 
 import (

--- a/plugin/lighthouse/plugin_suite_test.go
+++ b/plugin/lighthouse/plugin_suite_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package lighthouse_test
 
 import (

--- a/plugin/lighthouse/record.go
+++ b/plugin/lighthouse/record.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package lighthouse
 
 import (

--- a/plugin/lighthouse/setup.go
+++ b/plugin/lighthouse/setup.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package lighthouse
 
 import (

--- a/plugin/lighthouse/setup_internal_test.go
+++ b/plugin/lighthouse/setup_internal_test.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package lighthouse
 
 import (

--- a/test/e2e/discovery/headless_services.go
+++ b/test/e2e/discovery/headless_services.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package discovery
 
 import (

--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package discovery
 
 import (

--- a/test/e2e/discovery/statefulsets.go
+++ b/test/e2e/discovery/statefulsets.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package discovery
 
 import (

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package framework
 
 import (


### PR DESCRIPTION
The idea here is to make sure the license headers are detached from the
package declarations, as otherwise the headers are considered a part of
the package documentation and included with it.

Add per-PR job to maintain consistent standards across all repos.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>
(cherry picked from commit 70f817e8638938ebf900fd9d130db4cc235762aa)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
