### PR TITLE
Use NettestImageURL var from shipyard

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2
 	github.com/submariner-io/admiral v0.13.0-m2
-	github.com/submariner-io/shipyard v0.13.0-m2
+	github.com/submariner-io/shipyard v0.13.0-m2.0.20220613150042-b90492334262
 	github.com/uw-labs/lichen v0.1.7
 	k8s.io/api v0.21.11
 	k8s.io/apimachinery v0.21.11

--- a/go.sum
+++ b/go.sum
@@ -566,8 +566,9 @@ github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMT
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/submariner-io/admiral v0.13.0-m2 h1:cdwtgkyvUpPt8LNk7KJsaHcelzpksWWldtPvJ5MIdwo=
 github.com/submariner-io/admiral v0.13.0-m2/go.mod h1:9OWhRE9xZGBGCDFYRVJwOTSUXnTAP9fUWw1KnOrzGVE=
-github.com/submariner-io/shipyard v0.13.0-m2 h1:Lss22ebdN8P2KyylFkWEmHgakQq6wlVHxokZpBXleUM=
 github.com/submariner-io/shipyard v0.13.0-m2/go.mod h1:QC3tq6LKRCaavN3/pGw/QqSVIsVJKA9rbmNueihTydE=
+github.com/submariner-io/shipyard v0.13.0-m2.0.20220613150042-b90492334262 h1:H2jW/KPapyllIbWNthwZ7+YQ8TCkLTdikXdVdiH9724=
+github.com/submariner-io/shipyard v0.13.0-m2.0.20220613150042-b90492334262/go.mod h1:QC3tq6LKRCaavN3/pGw/QqSVIsVJKA9rbmNueihTydE=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/test/e2e/framework/deployments.go
+++ b/test/e2e/framework/deployments.go
@@ -53,7 +53,7 @@ func (f *Framework) NewNetShootDeployment(cluster framework.ClusterIndex) *corev
 					Containers: []corev1.Container{
 						{
 							Name:            "netshoot",
-							Image:           "quay.io/submariner/nettest:devel",
+							Image:           framework.TestContext.NettestImageURL,
 							ImagePullPolicy: corev1.PullAlways,
 							Command: []string{
 								"sleep", "600",
@@ -93,7 +93,7 @@ func (f *Framework) NewNginxDeployment(cluster framework.ClusterIndex) *corev1.P
 					Containers: []corev1.Container{
 						{
 							Name:            "nginx-demo",
-							Image:           "quay.io/submariner/nettest:devel",
+							Image:           framework.TestContext.NettestImageURL,
 							ImagePullPolicy: corev1.PullAlways,
 							Ports: []corev1.ContainerPort{
 								{

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -394,7 +394,7 @@ func (f *Framework) NewNginxStatefulSet(cluster framework.ClusterIndex) *appsv1.
 					Containers: []v1.Container{
 						{
 							Name:            statefulServiceName,
-							Image:           "quay.io/submariner/nettest:devel",
+							Image:           framework.TestContext.NettestImageURL,
 							ImagePullPolicy: v1.PullAlways,
 							Ports: []v1.ContainerPort{
 								{


### PR DESCRIPTION
...to make the `nettest` image configurable for air-gapped deployments.
