### PR TITLE
Merge service ports in CoreDNS plugin

### DIFF
--- a/coredns/go.mod
+++ b/coredns/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/onsi/gomega v1.25.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
-	github.com/submariner-io/admiral v0.15.0-m2
+	github.com/submariner-io/admiral v0.15.0-m2.0.20230130142626-bfcd3f831286
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1

--- a/coredns/go.sum
+++ b/coredns/go.sum
@@ -453,8 +453,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/submariner-io/admiral v0.15.0-m2 h1:5xyFwjyd/1aCkAEd+E0sZIZdD9Z3L1uIkkLdZtu32ng=
-github.com/submariner-io/admiral v0.15.0-m2/go.mod h1:A939fnN3wDeKfrRSL+68mlUjRFvDj40bfGA+YQNlKSQ=
+github.com/submariner-io/admiral v0.15.0-m2.0.20230130142626-bfcd3f831286 h1:GiGGZvyxzzPCHJcn91/78DfMVp386RBD2IX+NxJvVIY=
+github.com/submariner-io/admiral v0.15.0-m2.0.20230130142626-bfcd3f831286/go.mod h1:gg9vi4qrzjJmvG6vdVv+Ym5hWt6n2yE0p9moOMOnioM=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tinylib/msgp v1.1.6 h1:i+SbKraHhnrf9M5MYmvQhFnbLhAXSDWF8WWsuyRdocw=

--- a/coredns/serviceimport/controller_test.go
+++ b/coredns/serviceimport/controller_test.go
@@ -144,7 +144,7 @@ func testLifecycleNotifications() {
 }
 
 //nolint:unparam // `name` always receives `service1'.
-func newServiceImport(namespace, name, serviceIP, clusterID string) *mcsv1a1.ServiceImport {
+func newServiceImport(namespace, name, serviceIP, clusterID string, ports ...mcsv1a1.ServicePort) *mcsv1a1.ServiceImport {
 	return &mcsv1a1.ServiceImport{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name + "-" + namespace + "-" + clusterID,
@@ -156,8 +156,9 @@ func newServiceImport(namespace, name, serviceIP, clusterID string) *mcsv1a1.Ser
 			},
 		},
 		Spec: mcsv1a1.ServiceImportSpec{
-			Type: mcsv1a1.ClusterSetIP,
-			IPs:  []string{serviceIP},
+			Type:  mcsv1a1.ClusterSetIP,
+			IPs:   []string{serviceIP},
+			Ports: ports,
 		},
 		Status: mcsv1a1.ServiceImportStatus{
 			Clusters: []mcsv1a1.ClusterStatus{


### PR DESCRIPTION
The MCS spec states that the service ports from the constituent cluster services should be merged if there are conflicts. Currently LH assumes the service ports are the same across all clusters which would be problematic if a client tried to access a port which doesn't exist on the selected backend cluster. For a DNS query that requests a specific cluster, LH should return that cluster's ports otherwise return the intersection of all the ports across all constituent clusters.

Depends on https://github.com/submariner-io/admiral/pull/528
