### PR TITLE
Run dependabot for go weekly, all updates at once

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,16 +23,14 @@ updates:
   - package-ecosystem: gomod
     directory: "/"
     schedule:
-      interval: daily
-    open-pull-requests-limit: 10
+      interval: weekly
     ignore:
       # Our own dependencies are handled during releases
       - dependency-name: github.com/submariner-io/*
   - package-ecosystem: gomod
     directory: "/coredns"
     schedule:
-      interval: daily
-    open-pull-requests-limit: 10
+      interval: weekly
     ignore:
       # Our own dependencies are handled during releases
       - dependency-name: github.com/submariner-io/*


### PR DESCRIPTION
To minimize the code review work required to merge go update PRs, cause
dependabot to give us all the updates at the same time, once a week.
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
