### PR TITLE
Use ENV vars instead of flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,23 +25,23 @@ include $(SHIPYARD_DIR)/Makefile.inc
 TARGETS := $(shell ls -p scripts | grep -v -e / -e deploy)
 override E2E_ARGS += cluster1 cluster2 cluster3
 override UNIT_TEST_ARGS += test/e2e
-override DEPLOY_ARGS += --service_discovery
+export LIGHTHOUSE = true
 
 # Targets to make
 
 build: $(ARCH_BINARIES)
 
 bin/%/lighthouse-agent: vendor/modules.txt $(shell find pkg/agent)
-	GOARCH=$(call dockertogoarch,$(patsubst bin/linux/%/,%,$(dir $@))) ${SCRIPTS_DIR}/compile.sh $@ ./pkg/agent $(BUILD_ARGS)
+	GOARCH=$(call dockertogoarch,$(patsubst bin/linux/%/,%,$(dir $@))) ${SCRIPTS_DIR}/compile.sh $@ ./pkg/agent
 
 bin/%/lighthouse-coredns: coredns/vendor/modules.txt $(shell find coredns)
 	mkdir -p $(@D)
-	cd coredns && GOARCH=$(call dockertogoarch,$(patsubst bin/linux/%/,%,$(dir $@))) ${SCRIPTS_DIR}/compile.sh $@ . $(BUILD_ARGS)
+	cd coredns && GOARCH=$(call dockertogoarch,$(patsubst bin/linux/%/,%,$(dir $@))) ${SCRIPTS_DIR}/compile.sh $@ .
 	mv coredns/$@ $@
 
 e2e: vendor/modules.txt
 
-licensecheck: BUILD_ARGS=--noupx
+licensecheck: export BUILD_UPX = false
 licensecheck: $(ARCH_BINARIES) bin/lichen
 	bin/lichen -c .lichen.yaml $(ARCH_BINARIES)
 


### PR DESCRIPTION
Switch to using Shipyard's ENV vars instead of flags, much simpler to
understand.

Depends on https://github.com/submariner-io/shipyard/pull/890

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
