### PR TITLE
Wrap parameter/return lists as expected by gofumpt

### DIFF
--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -58,7 +58,8 @@ type AgentConfig struct {
 
 // nolint:gocritic // (hugeParam) This function modifies syncerConf so we don't want to pass by pointer.
 func New(spec *AgentSpecification, syncerConf broker.SyncerConfig, kubeClientSet kubernetes.Interface,
-	syncerMetricNames AgentConfig) (*Controller, error) {
+	syncerMetricNames AgentConfig,
+) (*Controller, error) {
 	if errs := validations.IsDNS1123Label(spec.ClusterID); len(errs) > 0 {
 		return nil, errors.Errorf("%s is not a valid ClusterID %v", spec.ClusterID, errs)
 	}

--- a/pkg/agent/controller/controller_suite_test.go
+++ b/pkg/agent/controller/controller_suite_test.go
@@ -304,7 +304,8 @@ func (c *cluster) start(t *testDriver, syncerConfig broker.SyncerConfig) {
 }
 
 func awaitServiceImport(client dynamic.ResourceInterface, service *corev1.Service, sType mcsv1a1.ServiceImportType,
-	serviceIP string) *mcsv1a1.ServiceImport {
+	serviceIP string,
+) *mcsv1a1.ServiceImport {
 	obj := test.AwaitResource(client, service.Name+"-"+service.Namespace+"-"+clusterID1)
 
 	serviceImport := &mcsv1a1.ServiceImport{}
@@ -378,7 +379,8 @@ func (c *cluster) awaitUpdatedServiceImport(service *corev1.Service, serviceIP s
 }
 
 func awaitEndpointSlice(endpointSliceClient dynamic.ResourceInterface, endpoints *corev1.Endpoints,
-	service *corev1.Service, namespace string, globalIPs []string) *discovery.EndpointSlice {
+	service *corev1.Service, namespace string, globalIPs []string,
+) *discovery.EndpointSlice {
 	obj := test.AwaitResource(endpointSliceClient, endpoints.Name+"-"+clusterID1)
 
 	endpointSlice := &discovery.EndpointSlice{}

--- a/pkg/agent/controller/endpoint.go
+++ b/pkg/agent/controller/endpoint.go
@@ -44,7 +44,8 @@ import (
 
 func startEndpointController(localClient dynamic.Interface, restMapper meta.RESTMapper, scheme *runtime.Scheme,
 	serviceImport *mcsv1a1.ServiceImport, serviceImportNameSpace, serviceName, clusterID string,
-	globalIngressIPCache *globalIngressIPCache) (*EndpointController, error) {
+	globalIngressIPCache *globalIngressIPCache,
+) (*EndpointController, error) {
 	klog.V(log.DEBUG).Infof("Starting Endpoints controller for service %s/%s", serviceImportNameSpace, serviceName)
 
 	globalIngressIPGVR, _ := schema.ParseResourceArg("globalingressips.v1.submariner.io")
@@ -154,7 +155,8 @@ func (e *EndpointController) endpointsToEndpointSlice(obj runtime.Object, numReq
 }
 
 func (e *EndpointController) endpointSliceFromEndpoints(endpoints *corev1.Endpoints, op syncer.Operation) (
-	runtime.Object, bool) {
+	runtime.Object, bool,
+) {
 	endpointSlice := &discovery.EndpointSlice{}
 
 	endpointSlice.Name = endpoints.Name + "-" + e.clusterID
@@ -207,7 +209,8 @@ func (e *EndpointController) endpointSliceFromEndpoints(endpoints *corev1.Endpoi
 }
 
 func (e *EndpointController) getEndpointsFromAddresses(addresses []corev1.EndpointAddress, addressType discovery.AddressType,
-	ready bool) ([]discovery.Endpoint, bool) {
+	ready bool,
+) ([]discovery.Endpoint, bool) {
 	endpoints := []discovery.Endpoint{}
 	isIPv6AddressType := addressType == discovery.AddressTypeIPv6
 

--- a/pkg/agent/controller/global_ingressip_cache.go
+++ b/pkg/agent/controller/global_ingressip_cache.go
@@ -78,7 +78,8 @@ func (c *globalIngressIPCache) onDelete(obj *unstructured.Unstructured) {
 }
 
 func (c *globalIngressIPCache) applyToCache(obj *unstructured.Unstructured,
-	apply func(to *sync.Map, key string, obj *unstructured.Unstructured)) {
+	apply func(to *sync.Map, key string, obj *unstructured.Unstructured),
+) {
 	target, _, _ := unstructured.NestedString(obj.Object, "spec", "target")
 	switch target {
 	case ClusterIPService:

--- a/pkg/agent/controller/serviceimport.go
+++ b/pkg/agent/controller/serviceimport.go
@@ -34,7 +34,8 @@ import (
 )
 
 func newServiceImportController(spec *AgentSpecification, serviceSyncer syncer.Interface, restMapper meta.RESTMapper,
-	localClient dynamic.Interface, scheme *runtime.Scheme) (*ServiceImportController, error) {
+	localClient dynamic.Interface, scheme *runtime.Scheme,
+) (*ServiceImportController, error) {
 	controller := &ServiceImportController{
 		serviceSyncer: serviceSyncer,
 		localClient:   localClient,
@@ -134,7 +135,8 @@ func (c *ServiceImportController) serviceImportDeleted(serviceImport *mcsv1a1.Se
 }
 
 func (c *ServiceImportController) serviceImportToEndpointController(obj runtime.Object, numRequeues int,
-	op syncer.Operation) (runtime.Object, bool) {
+	op syncer.Operation,
+) (runtime.Object, bool) {
 	serviceImport := obj.(*mcsv1a1.ServiceImport)
 	key, _ := cache.MetaNamespaceKeyFunc(serviceImport)
 

--- a/pkg/endpointslice/controller_test.go
+++ b/pkg/endpointslice/controller_test.go
@@ -142,7 +142,8 @@ func (t *endpointSliceTestDriver) createEndpointSlice(namespace string, endpoint
 }
 
 func (t *endpointSliceTestDriver) newEndpointSliceFromEndpoint(serviceName, remoteCluster, esName,
-	esNs string, endPoints []discovery.Endpoint) *discovery.EndpointSlice {
+	esNs string, endPoints []discovery.Endpoint,
+) *discovery.EndpointSlice {
 	return &discovery.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      esName,

--- a/pkg/serviceimport/map.go
+++ b/pkg/serviceimport/map.go
@@ -66,7 +66,8 @@ type Map struct {
 }
 
 func (m *Map) selectIP(si *serviceInfo, name, namespace string, checkCluster func(string) bool,
-	checkEndpoint func(string, string, string) bool) *DNSRecord {
+	checkEndpoint func(string, string, string) bool,
+) *DNSRecord {
 	queueLength := si.balancer.ItemCount()
 	for i := 0; i < queueLength; i++ {
 		selectedName := si.balancer.Next().(string)
@@ -84,7 +85,8 @@ func (m *Map) selectIP(si *serviceInfo, name, namespace string, checkCluster fun
 }
 
 func (m *Map) GetIP(namespace, name, cluster, localCluster string, checkCluster func(string) bool,
-	checkEndpoint func(string, string, string) bool) (record *DNSRecord, found, isLocal bool) {
+	checkEndpoint func(string, string, string) bool,
+) (record *DNSRecord, found, isLocal bool) {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 

--- a/plugin/lighthouse/handler.go
+++ b/plugin/lighthouse/handler.go
@@ -68,7 +68,8 @@ func (lh *Lighthouse) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns
 }
 
 func (lh *Lighthouse) getDNSRecord(ctx context.Context, zone string, state *request.Request, w dns.ResponseWriter,
-	r *dns.Msg, pReq *recordRequest) (int, error) {
+	r *dns.Msg, pReq *recordRequest,
+) (int, error) {
 	var isHeadless bool
 	var (
 		dnsRecords []serviceimport.DNSRecord

--- a/plugin/lighthouse/handler_test.go
+++ b/plugin/lighthouse/handler_test.go
@@ -1033,7 +1033,8 @@ func setupEndpointSliceMap() *endpointslice.Map {
 
 // nolint:unparam // `name` always receives `service1'.
 func newServiceImport(namespace, name, clusterID, serviceIP, portName string,
-	portNumber int32, protocol v1.Protocol, siType mcsv1a1.ServiceImportType) *mcsv1a1.ServiceImport {
+	portNumber int32, protocol v1.Protocol, siType mcsv1a1.ServiceImportType,
+) *mcsv1a1.ServiceImport {
 	return &mcsv1a1.ServiceImport{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -1069,7 +1070,8 @@ func newServiceImport(namespace, name, clusterID, serviceIP, portName string,
 
 // nolint:unparam // `namespace` always receives `namespace1`.
 func newEndpointSlice(namespace, name, clusterID, portName string, hostName, endpointIPs []string, portNumber int32,
-	protocol v1.Protocol) *discovery.EndpointSlice {
+	protocol v1.Protocol,
+) *discovery.EndpointSlice {
 	endpoints := make([]discovery.Endpoint, len(endpointIPs))
 
 	for i := range endpointIPs {

--- a/plugin/lighthouse/record.go
+++ b/plugin/lighthouse/record.go
@@ -43,7 +43,8 @@ func (lh *Lighthouse) createARecords(dnsrecords []serviceimport.DNSRecord, state
 }
 
 func (lh *Lighthouse) createSRVRecords(dnsrecords []serviceimport.DNSRecord, state *request.Request, pReq *recordRequest, zone string,
-	isHeadless bool) []dns.RR {
+	isHeadless bool,
+) []dns.RR {
 	var records []dns.RR
 
 	for _, dnsRecord := range dnsrecords {

--- a/test/e2e/discovery/headless_services.go
+++ b/test/e2e/discovery/headless_services.go
@@ -238,7 +238,8 @@ func RunHeadlessDiscoveryClusterNameTest(f *lhframework.Framework) {
 
 // nolint:unparam // cluster` always receives `framework.ClusterA`.
 func verifyHeadlessIpsWithDig(f *framework.Framework, cluster framework.ClusterIndex, service *corev1.Service, targetPod *corev1.PodList,
-	ipList, domains []string, clusterName string, shouldContain bool) {
+	ipList, domains []string, clusterName string, shouldContain bool,
+) {
 	cmd := []string{"dig", "+short"}
 
 	var clusterDNSName string
@@ -292,7 +293,8 @@ func verifyHeadlessIpsWithDig(f *framework.Framework, cluster framework.ClusterI
 
 // nolint:gocognit,unparam // This really isn't that complex and would be awkward to refactor.
 func verifyHeadlessSRVRecordsWithDig(f *framework.Framework, cluster framework.ClusterIndex, service *corev1.Service,
-	targetPod *corev1.PodList, hostNameList, domains []string, clusterName string, withPort, withcluster, shouldContain bool) {
+	targetPod *corev1.PodList, hostNameList, domains []string, clusterName string, withPort, withcluster, shouldContain bool,
+) {
 	ports := service.Spec.Ports
 	for i := range domains {
 		for j := range ports {
@@ -345,7 +347,8 @@ func verifyHeadlessSRVRecordsWithDig(f *framework.Framework, cluster framework.C
 }
 
 func createSRVQuery(f *framework.Framework, port *corev1.ServicePort, service *corev1.Service,
-	domain string, clusterName string, withPort, withcluster bool) (cmd []string, domainName string) {
+	domain string, clusterName string, withPort, withcluster bool,
+) (cmd []string, domainName string) {
 	cmd = []string{"dig", "+short", "SRV"}
 
 	domainName = service.Name + "." + f.Namespace + ".svc." + domain

--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -522,7 +522,8 @@ func RunServicesClusterAvailabilityMutliClusterTest(f *lhframework.Framework) {
 
 // nolint:gocognit,unparam // This really isn't that complex and would be awkward to refactor.
 func verifySRVWithDig(f *framework.Framework, srcCluster framework.ClusterIndex, service *corev1.Service, targetPod *corev1.PodList,
-	domains []string, clusterName string, withPort, shouldContain bool) {
+	domains []string, clusterName string, withPort, shouldContain bool,
+) {
 	ports := service.Spec.Ports
 	for i := range domains {
 		for _, port := range ports {
@@ -589,7 +590,8 @@ func verifySRVWithDig(f *framework.Framework, srcCluster framework.ClusterIndex,
 }
 
 func verifyRoundRobinWithDig(f *framework.Framework, srcCluster framework.ClusterIndex, serviceName string, serviceIPList []string,
-	targetPod *corev1.PodList, domains []string) {
+	targetPod *corev1.PodList, domains []string,
+) {
 	cmd := []string{"dig", "+short"}
 
 	for i := range domains {

--- a/test/e2e/discovery/statefulsets.go
+++ b/test/e2e/discovery/statefulsets.go
@@ -192,7 +192,8 @@ func RunSSPodsAvailabilityTest(f *lhframework.Framework) {
 
 // nolint:unparam //  `targetCluster` always receives `framework.ClusterA`.
 func verifyEndpointSlices(f *framework.Framework, targetCluster framework.ClusterIndex, netshootPodList *corev1.PodList,
-	endpointSlices *discovery.EndpointSliceList, svcName string, verifyCount int, shouldContain bool) {
+	endpointSlices *discovery.EndpointSliceList, svcName string, verifyCount int, shouldContain bool,
+) {
 	count := 0
 
 	for i := range endpointSlices.Items {
@@ -210,7 +211,8 @@ func verifyEndpointSlices(f *framework.Framework, targetCluster framework.Cluste
 }
 
 func verifyEndpointsWithDig(f *framework.Framework, targetCluster framework.ClusterIndex, targetPod *corev1.PodList,
-	endpoint *discovery.Endpoint, sourceCluster, service string, domains []string, shouldContain bool) {
+	endpoint *discovery.Endpoint, sourceCluster, service string, domains []string, shouldContain bool,
+) {
 	cmd := []string{"dig", "+short"}
 
 	query := *endpoint.Hostname + "." + sourceCluster + "." + service

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -184,7 +184,8 @@ func (f *Framework) AwaitServiceImportIP(srcCluster, targetCluster framework.Clu
 }
 
 func (f *Framework) AwaitServiceImportWithIP(targetCluster framework.ClusterIndex, svc *v1.Service,
-	serviceIP string) *mcsv1a1.ServiceImport {
+	serviceIP string,
+) *mcsv1a1.ServiceImport {
 	var retServiceImport *mcsv1a1.ServiceImport
 
 	siNamePrefix := svc.Name + "-" + svc.Namespace + "-"
@@ -253,7 +254,8 @@ func (f *Framework) AwaitServiceImportCount(targetCluster framework.ClusterIndex
 }
 
 func (f *Framework) NewNginxHeadlessServiceWithParams(name, app, portName string, protcol v1.Protocol,
-	cluster framework.ClusterIndex) *v1.Service {
+	cluster framework.ClusterIndex,
+) *v1.Service {
 	var port int32 = 80
 
 	nginxService := v1.Service{
@@ -292,7 +294,8 @@ func (f *Framework) NewNginxHeadlessService(cluster framework.ClusterIndex) *v1.
 }
 
 func (f *Framework) AwaitEndpointIPs(targetCluster framework.ClusterIndex, name,
-	namespace string, count int) (ipList, hostNameList []string) {
+	namespace string, count int,
+) (ipList, hostNameList []string) {
 	ep := framework.KubeClients[targetCluster].CoreV1().Endpoints(namespace)
 	By(fmt.Sprintf("Retrieving Endpoints for %s on %q", name, framework.TestContext.ClusterIDs[targetCluster]))
 	framework.AwaitUntil("retrieve Endpoints", func() (interface{}, error) {
@@ -426,7 +429,8 @@ func create(f *Framework, cluster framework.ClusterIndex, statefulSet *appsv1.St
 }
 
 func (f *Framework) AwaitEndpointSlices(targetCluster framework.ClusterIndex, name, namespace string,
-	expSliceCount, expEpCount int) (endpointSliceList *discovery.EndpointSliceList) {
+	expSliceCount, expEpCount int,
+) (endpointSliceList *discovery.EndpointSliceList) {
 	ep := framework.KubeClients[targetCluster].DiscoveryV1().EndpointSlices(namespace)
 	labelMap := map[string]string{
 		discovery.LabelManagedBy: lhconstants.LabelValueManagedBy,
@@ -546,13 +550,15 @@ func (f *Framework) SetHealthCheckIP(cluster framework.ClusterIndex, ip, endpoin
 }
 
 func (f *Framework) VerifyServiceIPWithDig(srcCluster, targetCluster framework.ClusterIndex, service *v1.Service, targetPod *v1.PodList,
-	domains []string, clusterName string, shouldContain bool) {
+	domains []string, clusterName string, shouldContain bool,
+) {
 	serviceIP := f.GetServiceIP(targetCluster, service, srcCluster == targetCluster)
 	f.VerifyIPWithDig(srcCluster, service, targetPod, domains, clusterName, serviceIP, shouldContain)
 }
 
 func (f *Framework) VerifyIPWithDig(srcCluster framework.ClusterIndex, service *v1.Service, targetPod *v1.PodList,
-	domains []string, clusterName, serviceIP string, shouldContain bool) {
+	domains []string, clusterName, serviceIP string, shouldContain bool,
+) {
 	cmd := []string{"dig", "+short"}
 
 	var clusterDNSName string

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 /*


### PR DESCRIPTION
This is required by golangci-lint 1.45.2; it all involves formatting
wrapped lists of parameters or return types.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
