### PR TITLE
Use minimal KIND clusters

### DIFF
--- a/.shipyard.e2e.yml
+++ b/.shipyard.e2e.yml
@@ -1,9 +1,8 @@
 ---
 cni: weave
 submariner: true
-nodes: control-plane worker worker
+nodes: control-plane
 clusters:
   cluster1:
   cluster2:
   cluster3:
-    nodes: control-plane worker


### PR DESCRIPTION
Seems that we don't really need such large clusters to run E2E, as
Lighthouse doesn't care about specific nodes.

Using minimal cluster speeds up the deployment and tests, and frees up
system resources.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
