### PR TITLE
Build packages, not files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,11 @@ package/.image.lighthouse-coredns: bin/lighthouse-coredns
 build: $(BINARIES)
 
 bin/lighthouse-agent: vendor/modules.txt $(shell find pkg/agent)
-	${SCRIPTS_DIR}/compile.sh $@ pkg/agent/main.go $(BUILD_ARGS)
+	${SCRIPTS_DIR}/compile.sh $@ ./pkg/agent $(BUILD_ARGS)
 
 bin/lighthouse-coredns: coredns/vendor/modules.txt $(shell find coredns)
-	cd coredns && ${SCRIPTS_DIR}/compile.sh $@ main.go $(BUILD_ARGS)
+	mkdir -p $(@D)
+	cd coredns && ${SCRIPTS_DIR}/compile.sh $@ . $(BUILD_ARGS)
 	mv coredns/$@ $@
 
 licensecheck: BUILD_ARGS=--noupx


### PR DESCRIPTION
This specifies packages to build rather than main.go files, which
ensures that we record the correct module information in Go 1.18+.

Fixes: #745
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
