### PR TITLE
Remove origin-name[space] annotations for ServiceImport

### DIFF
--- a/coredns/plugin/handler_test.go
+++ b/coredns/plugin/handler_test.go
@@ -1045,11 +1045,9 @@ func newServiceImport(namespace, name, clusterID, serviceIP, portName string,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Annotations: map[string]string{
-				"origin-name":      name,
-				"origin-namespace": namespace,
-			},
 			Labels: map[string]string{
+				constants.LighthouseLabelSourceName:    name,
+				constants.LabelSourceNamespace:         namespace,
 				constants.LighthouseLabelSourceCluster: clusterID,
 			},
 		},

--- a/coredns/serviceimport/controller_test.go
+++ b/coredns/serviceimport/controller_test.go
@@ -149,11 +149,9 @@ func newServiceImport(namespace, name, serviceIP, clusterID string) *mcsv1a1.Ser
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name + "-" + namespace + "-" + clusterID,
 			Namespace: namespace,
-			Annotations: map[string]string{
-				"origin-name":      name,
-				"origin-namespace": namespace,
-			},
 			Labels: map[string]string{
+				constants.LighthouseLabelSourceName:    name,
+				constants.LabelSourceNamespace:         namespace,
 				constants.LighthouseLabelSourceCluster: clusterID,
 			},
 		},

--- a/coredns/serviceimport/map.go
+++ b/coredns/serviceimport/map.go
@@ -132,8 +132,8 @@ func NewMap(localClusterID string) *Map {
 }
 
 func (m *Map) Put(serviceImport *mcsv1a1.ServiceImport) {
-	if name, ok := serviceImport.Annotations["origin-name"]; ok {
-		namespace := serviceImport.Annotations["origin-namespace"]
+	if name, ok := serviceImport.Labels[constants.LighthouseLabelSourceName]; ok {
+		namespace := serviceImport.Labels[constants.LabelSourceNamespace]
 		key := keyFunc(namespace, name)
 
 		m.mutex.Lock()
@@ -175,8 +175,8 @@ func (m *Map) Put(serviceImport *mcsv1a1.ServiceImport) {
 }
 
 func (m *Map) Remove(serviceImport *mcsv1a1.ServiceImport) {
-	if name, ok := serviceImport.Annotations["origin-name"]; ok {
-		namespace := serviceImport.Annotations["origin-namespace"]
+	if name, ok := serviceImport.Labels[constants.LighthouseLabelSourceName]; ok {
+		namespace := serviceImport.Labels[constants.LabelSourceNamespace]
 		key := keyFunc(namespace, name)
 
 		m.mutex.Lock()

--- a/pkg/agent/controller/controller_suite_test.go
+++ b/pkg/agent/controller/controller_suite_test.go
@@ -358,8 +358,8 @@ func findServiceImport(client dynamic.ResourceInterface, namespace, name string)
 	Expect(err).To(Succeed())
 
 	for i := range list.Items {
-		if list.Items[i].GetAnnotations()[constants.OriginName] == name &&
-			list.Items[i].GetAnnotations()[constants.OriginNamespace] == namespace {
+		if list.Items[i].GetLabels()[constants.LighthouseLabelSourceName] == name &&
+			list.Items[i].GetLabels()[constants.LabelSourceNamespace] == namespace {
 			serviceImport := &mcsv1a1.ServiceImport{}
 			Expect(scheme.Scheme.Convert(&list.Items[i], serviceImport, nil)).To(Succeed())
 

--- a/pkg/agent/controller/serviceimport.go
+++ b/pkg/agent/controller/serviceimport.go
@@ -106,9 +106,8 @@ func (c *ServiceImportController) serviceImportCreatedOrUpdated(serviceImport *m
 		return false
 	}
 
-	annotations := serviceImport.ObjectMeta.Annotations
-	serviceNameSpace := annotations[constants.OriginNamespace]
-	serviceName := annotations[constants.OriginName]
+	serviceNameSpace := serviceImport.Labels[constants.LabelSourceNamespace]
+	serviceName := serviceImport.Labels[constants.LighthouseLabelSourceName]
 
 	endpointController, err := startEndpointController(c.localClient, c.restMapper, c.scheme,
 		serviceImport, serviceNameSpace, serviceName, c.clusterID, c.globalIngressIPCache)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -23,8 +23,6 @@ import (
 )
 
 const (
-	OriginName                   = "origin-name"
-	OriginNamespace              = "origin-namespace"
 	LighthouseLabelSourceName    = "lighthouse.submariner.io/sourceName"
 	LabelSourceNamespace         = "lighthouse.submariner.io/sourceNamespace"
 	LighthouseLabelSourceCluster = "lighthouse.submariner.io/sourceCluster"


### PR DESCRIPTION
...in lieu of the equivalent labels (`LighthouseLabelSourceCluster` and `LabelSourceNamespace` constants) which were added later.

