### PR TITLE
Use Dependabot to update GHAs on release-0.12

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     directory: '/'
     schedule:
       interval: daily
+  - package-ecosystem: github-actions
+    directory: '/'
+    target-branch: "release-0.12"
+    schedule:
+      interval: daily
   - package-ecosystem: gomod
     directory: "/"
     schedule:


### PR DESCRIPTION
Add Dependabot configuration to automatically update GitHub Actions on
the release-0.12 branch.

This will facilitate quick updates while using SHA-based versions.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
