### PR TITLE
Automated backport of #880: Use the default kind CNI

### DIFF
--- a/.shipyard.e2e.yml
+++ b/.shipyard.e2e.yml
@@ -1,5 +1,4 @@
 ---
-cni: weave
 submariner: true
 nodes: control-plane
 clusters:


### PR DESCRIPTION
Backport of #880 on release-0.12.

#880: Use the default kind CNI

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.