### PR TITLE
Add security-events write permission for reporting

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -34,6 +34,8 @@ jobs:
     name: Vulnerability Scanning
     if: github.repository_owner == 'submariner-io'
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - name: Check out the repository
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b


### PR DESCRIPTION
The Anchore vulnerability scan GitHub Action that reports results on
merges needs the `security-events: write` permission or the
github/codeql-action/upload-sarif step fails with HTTP 403.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
