### PR TITLE
Use latest `Shipyard` for simpleserver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/submariner-io/admiral v0.12.0-m3.0.20220223161649-65232cddf5c0
-	github.com/submariner-io/shipyard v0.12.0-m3.0.20220421170648-adf7571e55ed
+	github.com/submariner-io/shipyard v0.12.0-m3.0.20220427131749-6b99f918e45e
 	github.com/uw-labs/lichen v0.1.5
 	k8s.io/api v0.23.4
 	k8s.io/apimachinery v0.23.4

--- a/go.sum
+++ b/go.sum
@@ -735,8 +735,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/submariner-io/admiral v0.12.0-m3.0.20220223161649-65232cddf5c0 h1:BK7CD5QxPcBipR/ikj97M8LdnKp2n7HFoBSgnyAvUjk=
 github.com/submariner-io/admiral v0.12.0-m3.0.20220223161649-65232cddf5c0/go.mod h1:hFPcxH0gAr559/qK7ri10Yh1wyeK6yzow1PIqtBk+30=
 github.com/submariner-io/shipyard v0.12.0-m3/go.mod h1:el/lH6ed/1BN1FvEXlptiib7qT2cTwEQ4AMceH3js9g=
-github.com/submariner-io/shipyard v0.12.0-m3.0.20220421170648-adf7571e55ed h1:MXqKVIX2TfGhiEeiKC6DxYtn69aL5OM+IhDg7OMK6rI=
-github.com/submariner-io/shipyard v0.12.0-m3.0.20220421170648-adf7571e55ed/go.mod h1:JpJa1JxmdFqDUl7c/vJJE5HmRXxjZXeCgwa+d8uyVOs=
+github.com/submariner-io/shipyard v0.12.0-m3.0.20220427131749-6b99f918e45e h1:eHeQdejigQR4oZCT0ubIXbxvXWRK5WsxvV/s14WzMWU=
+github.com/submariner-io/shipyard v0.12.0-m3.0.20220427131749-6b99f918e45e/go.mod h1:JpJa1JxmdFqDUl7c/vJJE5HmRXxjZXeCgwa+d8uyVOs=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/timewasted/linode v0.0.0-20160829202747-37e84520dcf7/go.mod h1:imsgLplxEC/etjIhdr3dNzV3JeT27LbVu5pYWm0JCBY=
 github.com/tinylib/msgp v1.1.2 h1:gWmO7n0Ys2RBEb7GPYB9Ujq8Mk5p2U08lRnmMcGy6BQ=


### PR DESCRIPTION
Shipyard's E2E framework was updated to use a simple server, the
consuming projects need to update in order to properly consume it.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
