### PR TITLE
Remove legacy label checks for Endpointslices

### DIFF
--- a/coredns/endpointslice/map.go
+++ b/coredns/endpointslice/map.go
@@ -112,11 +112,6 @@ func (m *Map) Put(es *discovery.EndpointSlice) {
 
 	cluster, ok := es.Labels[constants.MCSLabelSourceCluster]
 
-	// Remove this after 0.12 (this handles old map entries with pre-MCS labels)
-	if !ok {
-		cluster, ok = es.Labels[constants.LighthouseLabelSourceCluster]
-	}
-
 	if !ok {
 		klog.Warningf("Cluster label missing on %#v", es.ObjectMeta)
 		return
@@ -229,11 +224,6 @@ func (m *Map) Remove(es *discovery.EndpointSlice) {
 	key, ok := getKey(es)
 	if ok {
 		cluster, ok := es.Labels[constants.MCSLabelSourceCluster]
-
-		// Remove this after 0.12 (this handles old map entries with pre-MCS labels)
-		if !ok {
-			cluster, ok = es.Labels[constants.LighthouseLabelSourceCluster]
-		}
 
 		if !ok {
 			return

--- a/pkg/agent/controller/endpoint.go
+++ b/pkg/agent/controller/endpoint.go
@@ -113,19 +113,6 @@ func (e *EndpointController) cleanup() {
 	if err != nil && !apierrors.IsNotFound(err) {
 		logger.Errorf(err, "Error deleting the EndpointSlices associated with ServiceImport %q", e.serviceImportName)
 	}
-
-	// Lighthouse-proprietary labels
-	err = resourceClient.DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(map[string]string{
-			constants.LabelSourceNamespace:         e.serviceImportSourceNameSpace,
-			constants.LighthouseLabelSourceCluster: e.clusterID,
-			constants.LighthouseLabelSourceName:    e.serviceName,
-		}).String(),
-	})
-
-	if err != nil && !apierrors.IsNotFound(err) {
-		logger.Errorf(err, "Error deleting the EndpointSlices associated with ServiceImport %q", e.serviceImportName)
-	}
 }
 
 func (e *EndpointController) endpointsToEndpointSlice(obj runtime.Object, numRequeues int, op syncer.Operation) (runtime.Object, bool) {


### PR DESCRIPTION
The proprietary `LighthouseLabelSourceCluster` et al labels were replaced with the MSC-standard labels in 0.12 but some checks were left in for migration.
