### PR TITLE
Don't use local lighthouse in coredns go.mod

### DIFF
--- a/coredns/go.mod
+++ b/coredns/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2
 	github.com/submariner-io/admiral v0.13.0-m2
-	github.com/submariner-io/lighthouse v0.13.0-m1
+	github.com/submariner-io/lighthouse v0.13.0-rc2
 	k8s.io/api v0.24.2
 	k8s.io/apimachinery v0.24.2
 	k8s.io/client-go v0.24.2
@@ -109,8 +109,11 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
+// Pin to a non-local version of lighthouse. This is not ideal, but there's a limitation in Cachito.
+// This will hopefully be fixed, but need a workaround for now.
+// https://issues.redhat.com/browse/CLOUDBLD-10559
 // Local project
-replace github.com/submariner-io/lighthouse => ../
+// replace github.com/submariner-io/lighthouse => ../
 
 // Avoid an ambiguous import (cloud.google.com/go/compute/metadata in both
 // cloud.google.com/go v0.81.0 and cloud.google.com/go/compute v0.1.3.0)


### PR DESCRIPTION
This is a temporary workaround to avoid a limitation in Cachito.

https://issues.redhat.com/browse/CLOUDBLD-10559

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
