### PR TITLE
Remove helm jobs

### DIFF
--- a/.github/workflows/e2e-full.yml
+++ b/.github/workflows/e2e-full.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        deploytool: ['operator', 'helm']
+        deploytool: ['operator']
         globalnet: ['', 'globalnet']
         k8s_version: ['1.25']
         include:

--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,6 @@ IMAGES := lighthouse-agent lighthouse-coredns
 MULTIARCH_IMAGES := $(IMAGES)
 SETTINGS = $(DAPPER_SOURCE)/.shipyard.e2e.yml
 
-# TODO: Remove once 0.14.0/0.13.1 helm chart is released
-# This is needed because the operator was erroneously using image names for overrides, and it has been fixed on devel
-ifeq ($(DEPLOYTOOL),helm)
-PRELOAD_IMAGES := submariner-operator
-endif
-
 include $(SHIPYARD_DIR)/Makefile.inc
 
 TARGETS := $(shell ls -p scripts | grep -v -e / -e deploy)


### PR DESCRIPTION
The helm jobs have been failing recently due to mis-matched image versions, ie it's using the latest **submariner-operator** b/c it's specifically pre-loaded for helm but it's using the chart version set in **submariner-charts** for the **submariner-gateway** and **submariner-routeagent** images, which is currently set to _0.13.0-rc2_. So in order to use the latest _devel_ image versions, we'd need to pre-load them all.

Given that and the fact that we don't have helm jobs in the **submariner** and **submariner-operator** repos (or they were removed), it seems inconsistent to test helm in lighthouse so the jobs have been removed.
