### PR TITLE
Resolve service to serviceimport IP

### DIFF
--- a/coredns/plugin/record.go
+++ b/coredns/plugin/record.go
@@ -99,13 +99,8 @@ func (lh *Lighthouse) createSRVRecords(dnsrecords []serviceimport.DNSRecord, sta
 func (lh *Lighthouse) getClusterIPForSvc(pReq *recordRequest) (*serviceimport.DNSRecord, bool) {
 	localClusterID := lh.ClusterStatus.LocalClusterID()
 
-	record, found, isLocal := lh.ServiceImports.GetIP(pReq.namespace, pReq.service, pReq.cluster, localClusterID, lh.ClusterStatus.IsConnected,
+	record, found, _ := lh.ServiceImports.GetIP(pReq.namespace, pReq.service, pReq.cluster, localClusterID, lh.ClusterStatus.IsConnected,
 		lh.EndpointsStatus.IsHealthy)
-
-	getLocal := isLocal || pReq.cluster != "" && pReq.cluster == localClusterID
-	if found && getLocal {
-		record, found = lh.LocalServices.GetIP(pReq.service, pReq.namespace)
-	}
 
 	return record, found
 }

--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -189,8 +189,10 @@ func RunServiceDiscoveryLocalTest(f *lhframework.Framework) {
 	netshootPodList := f.NewNetShootDeployment(framework.ClusterA)
 	clusterADomain := getClusterDomain(f.Framework, framework.ClusterA, netshootPodList)
 
-	f.VerifyServiceIPWithDig(framework.ClusterA, framework.ClusterA, nginxServiceClusterA, netshootPodList,
-		[]string{clusterADomain}, "", true)
+	if !framework.TestContext.GlobalnetEnabled {
+		f.VerifyServiceIPWithDig(framework.ClusterA, framework.ClusterA, nginxServiceClusterA, netshootPodList,
+			[]string{clusterADomain}, "", true)
+	}
 
 	f.DeleteService(framework.ClusterA, nginxServiceClusterA.Name)
 
@@ -345,15 +347,26 @@ func RunServicesPodAvailabilityMultiClusterTest(f *lhframework.Framework) {
 	f.SetNginxReplicaSet(framework.ClusterC, 0)
 
 	f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace, 2, 1)
-	f.VerifyServiceIPWithDig(framework.ClusterA, framework.ClusterA, nginxServiceClusterC, netshootPodList, checkedDomains,
-		"", false)
+
+	if framework.TestContext.GlobalnetEnabled {
+		f.VerifyIPWithDig(framework.ClusterA, nginxServiceClusterC, netshootPodList, checkedDomains, "", "1.2.3.4", false)
+	} else {
+		f.VerifyServiceIPWithDig(framework.ClusterA, framework.ClusterA, nginxServiceClusterC, netshootPodList, checkedDomains,
+			"", false)
+	}
+
 	f.VerifyServiceIPWithDig(framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains,
 		"", true)
-
 	f.SetNginxReplicaSet(framework.ClusterB, 0)
 	f.AwaitEndpointSlices(framework.ClusterA, nginxServiceClusterC.Name, nginxServiceClusterC.Namespace, 2, 0)
-	f.VerifyServiceIPWithDig(framework.ClusterA, framework.ClusterA, nginxServiceClusterC, netshootPodList, checkedDomains,
-		"", false)
+
+	if framework.TestContext.GlobalnetEnabled {
+		f.VerifyIPWithDig(framework.ClusterA, nginxServiceClusterC, netshootPodList, checkedDomains, "", "1.2.3.4", false)
+	} else {
+		f.VerifyServiceIPWithDig(framework.ClusterA, framework.ClusterA, nginxServiceClusterC, netshootPodList, checkedDomains,
+			"", false)
+	}
+
 	f.VerifyServiceIPWithDig(framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, checkedDomains,
 		"", false)
 }

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -671,7 +671,7 @@ func (f *Framework) VerifyIPsWithDig(cluster framework.ClusterIndex, service *v1
 func (f *Framework) GetServiceIP(svcCluster framework.ClusterIndex, service *v1.Service, isLocal bool) string {
 	Expect(service.Spec.Type).To(Equal(v1.ServiceTypeClusterIP))
 
-	if !framework.TestContext.GlobalnetEnabled || isLocal {
+	if !framework.TestContext.GlobalnetEnabled {
 		return service.Spec.ClusterIP
 	}
 


### PR DESCRIPTION
Always resolve service to the IP appears in serviceimport resource.

Fixes: https://github.com/submariner-io/lighthouse/issues/993
Depend On: https://github.com/submariner-io/lighthouse/pull/1068

Signed-off-by: Yossi Boaron <yboaron@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
