### PR TITLE
[Backport] Use Quay mirror of official nginx container images

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/submariner-io/admiral v0.12.0
-	github.com/submariner-io/shipyard v0.12.0
+	github.com/submariner-io/shipyard v0.12.1-0.20220421224802-2788e35a83cd
 	github.com/uw-labs/lichen v0.1.5
 	k8s.io/api v0.21.0
 	k8s.io/apimachinery v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -752,6 +752,8 @@ github.com/submariner-io/admiral v0.12.0 h1:o7w53UpkZPSwcIuG6hIT0aTDQC6HrLgcnZBi
 github.com/submariner-io/admiral v0.12.0/go.mod h1:AX0lc3FjWxM3KwSx0kU0b3f1xFxkm5k533pTehHl6QA=
 github.com/submariner-io/shipyard v0.12.0 h1:vdOFYnSx/5WqMXfebhWWEzdaTdoBNBIvg/URRfGaYRY=
 github.com/submariner-io/shipyard v0.12.0/go.mod h1:i3KjrLOHgG1uL+OeYolFNV1BmaOGlh2jEMQfNKtXOAo=
+github.com/submariner-io/shipyard v0.12.1-0.20220421224802-2788e35a83cd h1:Ilgju1c00qDjrPy/Y5dSx0dsOd8Gqn1kgKrJtLhwGFM=
+github.com/submariner-io/shipyard v0.12.1-0.20220421224802-2788e35a83cd/go.mod h1:i3KjrLOHgG1uL+OeYolFNV1BmaOGlh2jEMQfNKtXOAo=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/timewasted/linode v0.0.0-20160829202747-37e84520dcf7/go.mod h1:imsgLplxEC/etjIhdr3dNzV3JeT27LbVu5pYWm0JCBY=
 github.com/tinylib/msgp v1.1.2 h1:gWmO7n0Ys2RBEb7GPYB9Ujq8Mk5p2U08lRnmMcGy6BQ=

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -367,7 +367,7 @@ func (f *Framework) SetNginxReplicaSet(cluster framework.ClusterIndex, count uin
 
 func (f *Framework) NewNginxStatefulSet(cluster framework.ClusterIndex) *appsv1.StatefulSet {
 	var replicaCount int32 = 1
-	var port int32 = 8080
+	var port int32 = 80
 
 	nginxStatefulSet := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -391,7 +391,7 @@ func (f *Framework) NewNginxStatefulSet(cluster framework.ClusterIndex) *appsv1.
 					Containers: []v1.Container{
 						{
 							Name:            statefulServiceName,
-							Image:           "quay.io/bitnami/nginx:latest",
+							Image:           "quay.io/testing-farm/nginx:latest",
 							ImagePullPolicy: v1.PullAlways,
 							Ports: []v1.ContainerPort{
 								{


### PR DESCRIPTION
The current nginx container images from bitnami are failing to pull.
They seem to no longer be provided as a part of bitnami changes.

This Quay nginx source seems to automatically mirror the official nginx
builds on DockerHub. Just like us, they want to avoid the rate limiting.

I verified the SHAs of the containers here match the official ones

https://quay.io/repository/testing-farm/nginx/manifest/sha256:61face6bf030edce7ef6d7dd66fe452298d6f5f7ce032afdd01683ef02b2b841

https://hub.docker.com/layers/nginx/library/nginx/latest/images/sha256-61face6bf030edce7ef6d7dd66fe452298d6f5f7ce032afdd01683ef02b2b841

Red Hat seems to be a steward of the project, based on the Red Hat 2022
copyright notice here: https://gitlab.com/testing-farm/docs/root

All the standard nginx images seem to use port 80, including this one.
Switch from current port 8080 to 80 to make this container work.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
