### PR TITLE
Backport: Use Shipyard's nettest simpleserver

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -367,7 +367,7 @@ func (f *Framework) SetNginxReplicaSet(cluster framework.ClusterIndex, count uin
 
 func (f *Framework) NewNginxStatefulSet(cluster framework.ClusterIndex) *appsv1.StatefulSet {
 	var replicaCount int32 = 1
-	var port int32 = 80
+	var port int32 = 8080
 
 	nginxStatefulSet := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -391,7 +391,7 @@ func (f *Framework) NewNginxStatefulSet(cluster framework.ClusterIndex) *appsv1.
 					Containers: []v1.Container{
 						{
 							Name:            statefulServiceName,
-							Image:           "quay.io/testing-farm/nginx:latest",
+							Image:           "quay.io/submariner/nettest:devel",
 							ImagePullPolicy: v1.PullAlways,
 							Ports: []v1.ContainerPort{
 								{
@@ -399,7 +399,7 @@ func (f *Framework) NewNginxStatefulSet(cluster framework.ClusterIndex) *appsv1.
 									Name:          "web",
 								},
 							},
-							Command: []string{},
+							Command: []string{"/app/simpleserver"},
 						},
 					},
 					RestartPolicy: v1.RestartPolicyAlways,


### PR DESCRIPTION
The nginx image is giving us maintenance issues, use a simple netcat
process run from an existing container instead.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>
(cherry picked from commit 2ae7357ff15f05d8b8763cb161f1062fc7652e37)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
