### PR TITLE
Don't specify images to preload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ PLATFORMS ?= linux/amd64,linux/arm64
 BINARIES := lighthouse-agent lighthouse-coredns
 ARCH_BINARIES := $(foreach platform,$(subst $(comma),$(space),$(PLATFORMS)),$(foreach binary,$(BINARIES),bin/$(call gotodockerarch,$(platform))/$(binary)))
 IMAGES := lighthouse-agent lighthouse-coredns
-PRELOAD_IMAGES := submariner-gateway submariner-operator submariner-route-agent $(IMAGES)
 MULTIARCH_IMAGES := $(IMAGES)
 SETTINGS = $(DAPPER_SOURCE)/.shipyard.e2e.yml
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,12 @@ IMAGES := lighthouse-agent lighthouse-coredns
 MULTIARCH_IMAGES := $(IMAGES)
 SETTINGS = $(DAPPER_SOURCE)/.shipyard.e2e.yml
 
+# TODO: Remove once 0.14.0/0.13.1 helm chart is released
+# This is needed because the operator was erroneously using image names for overrides, and it has been fixed on devel
+ifeq ($(DEPLOYTOOL),helm)
+PRELOAD_IMAGES := submariner-operator
+endif
+
 include $(SHIPYARD_DIR)/Makefile.inc
 
 TARGETS := $(shell ls -p scripts | grep -v -e / -e deploy)


### PR DESCRIPTION
Shipyard now preloads all built images,
there's no need to explicitly preload any images.

Depends on https://github.com/submariner-io/shipyard/pull/937

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
