### PR TITLE
Bump Admiral to 0.13.0-m2

### DIFF
--- a/coredns/go.mod
+++ b/coredns/go.mod
@@ -1,6 +1,6 @@
 module github.com/submariner-io/lighthouse/coredns
 
-go 1.13
+go 1.16
 
 require (
 	github.com/caddyserver/caddy v1.0.5
@@ -11,7 +11,7 @@ require (
 	github.com/onsi/gomega v1.19.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2
-	github.com/submariner-io/admiral v0.13.0-m1
+	github.com/submariner-io/admiral v0.13.0-m2
 	github.com/submariner-io/lighthouse v0.13.0-m1
 	k8s.io/api v0.21.11
 	k8s.io/apimachinery v0.21.11

--- a/coredns/go.sum
+++ b/coredns/go.sum
@@ -702,7 +702,6 @@ github.com/prometheus/client_golang v1.5.1/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3O
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.10.0/go.mod h1:WJM3cc3yu7XKBKa/I8WeZm+V3eltZnBwfENSU7mdogU=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
-github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_golang v1.12.2 h1:51L9cDoUHVrXx4zWYlcLQIZ+d+VXHgqnYKkIuq4g/34=
 github.com/prometheus/client_golang v1.12.2/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -800,9 +799,9 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/submariner-io/admiral v0.13.0-m1 h1:CgYd5kVNSX5ghTGRbSlB5PLWinuXmve0u+uNsnYb5XM=
-github.com/submariner-io/admiral v0.13.0-m1/go.mod h1:fgBeRxzNKP77awldhsAZujsljtoOeGogkMfz7lkbdZA=
-github.com/submariner-io/shipyard v0.13.0-m1/go.mod h1:JpJa1JxmdFqDUl7c/vJJE5HmRXxjZXeCgwa+d8uyVOs=
+github.com/submariner-io/admiral v0.13.0-m2 h1:cdwtgkyvUpPt8LNk7KJsaHcelzpksWWldtPvJ5MIdwo=
+github.com/submariner-io/admiral v0.13.0-m2/go.mod h1:9OWhRE9xZGBGCDFYRVJwOTSUXnTAP9fUWw1KnOrzGVE=
+github.com/submariner-io/shipyard v0.13.0-m2/go.mod h1:QC3tq6LKRCaavN3/pGw/QqSVIsVJKA9rbmNueihTydE=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/timewasted/linode v0.0.0-20160829202747-37e84520dcf7/go.mod h1:imsgLplxEC/etjIhdr3dNzV3JeT27LbVu5pYWm0JCBY=
 github.com/tinylib/msgp v1.1.2 h1:gWmO7n0Ys2RBEb7GPYB9Ujq8Mk5p2U08lRnmMcGy6BQ=

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/gomega v1.19.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2
-	github.com/submariner-io/admiral v0.13.0-m1
+	github.com/submariner-io/admiral v0.13.0-m2
 	github.com/submariner-io/shipyard v0.13.0-m2
 	github.com/uw-labs/lichen v0.1.7
 	k8s.io/api v0.21.11

--- a/go.sum
+++ b/go.sum
@@ -491,7 +491,6 @@ github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDf
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
-github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_golang v1.12.2 h1:51L9cDoUHVrXx4zWYlcLQIZ+d+VXHgqnYKkIuq4g/34=
 github.com/prometheus/client_golang v1.12.2/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -565,9 +564,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/submariner-io/admiral v0.13.0-m1 h1:CgYd5kVNSX5ghTGRbSlB5PLWinuXmve0u+uNsnYb5XM=
-github.com/submariner-io/admiral v0.13.0-m1/go.mod h1:fgBeRxzNKP77awldhsAZujsljtoOeGogkMfz7lkbdZA=
-github.com/submariner-io/shipyard v0.13.0-m1/go.mod h1:JpJa1JxmdFqDUl7c/vJJE5HmRXxjZXeCgwa+d8uyVOs=
+github.com/submariner-io/admiral v0.13.0-m2 h1:cdwtgkyvUpPt8LNk7KJsaHcelzpksWWldtPvJ5MIdwo=
+github.com/submariner-io/admiral v0.13.0-m2/go.mod h1:9OWhRE9xZGBGCDFYRVJwOTSUXnTAP9fUWw1KnOrzGVE=
 github.com/submariner-io/shipyard v0.13.0-m2 h1:Lss22ebdN8P2KyylFkWEmHgakQq6wlVHxokZpBXleUM=
 github.com/submariner-io/shipyard v0.13.0-m2/go.mod h1:QC3tq6LKRCaavN3/pGw/QqSVIsVJKA9rbmNueihTydE=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=


### PR DESCRIPTION
This is the result of

    go get github.com/submariner-io/admiral@v0.13.0-m2
    go mod tidy -go=1.16 && go mod tidy -go=1.17

The result survives a "go mod tidy" without error and without
changes.

See https://tip.golang.org/doc/go1.17#go-command for background.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
