### PR TITLE
Fix flaky agent controller test

### DIFF
--- a/pkg/agent/controller/endpoint.go
+++ b/pkg/agent/controller/endpoint.go
@@ -88,8 +88,10 @@ func startEndpointController(localClient dynamic.Interface, restMapper meta.REST
 }
 
 func (e *EndpointController) stop() {
-	close(e.stopCh)
-	e.cleanup()
+	e.stopOnce.Do(func() {
+		close(e.stopCh)
+		e.cleanup()
+	})
 }
 
 func (e *EndpointController) cleanup() {

--- a/pkg/agent/controller/serviceimport.go
+++ b/pkg/agent/controller/serviceimport.go
@@ -127,10 +127,9 @@ func (c *ServiceImportController) serviceImportDeleted(serviceImport *mcsv1a1.Se
 		return
 	}
 
-	if obj, found := c.endpointControllers.Load(key); found {
+	if obj, found := c.endpointControllers.LoadAndDelete(key); found {
 		endpointController := obj.(*EndpointController)
 		endpointController.stop()
-		c.endpointControllers.Delete(key)
 	}
 }
 

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -75,9 +75,10 @@ type EndpointController struct {
 	serviceName                  string
 	serviceImportSourceNameSpace string
 	stopCh                       chan struct{}
+	stopOnce                     sync.Once
+	isHeadless                   bool
 	localClient                  dynamic.Interface
 	ingressIPClient              dynamic.NamespaceableResourceInterface
-	isHeadless                   bool
 	globalIngressIPCache         *globalIngressIPCache
 }
 


### PR DESCRIPTION
Intermittent panic on test tear down:

```
panic: close of closed channel

goroutine 1191 [running]:
github.com/submariner-io/lighthouse/pkg/agent/controller.(*EndpointController).stop(0xc002d433b0)
	/go/src/github.com/submariner-io/lighthouse/pkg/agent/controller/endpoint.go:91 +0x6b
github.com/submariner-io/lighthouse/pkg/agent/controller.(*ServiceImportController).start.func1.1(0x1e49200, 0xc003667c30, 0x1f30800, 0xc002d433b0, 0x2)
	/go/src/github.com/submariner-io/lighthouse/pkg/agent/controller/serviceimport.go:85 +0x66
sync.(*Map).Range(0xc002c54ee0, 0x20ea288)
	/usr/lib/golang/src/sync/map.go:345 +0x16c
```

There's a race between the two code paths that call `stop`.
Synchronize access so that the code in `stop` is only executed once.
