### PR TITLE
Don't use local lighthouse in coredns go.mod

### DIFF
--- a/coredns/go.mod
+++ b/coredns/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2
 	github.com/submariner-io/admiral v0.13.0-rc2
-	github.com/submariner-io/lighthouse v0.13.0-m1
+	github.com/submariner-io/lighthouse v0.13.0-rc2
 	golang.org/x/tools v0.1.7 // indirect
 	k8s.io/api v0.21.11
 	k8s.io/apimachinery v0.21.11
@@ -21,5 +21,8 @@ require (
 	sigs.k8s.io/mcs-api v0.1.0
 )
 
+// Pin to a non-local version of lighthouse. This is not ideal, but there's a limitation in Cachito.
+// This will hopefully be fixed, but need a workaround for now.
+// https://issues.redhat.com/browse/CLOUDBLD-10559
 // Local project
-replace github.com/submariner-io/lighthouse => ../
+// replace github.com/submariner-io/lighthouse => ../

--- a/coredns/go.sum
+++ b/coredns/go.sum
@@ -804,6 +804,8 @@ github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMT
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/submariner-io/admiral v0.13.0-rc2 h1:NvVUdgL1Zt/gzyXp4GcZheWJejtf2oiogWZ7qiKZa7I=
 github.com/submariner-io/admiral v0.13.0-rc2/go.mod h1:ZRuSTYk6P8+TU8cUQLF8mqDHUZdcjSrAQNMwajbkbd4=
+github.com/submariner-io/lighthouse v0.13.0-rc2 h1:MSGzqVRPUjm1rwwTKBVTi8mhaKX9Qm/sOPZU1AGcLlE=
+github.com/submariner-io/lighthouse v0.13.0-rc2/go.mod h1:zzYze3ui+vkKJL98HqiHWFBM4qxGBef3BVXDIP/VGO0=
 github.com/submariner-io/shipyard v0.13.0-rc2/go.mod h1:QC3tq6LKRCaavN3/pGw/QqSVIsVJKA9rbmNueihTydE=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/timewasted/linode v0.0.0-20160829202747-37e84520dcf7/go.mod h1:imsgLplxEC/etjIhdr3dNzV3JeT27LbVu5pYWm0JCBY=


### PR DESCRIPTION
This is a temporary workaround to avoid a limitation in Cachito.

https://issues.redhat.com/browse/CLOUDBLD-10559

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
