### PR TITLE
Increase the dig timeout to 20s

### DIFF
--- a/test/e2e/discovery/headless_services.go
+++ b/test/e2e/discovery/headless_services.go
@@ -332,7 +332,7 @@ func verifyHeadlessSRVRecordsWithDig(f *framework.Framework, cluster framework.C
 func createSRVQuery(f *framework.Framework, port *corev1.ServicePort, service *corev1.Service,
 	domain string, clusterName string, withPort, withcluster bool,
 ) (cmd []string, domainName string) {
-	cmd = []string{"dig", "+short", "SRV"}
+	cmd = []string{"dig", "+short", "+timeout=20", "SRV"}
 
 	domainName = service.Name + "." + f.Namespace + ".svc." + domain
 	clusterDNSName := domainName

--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -527,7 +527,7 @@ func verifySRVWithDig(f *framework.Framework, srcCluster framework.ClusterIndex,
 	ports := service.Spec.Ports
 	for i := range domains {
 		for _, port := range ports {
-			cmd := []string{"dig", "+short", "SRV"}
+			cmd := []string{"dig", "+short", "+timeout=20", "SRV"}
 
 			clusterDNSName := service.Name + "." + f.Namespace + ".svc." + domains[i]
 
@@ -592,7 +592,7 @@ func verifySRVWithDig(f *framework.Framework, srcCluster framework.ClusterIndex,
 func verifyRoundRobinWithDig(f *framework.Framework, srcCluster framework.ClusterIndex, serviceName string, serviceIPList []string,
 	targetPod *corev1.PodList, domains []string,
 ) {
-	cmd := []string{"dig", "+short"}
+	cmd := []string{"dig", "+short", "+timeout=20"}
 
 	for i := range domains {
 		cmd = append(cmd, serviceName+"."+f.Namespace+".svc."+domains[i])

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -570,7 +570,7 @@ func (f *Framework) VerifyServiceIPWithDig(srcCluster, targetCluster framework.C
 func (f *Framework) VerifyIPWithDig(srcCluster framework.ClusterIndex, service *v1.Service, targetPod *v1.PodList,
 	domains []string, clusterName, serviceIP string, shouldContain bool,
 ) {
-	cmd := []string{"dig", "+short"}
+	cmd := []string{"dig", "+short", "+timeout=20"}
 
 	var clusterDNSName string
 	if clusterName != "" {
@@ -619,7 +619,7 @@ func (f *Framework) VerifyIPWithDig(srcCluster framework.ClusterIndex, service *
 func (f *Framework) VerifyIPsWithDig(cluster framework.ClusterIndex, service *v1.Service, targetPod *v1.PodList,
 	ipList, domains []string, clusterName string, shouldContain bool,
 ) {
-	cmd := []string{"dig", "+short"}
+	cmd := []string{"dig", "+short", "+timeout=20"}
 
 	var clusterDNSName string
 	if clusterName != "" {


### PR DESCRIPTION
We're seeing e2e failures with dig exiting with code 9, "No reply from server". This increases the dig timeout to reduce the risk of prematurely aborting the test.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
