### PR TITLE
Automated backport of #757: Return local cluster IP for headless services

### DIFF
--- a/coredns/endpointslice/controller_test.go
+++ b/coredns/endpointslice/controller_test.go
@@ -46,6 +46,7 @@ const (
 	testService2         = "testService2"
 	testNS1              = "testNameSpace1"
 	testNS2              = "testNameSpace2"
+	localClusterID       = "local"
 )
 
 var _ = Describe("EndpointSlice controller", func() {
@@ -120,7 +121,7 @@ func newEndpointSliceTestDiver() *endpointSliceTestDriver {
 
 	BeforeEach(func() {
 		t.kubeClient = fakeKubeClient.NewSimpleClientset()
-		t.epMap = endpointslice.NewMap()
+		t.epMap = endpointslice.NewMap(localClusterID, t.kubeClient)
 		t.controller = endpointslice.NewController(t.epMap)
 		t.controller.NewClientset = func(c *rest.Config) (kubernetes.Interface, error) {
 			return t.kubeClient, nil

--- a/coredns/endpointslice/map_test.go
+++ b/coredns/endpointslice/map_test.go
@@ -28,18 +28,20 @@ import (
 	lhconstants "github.com/submariner-io/lighthouse/pkg/constants"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeKubeClient "k8s.io/client-go/kubernetes/fake"
 )
 
 var _ = Describe("EndpointSlice Map", func() {
 	const (
-		service1    = "service1"
-		namespace1  = "namespace1"
-		clusterID1  = "clusterID1"
-		clusterID2  = "clusterID2"
-		clusterID3  = "clusterID3"
-		endpointIP  = "100.96.157.101"
-		endpointIP2 = "100.96.157.102"
-		endpointIP3 = "100.96.157.103"
+		service1       = "service1"
+		namespace1     = "namespace1"
+		clusterID1     = "clusterID1"
+		clusterID2     = "clusterID2"
+		clusterID3     = "clusterID3"
+		localClusterID = "local"
+		endpointIP     = "100.96.157.101"
+		endpointIP2    = "100.96.157.102"
+		endpointIP3    = "100.96.157.103"
 	)
 
 	var (
@@ -49,7 +51,7 @@ var _ = Describe("EndpointSlice Map", func() {
 
 	BeforeEach(func() {
 		clusterStatusMap = map[string]bool{clusterID1: true, clusterID2: true, clusterID3: true}
-		endpointSliceMap = endpointslice.NewMap()
+		endpointSliceMap = endpointslice.NewMap(localClusterID, fakeKubeClient.NewSimpleClientset())
 	})
 
 	checkCluster := func(id string) bool {

--- a/coredns/plugin/handler_test.go
+++ b/coredns/plugin/handler_test.go
@@ -29,13 +29,14 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
-	lighthouse "github.com/submariner-io/lighthouse/coredns/plugin"
-	lhconstants "github.com/submariner-io/lighthouse/pkg/constants"
 	"github.com/submariner-io/lighthouse/coredns/endpointslice"
+	lighthouse "github.com/submariner-io/lighthouse/coredns/plugin"
 	"github.com/submariner-io/lighthouse/coredns/serviceimport"
+	lhconstants "github.com/submariner-io/lighthouse/pkg/constants"
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeKubeClient "k8s.io/client-go/kubernetes/fake"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
@@ -1025,7 +1026,7 @@ func setupServiceImportMap() *serviceimport.Map {
 }
 
 func setupEndpointSliceMap() *endpointslice.Map {
-	esMap := endpointslice.NewMap()
+	esMap := endpointslice.NewMap(localClusterID, fakeKubeClient.NewSimpleClientset())
 	esMap.Put(newEndpointSlice(namespace1, service1, clusterID, portName1, []string{hostName1}, []string{endpointIP}, portNumber1, protocol1))
 
 	return esMap

--- a/coredns/plugin/setup.go
+++ b/coredns/plugin/setup.go
@@ -30,6 +30,7 @@ import (
 	"github.com/submariner-io/lighthouse/coredns/gateway"
 	"github.com/submariner-io/lighthouse/coredns/service"
 	"github.com/submariner-io/lighthouse/coredns/serviceimport"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -89,7 +90,8 @@ func lighthouseParse(c *caddy.Controller) (*Lighthouse, error) {
 		return nil, errors.Wrap(err, "error starting the ServiceImport controller")
 	}
 
-	epMap := endpointslice.NewMap()
+	kubeClient := kubernetes.NewForConfigOrDie(cfg)
+	epMap := endpointslice.NewMap(gwController.LocalClusterID(), kubeClient)
 	epController := endpointslice.NewController(epMap)
 
 	err = epController.Start(cfg)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -28,4 +28,5 @@ const (
 	LabelValueManagedBy                = "lighthouse-agent.submariner.io"
 	MCSLabelServiceName                = "multicluster.kubernetes.io/service-name"
 	MCSLabelSourceCluster              = "multicluster.kubernetes.io/source-cluster"
+	KubernetesServiceName              = "kubernetes.io/service-name"
 )

--- a/test/e2e/discovery/headless_services.go
+++ b/test/e2e/discovery/headless_services.go
@@ -53,6 +53,10 @@ var _ = Describe("[discovery] Test Headless Service Discovery Across Clusters", 
 		It("should only resolve the IPs from the active pods", func() {
 			RunHeadlessPodsAvailabilityTest(f)
 		})
+
+		It("should resolve the local pod IPs", func() {
+			RunHeadlessPodsAvailabilityTestLocal(f)
+		})
 	})
 
 	When("a pod tries to resolve a headless service in a specific remote cluster by its cluster name", func() {
@@ -80,10 +84,10 @@ func RunHeadlessDiscoveryTest(f *lhframework.Framework) {
 
 	netshootPodList := f.NewNetShootDeployment(framework.ClusterA)
 
-	ipList, hostNameList := f.GetPodIPs(framework.ClusterB, nginxHeadlessClusterB)
-	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains,
+	ipList, hostNameList := f.GetPodIPs(framework.ClusterB, nginxHeadlessClusterB, false)
+	f.VerifyIPsWithDig(framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains,
 		"", true)
-	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains,
+	f.VerifyIPsWithDig(framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains,
 		clusterBName, true)
 
 	verifyHeadlessSRVRecordsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, hostNameList, checkedDomains,
@@ -94,7 +98,7 @@ func RunHeadlessDiscoveryTest(f *lhframework.Framework) {
 	f.DeleteServiceExport(framework.ClusterB, nginxHeadlessClusterB.Name, nginxHeadlessClusterB.Namespace)
 	f.AwaitServiceImportCount(framework.ClusterA, nginxHeadlessClusterB.Name, nginxHeadlessClusterB.Namespace, 0)
 
-	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains,
+	f.VerifyIPsWithDig(framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains,
 		"", false)
 	verifyHeadlessSRVRecordsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, hostNameList, checkedDomains,
 		clusterBName, false, false, false)
@@ -126,14 +130,14 @@ func RunHeadlessDiscoveryLocalAndRemoteTest(f *lhframework.Framework) {
 
 	netshootPodList := f.NewNetShootDeployment(framework.ClusterA)
 
-	ipListB, hostNameListB := f.GetPodIPs(framework.ClusterB, nginxHeadlessClusterB)
-	ipListA, hostNameListA := f.GetPodIPs(framework.ClusterA, nginxHeadlessClusterA)
+	ipListB, hostNameListB := f.GetPodIPs(framework.ClusterB, nginxHeadlessClusterB, false)
+	ipListA, hostNameListA := f.GetPodIPs(framework.ClusterA, nginxHeadlessClusterA, true)
 
 	var ipList []string
 	ipList = append(ipList, ipListB...)
 	ipList = append(ipList, ipListA...)
 
-	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains,
+	f.VerifyIPsWithDig(framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains,
 		"", true)
 
 	verifyHeadlessSRVRecordsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, hostNameListB, checkedDomains,
@@ -143,10 +147,10 @@ func RunHeadlessDiscoveryLocalAndRemoteTest(f *lhframework.Framework) {
 	f.DeleteServiceExport(framework.ClusterB, nginxHeadlessClusterB.Name, nginxHeadlessClusterB.Namespace)
 	f.AwaitServiceImportCount(framework.ClusterA, nginxHeadlessClusterB.Name, nginxHeadlessClusterB.Namespace, 1)
 
-	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipListB, checkedDomains,
+	f.VerifyIPsWithDig(framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipListB, checkedDomains,
 		"", false)
 
-	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipListA, checkedDomains,
+	f.VerifyIPsWithDig(framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipListA, checkedDomains,
 		"", true)
 	verifyHeadlessSRVRecordsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, hostNameListB, checkedDomains,
 		clusterBName, true, false, false)
@@ -174,18 +178,52 @@ func RunHeadlessPodsAvailabilityTest(f *lhframework.Framework) {
 
 	netshootPodList := f.NewNetShootDeployment(framework.ClusterA)
 
-	ipList, _ := f.AwaitPodIPs(framework.ClusterB, nginxHeadlessClusterB, 3)
-	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains,
+	ipList, _ := f.AwaitPodIPs(framework.ClusterB, nginxHeadlessClusterB, 3, false)
+	f.VerifyIPsWithDig(framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains,
 		"", true)
 
 	f.SetNginxReplicaSet(framework.ClusterB, 0)
-	ipList, _ = f.AwaitPodIPs(framework.ClusterB, nginxHeadlessClusterB, 0)
-	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains,
+	ipList, _ = f.AwaitPodIPs(framework.ClusterB, nginxHeadlessClusterB, 0, false)
+	f.VerifyIPsWithDig(framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains,
 		"", false)
 
 	f.SetNginxReplicaSet(framework.ClusterB, 2)
-	ipList, _ = f.AwaitPodIPs(framework.ClusterB, nginxHeadlessClusterB, 2)
-	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains,
+	ipList, _ = f.AwaitPodIPs(framework.ClusterB, nginxHeadlessClusterB, 2, false)
+	f.VerifyIPsWithDig(framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipList, checkedDomains,
+		"", true)
+}
+
+func RunHeadlessPodsAvailabilityTestLocal(f *lhframework.Framework) {
+	clusterAName := framework.TestContext.ClusterIDs[framework.ClusterA]
+
+	By(fmt.Sprintf("Creating an Nginx Deployment on on %q", clusterAName))
+	f.NewNginxDeployment(framework.ClusterA)
+	f.SetNginxReplicaSet(framework.ClusterA, 3)
+
+	By(fmt.Sprintf("Creating a Nginx Headless Service on %q", clusterAName))
+
+	nginxHeadlessClusterA := f.NewNginxHeadlessService(framework.ClusterA)
+
+	f.NewServiceExport(framework.ClusterA, nginxHeadlessClusterA.Name, nginxHeadlessClusterA.Namespace)
+
+	f.AwaitServiceExportedStatusCondition(framework.ClusterA, nginxHeadlessClusterA.Name, nginxHeadlessClusterA.Namespace)
+
+	By(fmt.Sprintf("Creating a Netshoot Deployment on %q", clusterAName))
+
+	netshootPodList := f.NewNetShootDeployment(framework.ClusterA)
+
+	ipList, _ := f.AwaitPodIPs(framework.ClusterA, nginxHeadlessClusterA, 3, true)
+	f.VerifyIPsWithDig(framework.ClusterA, nginxHeadlessClusterA, netshootPodList, ipList, checkedDomains,
+		"", true)
+
+	f.SetNginxReplicaSet(framework.ClusterA, 0)
+	ipList, _ = f.AwaitPodIPs(framework.ClusterA, nginxHeadlessClusterA, 0, true)
+	f.VerifyIPsWithDig(framework.ClusterA, nginxHeadlessClusterA, netshootPodList, ipList, checkedDomains,
+		"", false)
+
+	f.SetNginxReplicaSet(framework.ClusterA, 2)
+	ipList, _ = f.AwaitPodIPs(framework.ClusterA, nginxHeadlessClusterA, 2, true)
+	f.VerifyIPsWithDig(framework.ClusterA, nginxHeadlessClusterA, netshootPodList, ipList, checkedDomains,
 		"", true)
 }
 
@@ -217,12 +255,12 @@ func RunHeadlessDiscoveryClusterNameTest(f *lhframework.Framework) {
 
 	netshootPodList := f.NewNetShootDeployment(framework.ClusterA)
 
-	ipListClusterA, hostNameListA := f.GetPodIPs(framework.ClusterA, nginxHeadlessClusterA)
-	ipListClusterB, hostNameListB := f.GetPodIPs(framework.ClusterB, nginxHeadlessClusterB)
+	ipListClusterA, hostNameListA := f.GetPodIPs(framework.ClusterA, nginxHeadlessClusterA, true)
+	ipListClusterB, hostNameListB := f.GetPodIPs(framework.ClusterB, nginxHeadlessClusterB, false)
 
-	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterA, netshootPodList, ipListClusterA, checkedDomains,
+	f.VerifyIPsWithDig(framework.ClusterA, nginxHeadlessClusterA, netshootPodList, ipListClusterA, checkedDomains,
 		clusterAName, true)
-	verifyHeadlessIpsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipListClusterB, checkedDomains,
+	f.VerifyIPsWithDig(framework.ClusterA, nginxHeadlessClusterB, netshootPodList, ipListClusterB, checkedDomains,
 		clusterBName, true)
 
 	verifyHeadlessSRVRecordsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, hostNameListA, checkedDomains,
@@ -234,61 +272,6 @@ func RunHeadlessDiscoveryClusterNameTest(f *lhframework.Framework) {
 		clusterAName, false, true, true)
 	verifyHeadlessSRVRecordsWithDig(f.Framework, framework.ClusterA, nginxHeadlessClusterB, netshootPodList, hostNameListB, checkedDomains,
 		clusterBName, false, true, true)
-}
-
-// nolint:unparam // cluster` always receives `framework.ClusterA`.
-func verifyHeadlessIpsWithDig(f *framework.Framework, cluster framework.ClusterIndex, service *corev1.Service, targetPod *corev1.PodList,
-	ipList, domains []string, clusterName string, shouldContain bool,
-) {
-	cmd := []string{"dig", "+short"}
-
-	var clusterDNSName string
-	if clusterName != "" {
-		clusterDNSName = clusterName + "."
-	}
-
-	for i := range domains {
-		cmd = append(cmd, clusterDNSName+service.Name+"."+f.Namespace+".svc."+domains[i])
-	}
-
-	op := opAre
-	if !shouldContain {
-		op += not
-	}
-
-	By(fmt.Sprintf("Executing %q to verify IPs %v for service %q %q discoverable", strings.Join(cmd, " "), ipList, service.Name, op))
-	framework.AwaitUntil(" service IP verification", func() (interface{}, error) {
-		stdout, _, err := f.ExecWithOptions(&framework.ExecOptions{
-			Command:       cmd,
-			Namespace:     f.Namespace,
-			PodName:       targetPod.Items[0].Name,
-			ContainerName: targetPod.Items[0].Spec.Containers[0].Name,
-			CaptureStdout: true,
-			CaptureStderr: true,
-		}, cluster)
-		if err != nil {
-			return nil, err
-		}
-
-		return stdout, nil
-	}, func(result interface{}) (bool, string, error) {
-		By(fmt.Sprintf("Validating that dig result %s %q", op, result))
-		if len(ipList) == 0 && result != "" {
-			return false, fmt.Sprintf("expected execution result %q to be empty", result), nil
-		}
-		for _, ip := range ipList {
-			doesContain := strings.Contains(result.(string), ip)
-			if doesContain && !shouldContain {
-				return false, fmt.Sprintf("expected execution result %q not to contain %q", result, ip), nil
-			}
-
-			if !doesContain && shouldContain {
-				return false, fmt.Sprintf("expected execution result %q to contain %q", result, ip), nil
-			}
-		}
-
-		return true, "", nil
-	})
 }
 
 // nolint:gocognit,unparam // This really isn't that complex and would be awkward to refactor.


### PR DESCRIPTION
Backport of #757 on release-0.13.

#757: Return local cluster IP for headless services

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.