### PR TITLE
Don't use local lighthouse in coredns go.mod

### DIFF
--- a/coredns/go.mod
+++ b/coredns/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.13.0
 	github.com/submariner-io/admiral v0.14.0-rc1
-	github.com/submariner-io/lighthouse v0.14.0-m1
+	github.com/submariner-io/lighthouse v0.14.0-rc1
 	k8s.io/api v0.25.0
 	k8s.io/apimachinery v0.25.0
 	k8s.io/client-go v0.24.4
@@ -19,8 +19,11 @@ require (
 	sigs.k8s.io/mcs-api v0.1.0
 )
 
+// Pin to a non-local version of lighthouse. This is not ideal, but there's a limitation in Cachito.
+// This will hopefully be fixed, but need a workaround for now.
+// https://issues.redhat.com/browse/CLOUDBLD-10559
 // Local project
-replace github.com/submariner-io/lighthouse => ../
+// replace github.com/submariner-io/lighthouse => ../
 
 require (
 	cloud.google.com/go/compute v1.7.0 // indirect

--- a/coredns/go.sum
+++ b/coredns/go.sum
@@ -864,6 +864,8 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/submariner-io/admiral v0.14.0-rc1 h1:ug2Pfn6v4+TnheKdCokGPAj7YbsqBF/tqV5g0Q/e/M8=
 github.com/submariner-io/admiral v0.14.0-rc1/go.mod h1:MCrpioCaH1MOMusxUUeBlyW1ncCWiBDAT+YS8vDzCKk=
+github.com/submariner-io/lighthouse v0.14.0-rc1 h1:g893e9PGAS7qOP2XhaKcpvmKD5xflKCcZA3sMFPZGPE=
+github.com/submariner-io/lighthouse v0.14.0-rc1/go.mod h1:jTXEBZKCIRbYIK9/tu3L3ukSoo9XgBksdU4f+SS+DGQ=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tidwall/btree v0.3.0/go.mod h1:huei1BkDWJ3/sLXmO+bsCNELL+Bp2Kks9OLyQFkzvA8=
 github.com/tidwall/btree v1.1.0/go.mod h1:TzIRzen6yHbibdSfK6t8QimqbUnoxUSrZfeW7Uob0q4=


### PR DESCRIPTION
This is a temporary workaround to avoid a limitation in Cachito.

https://issues.redhat.com/browse/CLOUDBLD-10559

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>
(cherry picked from commit f0633b1e78ebb36d0555cfc3a9d2db9a6214e516)