### PR TITLE
Run Anchore scan on changes to all branches

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -1,0 +1,28 @@
+---
+name: Reporting
+
+on:
+  push:
+    branches:
+      - devel
+      - release-*
+
+jobs:
+  vulnerability-scan:
+    name: Vulnerability Scanning
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - name: Run Anchore vulnerability scanner
+        uses: anchore/scan-action@516844f15d82b6cdd0765b87aab79ed3ac006225
+        id: scan
+        with:
+          path: "."
+          fail-build: false
+      - name: Show Anchore scan SARIF report
+        run: cat ${{ steps.scan.outputs.sarif }}
+      - name: Upload Anchore scan SARIF report
+        uses: github/codeql-action/upload-sarif@9885f86fab4879632b7e44514f19148225dfbdcd
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}


### PR DESCRIPTION
Run Anchore vulnerability scanning on merges to the devel branch or any
release-* branch. This will cause GitHub's "Security overview"/"Code
scanning alerts" to correctly report results for each branch. Currently,
we only run scans on PRs and GH doesn't track/report the results outside
of PRs.

Closes: #816
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
