### PR TITLE
Consistently use the coredns logger in the plugin

### DIFF
--- a/coredns/endpointslice/controller.go
+++ b/coredns/endpointslice/controller.go
@@ -22,6 +22,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/lighthouse/coredns/constants"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,8 +32,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+var logger = log.Logger{Logger: logf.Log.WithName("EndpointSlice")}
 
 type NewClientsetFunc func(kubeConfig *rest.Config) (kubernetes.Interface, error)
 
@@ -67,7 +70,7 @@ func getNewClientsetFunc() NewClientsetFunc {
 }
 
 func (c *Controller) Start(kubeConfig *rest.Config) error {
-	klog.Infof("Starting EndpointSlice Controller")
+	logger.Infof("Starting EndpointSlice Controller")
 
 	clientSet, err := c.NewClientset(kubeConfig)
 	if err != nil {
@@ -107,14 +110,14 @@ func (c *Controller) Start(kubeConfig *rest.Config) error {
 				if endpointSlice, ok = obj.(*discovery.EndpointSlice); !ok {
 					tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 					if !ok {
-						klog.Errorf("Failed to get deleted endpointSlice object %v", obj)
+						logger.Errorf(nil, "Failed to get deleted endpointSlice object %v", obj)
 						return
 					}
 
 					endpointSlice, ok = tombstone.Obj.(*discovery.EndpointSlice)
 
 					if !ok {
-						klog.Errorf("Failed to convert deleted tombstone object %v  to endpointSlice", tombstone.Obj)
+						logger.Errorf(nil, "Failed to convert deleted tombstone object %v  to endpointSlice", tombstone.Obj)
 						return
 					}
 				}
@@ -131,7 +134,7 @@ func (c *Controller) Start(kubeConfig *rest.Config) error {
 func (c *Controller) Stop() {
 	close(c.stopCh)
 
-	klog.Infof("EndpointSlice Controller stopped")
+	logger.Infof("EndpointSlice Controller stopped")
 }
 
 func (c *Controller) IsHealthy(name, namespace, clusterID string) bool {

--- a/coredns/endpointslice/map.go
+++ b/coredns/endpointslice/map.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/klog/v2"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
@@ -106,14 +105,14 @@ func NewMap(localClusterID string, kubeClient kubernetes.Interface) *Map {
 func (m *Map) Put(es *discovery.EndpointSlice) {
 	key, ok := getKey(es)
 	if !ok {
-		klog.Warningf("Failed to get key labels from %#v", es.ObjectMeta)
+		logger.Warningf("Failed to get key labels from %#v", es.ObjectMeta)
 		return
 	}
 
 	cluster, ok := es.Labels[constants.MCSLabelSourceCluster]
 
 	if !ok {
-		klog.Warningf("Cluster label missing on %#v", es.ObjectMeta)
+		logger.Warningf("Cluster label missing on %#v", es.ObjectMeta)
 		return
 	}
 
@@ -143,8 +142,8 @@ func (m *Map) Put(es *discovery.EndpointSlice) {
 			return nil
 		})
 		if retryErr != nil {
-			klog.Errorf("Error finding local endpoint slice for service (%s/%s): %+v", es.Labels[constants.LabelSourceNamespace],
-				es.Labels[constants.MCSLabelServiceName], retryErr)
+			logger.Errorf(retryErr, "Error finding local endpoint slice for service (%s/%s)", es.Labels[constants.LabelSourceNamespace],
+				es.Labels[constants.MCSLabelServiceName])
 			return
 		}
 		if localSlice == nil {
@@ -215,7 +214,7 @@ func (m *Map) Put(es *discovery.EndpointSlice) {
 		epInfo.clusterInfo[cluster].recordList = append(epInfo.clusterInfo[cluster].recordList, records...)
 	}
 
-	klog.V(log.DEBUG).Infof("Adding clusterInfo %#v for EndpointSlice %q in %q", epInfo.clusterInfo[cluster], es.Name, cluster)
+	logger.V(log.DEBUG).Infof("Adding clusterInfo %#v for EndpointSlice %q in %q", epInfo.clusterInfo[cluster], es.Name, cluster)
 
 	m.epMap[key] = epInfo
 }
@@ -237,7 +236,7 @@ func (m *Map) Remove(es *discovery.EndpointSlice) {
 			return
 		}
 
-		klog.V(log.DEBUG).Infof("Adding endpointInfo %#v for %s in %s", epInfo.clusterInfo[cluster], es.Name, cluster)
+		logger.V(log.DEBUG).Infof("Adding endpointInfo %#v for %s in %s", epInfo.clusterInfo[cluster], es.Name, cluster)
 		delete(epInfo.clusterInfo, cluster)
 	}
 }

--- a/coredns/endpointslice/suite_test.go
+++ b/coredns/endpointslice/suite_test.go
@@ -23,12 +23,16 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/klog/v2"
+	"github.com/submariner-io/admiral/pkg/log/kzerolog"
 )
 
 func init() {
-	klog.InitFlags(nil)
+	kzerolog.AddFlags(nil)
 }
+
+var _ = BeforeSuite(func() {
+	kzerolog.InitK8sLogging()
+})
 
 func TestEndpointSlice(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/coredns/gateway/controller_test.go
+++ b/coredns/gateway/controller_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/fake"
+	"github.com/submariner-io/admiral/pkg/log/kzerolog"
 	"github.com/submariner-io/lighthouse/coredns/gateway"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -35,7 +36,6 @@ import (
 	"k8s.io/client-go/dynamic"
 	fakeClient "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/rest"
-	"k8s.io/klog/v2"
 )
 
 const (
@@ -268,8 +268,12 @@ func newGateway() *unstructured.Unstructured {
 }
 
 func init() {
-	klog.InitFlags(nil)
+	kzerolog.AddFlags(nil)
 }
+
+var _ = BeforeSuite(func() {
+	kzerolog.InitK8sLogging()
+})
 
 func TestGateway(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/coredns/go.mod
+++ b/coredns/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/coredns/caddy v1.1.1
 	github.com/coredns/coredns v1.10.0
+	github.com/go-logr/logr v1.2.3
 	github.com/miekg/dns v1.1.50
 	github.com/onsi/ginkgo/v2 v2.6.1
 	github.com/onsi/gomega v1.24.2
@@ -14,7 +15,7 @@ require (
 	k8s.io/api v0.26.0
 	k8s.io/apimachinery v0.26.0
 	k8s.io/client-go v0.26.0
-	k8s.io/klog/v2 v2.80.1
+	sigs.k8s.io/controller-runtime v0.14.1
 	sigs.k8s.io/mcs-api v0.1.0
 )
 
@@ -33,7 +34,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect
-	github.com/coreos/go-systemd/v22 v22.3.2 // indirect
+	github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgraph-io/ristretto v0.1.0 // indirect
 	github.com/dnstap/golang-dnstap v0.4.0 // indirect
@@ -43,7 +44,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/farsightsec/golang-framestream v0.3.0 // indirect
 	github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 // indirect
-	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect
@@ -60,6 +60,8 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
@@ -72,6 +74,7 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
+	github.com/rs/zerolog v1.28.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tinylib/msgp v1.1.2 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.4 // indirect
@@ -98,9 +101,10 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/klog v1.0.0 // indirect
+	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448 // indirect
-	sigs.k8s.io/controller-runtime v0.14.1 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/coredns/go.sum
+++ b/coredns/go.sum
@@ -181,8 +181,9 @@ github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
-github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzAJc1DzSI=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534 h1:rtAn27wIbmOGUs7RIbVgPEjb31ehTVniDwPGXyMxm5U=
+github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
@@ -701,6 +702,7 @@ github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope
 github.com/mattn/go-colorable v0.1.7/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
+github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
@@ -874,9 +876,11 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
+github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=
 github.com/rs/zerolog v1.28.0 h1:MirSo27VyNi7RJYP3078AA1+Cyzd2GB66qy3aUHvsWY=
+github.com/rs/zerolog v1.28.0/go.mod h1:NILgTygv/Uej1ra5XxGf82ZFSLk58MFGAUS2o6usyD0=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=

--- a/coredns/loadbalancer/smooth_weighted_round_robin.go
+++ b/coredns/loadbalancer/smooth_weighted_round_robin.go
@@ -21,8 +21,11 @@ package loadbalancer
 import (
 	"fmt"
 
-	"k8s.io/klog/v2"
+	"github.com/submariner-io/admiral/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+var logger = log.Logger{Logger: logf.Log.WithName("LoadBalancer")}
 
 type weightedItem struct {
 	item            interface{}
@@ -52,7 +55,7 @@ func (lb *smoothWeightedRR) Skip(item interface{}) {
 			wt.effectiveWeight = 0
 		}
 	} else {
-		klog.Errorf("Could not find item to skip: %v", item)
+		logger.Errorf(nil, "Could not find item to skip: %v", item)
 	}
 }
 

--- a/coredns/loadbalancer/suite_test.go
+++ b/coredns/loadbalancer/suite_test.go
@@ -23,7 +23,16 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/log/kzerolog"
 )
+
+func init() {
+	kzerolog.AddFlags(nil)
+}
+
+var _ = BeforeSuite(func() {
+	kzerolog.InitK8sLogging()
+})
 
 func TestLoadBalancer(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/coredns/plugin/coredns_log_sink.go
+++ b/coredns/plugin/coredns_log_sink.go
@@ -1,0 +1,79 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lighthouse
+
+import (
+	"fmt"
+
+	clog "github.com/coredns/coredns/plugin/pkg/log"
+	"github.com/go-logr/logr"
+	loga "github.com/submariner-io/admiral/pkg/log"
+)
+
+type corednsLogSink struct {
+	log clog.P
+}
+
+func (c *corednsLogSink) Init(_ logr.RuntimeInfo) {
+}
+
+func (c *corednsLogSink) Enabled(_ int) bool {
+	return true
+}
+
+func (c *corednsLogSink) Info(level int, msg string, kvList ...interface{}) {
+	for i := 0; i < len(kvList); i += 2 {
+		s, ok := kvList[i].(string)
+		if ok && s == loga.WarningKey {
+			c.log.Warning(msg)
+			return
+		}
+	}
+
+	if level >= loga.DEBUG {
+		c.log.Debug(msg)
+		return
+	}
+
+	c.log.Info(msg)
+}
+
+func (c *corednsLogSink) Error(err error, msg string, kvList ...interface{}) {
+	if err != nil {
+		msg = fmt.Sprintf("%s error=%s", msg, err.Error())
+	}
+
+	for i := 0; i < len(kvList); i += 2 {
+		s, ok := kvList[i].(string)
+		if ok && s == loga.FatalKey {
+			c.log.Fatal(msg)
+			return
+		}
+	}
+
+	c.log.Error(msg)
+}
+
+func (c *corednsLogSink) WithValues(_ ...interface{}) logr.LogSink {
+	return c
+}
+
+func (c *corednsLogSink) WithName(name string) logr.LogSink {
+	return &corednsLogSink{log: clog.NewWithPlugin(fmt.Sprintf("%s(%s)", PluginName, name))}
+}

--- a/coredns/plugin/lighthouse.go
+++ b/coredns/plugin/lighthouse.go
@@ -24,8 +24,10 @@ import (
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/pkg/fall"
 	clog "github.com/coredns/coredns/plugin/pkg/log"
+	"github.com/go-logr/logr"
 	"github.com/submariner-io/lighthouse/coredns/endpointslice"
 	"github.com/submariner-io/lighthouse/coredns/serviceimport"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -66,3 +68,7 @@ type EndpointsStatus interface {
 }
 
 var _ plugin.Handler = &Lighthouse{}
+
+func init() {
+	logf.SetLogger(logr.New(&corednsLogSink{log: log}))
+}

--- a/coredns/plugin/metrics.go
+++ b/coredns/plugin/metrics.go
@@ -20,7 +20,6 @@ package lighthouse
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/klog/v2"
 )
 
 const (
@@ -36,7 +35,7 @@ const (
 var dnsQueryCounter *prometheus.GaugeVec
 
 func init() {
-	klog.Infof("Initializing dns query counter")
+	log.Infof("Initializing dns query counter")
 
 	dnsQueryCounter = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{

--- a/coredns/plugin/plugin_suite_test.go
+++ b/coredns/plugin/plugin_suite_test.go
@@ -21,9 +21,14 @@ package lighthouse_test
 import (
 	"testing"
 
+	"github.com/coredns/coredns/plugin/pkg/log"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+func init() {
+	log.D.Set()
+}
 
 func TestPlugin(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/coredns/service/controller.go
+++ b/coredns/service/controller.go
@@ -20,7 +20,9 @@ package service
 
 import (
 	"context"
+
 	"github.com/submariner-io/lighthouse/coredns/serviceimport"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
@@ -31,9 +33,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
+
+var logger = log.Logger{Logger: logf.Log.WithName("Service")}
 
 type Controller struct {
 	// Indirection hook for unit tests to supply fake client sets
@@ -55,7 +58,7 @@ func NewController(localClusterID string) *Controller {
 }
 
 func (c *Controller) Start(kubeConfig *rest.Config) error {
-	klog.Infof("Starting Services Controller")
+	logger.Infof("Starting Services Controller")
 
 	clientSet, err := c.NewClientset(kubeConfig)
 	if err != nil {
@@ -89,7 +92,7 @@ func (c *Controller) Start(kubeConfig *rest.Config) error {
 func (c *Controller) Stop() {
 	close(c.stopCh)
 
-	klog.Infof("Services Controller stopped")
+	logger.Infof("Services Controller stopped")
 }
 
 func (c *Controller) GetIP(name, namespace string) (*serviceimport.DNSRecord, bool) {
@@ -97,7 +100,7 @@ func (c *Controller) GetIP(name, namespace string) (*serviceimport.DNSRecord, bo
 
 	obj, exists, err := c.svcStore.GetByKey(key)
 	if err != nil {
-		klog.V(log.DEBUG).Infof("Error trying to get service for key %q", key)
+		logger.V(log.DEBUG).Infof("Error trying to get service for key %q", key)
 		return nil, false
 	}
 

--- a/coredns/serviceimport/controller.go
+++ b/coredns/serviceimport/controller.go
@@ -26,11 +26,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 	mcsClientset "sigs.k8s.io/mcs-api/pkg/client/clientset/versioned"
 	mcsInformers "sigs.k8s.io/mcs-api/pkg/client/informers/externalversions"
 )
+
+var logger = log.Logger{Logger: logf.Log.WithName("ServiceImport")}
 
 type NewClientsetFunc func(kubeConfig *rest.Config) (mcsClientset.Interface, error)
 
@@ -64,7 +66,7 @@ func getNewClientsetFunc() NewClientsetFunc {
 }
 
 func (c *Controller) Start(kubeConfig *rest.Config) error {
-	klog.Infof("Starting ServiceImport Controller")
+	logger.Infof("Starting ServiceImport Controller")
 
 	clientSet, err := c.NewClientset(kubeConfig)
 	if err != nil {
@@ -95,17 +97,17 @@ func (c *Controller) Start(kubeConfig *rest.Config) error {
 func (c *Controller) Stop() {
 	close(c.stopCh)
 
-	klog.Infof("ServiceImport Controller stopped")
+	logger.Infof("ServiceImport Controller stopped")
 }
 
 func (c *Controller) serviceImportCreatedOrUpdated(obj interface{}) {
-	klog.V(log.DEBUG).Infof("In serviceImportCreatedOrUpdated for: %#v, ", obj)
+	logger.V(log.DEBUG).Infof("In serviceImportCreatedOrUpdated for: %#v, ", obj)
 
 	c.store.Put(obj.(*mcsv1a1.ServiceImport))
 }
 
 func (c *Controller) serviceImportDeleted(obj interface{}) {
-	klog.V(log.DEBUG).Infof("In serviceImportDeleted for: %#v, ", obj)
+	logger.V(log.DEBUG).Infof("In serviceImportDeleted for: %#v, ", obj)
 
 	var si *mcsv1a1.ServiceImport
 	var ok bool
@@ -113,13 +115,13 @@ func (c *Controller) serviceImportDeleted(obj interface{}) {
 	if si, ok = obj.(*mcsv1a1.ServiceImport); !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			klog.Errorf("Could not convert object %#v to DeletedFinalStateUnknown", obj)
+			logger.Errorf(nil, "Could not convert object %#v to DeletedFinalStateUnknown", obj)
 			return
 		}
 
 		si, ok = tombstone.Obj.(*mcsv1a1.ServiceImport)
 		if !ok {
-			klog.Errorf("Could not convert object tombstone %#v to Unstructured", tombstone.Obj)
+			logger.Errorf(nil, "Could not convert object tombstone %#v to Unstructured", tombstone.Obj)
 			return
 		}
 	}

--- a/coredns/serviceimport/map.go
+++ b/coredns/serviceimport/map.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/submariner-io/lighthouse/coredns/constants"
 	"github.com/submariner-io/lighthouse/coredns/loadbalancer"
-	"k8s.io/klog/v2"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
@@ -54,7 +53,7 @@ func (si *serviceInfo) resetLoadBalancing() {
 	for _, info := range si.records {
 		err := si.balancer.Add(info.name, info.weight)
 		if err != nil {
-			klog.Error(err)
+			logger.Error(err, "Error adding load balancer info")
 		}
 	}
 }
@@ -207,7 +206,7 @@ func getServiceWeightFrom(si *mcsv1a1.ServiceImport, forClusterName string) int6
 			return f
 		}
 
-		klog.Errorf("Error: %v parsing the %q annotation from ServiceImport %q", err, weightKey, si.Name)
+		logger.Errorf(err, "Error parsing the %q annotation from ServiceImport %q", weightKey, si.Name)
 	}
 
 	return 1 // Zero will cause no selection

--- a/coredns/serviceimport/suite_test.go
+++ b/coredns/serviceimport/suite_test.go
@@ -23,12 +23,16 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/klog/v2"
+	"github.com/submariner-io/admiral/pkg/log/kzerolog"
 )
 
 func init() {
-	klog.InitFlags(nil)
+	kzerolog.AddFlags(nil)
 }
+
+var _ = BeforeSuite(func() {
+	kzerolog.InitK8sLogging()
+})
 
 func TestServiceImport(t *testing.T) {
 	RegisterFailHandler(Fail)


### PR DESCRIPTION
Modified the plugin helper modules (_endpointslice_, _serviceimport_ et al) to use the `coredns` logger (indirectly via the `logr` interface) instead of `klog`.
