### PR TITLE
Automated backport of #964: Include namespace in EndpointSlice name

### DIFF
--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -558,6 +558,19 @@ func (a *Controller) filterLocalEndpointSlices(obj runtime.Object, numRequeues i
 		return nil, false
 	}
 
+	oldName := labels[constants.MCSLabelServiceName] + "-" + labels[constants.MCSLabelSourceCluster]
+	if op != syncer.Delete && endpointSlice.Name == oldName {
+		logger.Infof("EndpointSlice %s/%s has the old naming convention sans namespace - deleting it",
+			endpointSlice.Namespace, endpointSlice.Name)
+
+		err := a.endpointSliceSyncer.GetLocalFederator().Delete(endpointSlice)
+		if err != nil {
+			logger.Errorf(err, "Error deleting local EndpointSlice %s/%s", endpointSlice.Namespace, endpointSlice.Name)
+		}
+
+		return nil, false
+	}
+
 	return obj, false
 }
 

--- a/pkg/agent/controller/controller_suite_test.go
+++ b/pkg/agent/controller/controller_suite_test.go
@@ -439,7 +439,7 @@ func (c *cluster) awaitUpdatedServiceImport(service *corev1.Service, serviceIP s
 func awaitEndpointSlice(endpointSliceClient dynamic.ResourceInterface, endpoints *corev1.Endpoints,
 	service *corev1.Service, namespace string, globalIPs []string,
 ) *discovery.EndpointSlice {
-	obj := test.AwaitResource(endpointSliceClient, endpoints.Name+"-"+clusterID1)
+	obj := test.AwaitResource(endpointSliceClient, endpoints.Name+"-"+endpoints.Namespace+"-"+clusterID1)
 
 	endpointSlice := &discovery.EndpointSlice{}
 	Expect(scheme.Scheme.Convert(obj, endpointSlice, nil)).To(Succeed())
@@ -499,7 +499,7 @@ func (c *cluster) awaitEndpointSlice(t *testDriver) *discovery.EndpointSlice {
 }
 
 func awaitUpdatedEndpointSlice(endpointSliceClient dynamic.ResourceInterface, endpoints *corev1.Endpoints, expectedIPs []string) {
-	name := endpoints.Name + "-" + clusterID1
+	name := endpoints.Name + "-" + endpoints.Namespace + "-" + clusterID1
 
 	sort.Strings(expectedIPs)
 

--- a/pkg/agent/controller/endpoint.go
+++ b/pkg/agent/controller/endpoint.go
@@ -131,14 +131,12 @@ func (e *EndpointController) cleanup() {
 func (e *EndpointController) endpointsToEndpointSlice(obj runtime.Object, numRequeues int, op syncer.Operation) (runtime.Object, bool) {
 	endPoints := obj.(*corev1.Endpoints)
 
-	endpointSliceName := endPoints.Name + "-" + e.clusterID
-
 	if op == syncer.Delete {
 		logger.V(log.DEBUG).Infof("Endpoints %s/%s deleted", endPoints.Namespace, endPoints.Name)
 
 		return &discovery.EndpointSlice{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      endpointSliceName,
+				Name:      e.endpointSliceNameFrom(endPoints),
 				Namespace: endPoints.Namespace,
 			},
 		}, false
@@ -158,7 +156,7 @@ func (e *EndpointController) endpointSliceFromEndpoints(endpoints *corev1.Endpoi
 ) {
 	endpointSlice := &discovery.EndpointSlice{}
 
-	endpointSlice.Name = endpoints.Name + "-" + e.clusterID
+	endpointSlice.Name = e.endpointSliceNameFrom(endpoints)
 	endpointSlice.Labels = map[string]string{
 		discovery.LabelManagedBy:        constants.LabelValueManagedBy,
 		constants.LabelSourceNamespace:  e.serviceImportSourceNameSpace,
@@ -205,6 +203,10 @@ func (e *EndpointController) endpointSliceFromEndpoints(endpoints *corev1.Endpoi
 	}
 
 	return endpointSlice, false
+}
+
+func (e *EndpointController) endpointSliceNameFrom(endpoints *corev1.Endpoints) string {
+	return endpoints.Name + "-" + endpoints.Namespace + "-" + e.clusterID
 }
 
 func (e *EndpointController) getEndpointsFromAddresses(addresses []corev1.EndpointAddress, addressType discovery.AddressType,

--- a/pkg/agent/controller/reconciliation_test.go
+++ b/pkg/agent/controller/reconciliation_test.go
@@ -21,7 +21,10 @@ package controller_test
 import (
 	. "github.com/onsi/ginkgo"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
+	"github.com/submariner-io/lighthouse/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
@@ -154,6 +157,34 @@ var _ = Describe("Reconciliation", func() {
 			t.cluster2.start(t, *t.syncerConfig)
 
 			t.awaitNoEndpointSlice(t.cluster2.localEndpointSliceClient)
+		})
+	})
+
+	When("a local EndpointSlice with the old naming convention sans namespace exists on startup", func() {
+		epsName := "nginx-" + clusterID1
+
+		JustBeforeEach(func() {
+			eps := &discovery.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      epsName,
+					Namespace: serviceNamespace,
+					Labels: map[string]string{
+						discovery.LabelManagedBy:        constants.LabelValueManagedBy,
+						constants.MCSLabelSourceCluster: clusterID1,
+						constants.MCSLabelServiceName:   "nginx",
+					},
+				},
+			}
+
+			test.CreateResource(t.cluster1.localEndpointSliceClient, eps)
+
+			eps.Namespace = test.RemoteNamespace
+			test.CreateResource(t.brokerEndpointSliceClient, test.SetClusterIDLabel(eps, clusterID1))
+		})
+
+		It("should delete it", func() {
+			test.AwaitNoResource(t.cluster1.localEndpointSliceClient, epsName)
+			test.AwaitNoResource(t.brokerEndpointSliceClient, epsName)
 		})
 	})
 })

--- a/pkg/agent/controller/service_import_sync_test.go
+++ b/pkg/agent/controller/service_import_sync_test.go
@@ -20,8 +20,11 @@ package controller_test
 
 import (
 	. "github.com/onsi/ginkgo"
+	"github.com/submariner-io/admiral/pkg/syncer/test"
 	"github.com/submariner-io/lighthouse/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
 var _ = Describe("ServiceImport syncing", func() {
@@ -166,6 +169,57 @@ var _ = Describe("ServiceImport syncing", func() {
 			t.createService()
 			t.createServiceExport()
 			t.awaitServiceExported(t.service.Spec.ClusterIP)
+		})
+	})
+
+	When("two Services with the same name in different namespaces are exported", func() {
+		It("should sync ServiceImport and EndpointSlice resources for each", func() {
+			t.createEndpoints()
+			t.createService()
+			t.createServiceExport()
+			t.awaitServiceExported(t.service.Spec.ClusterIP)
+			t.awaitEndpointSlice()
+
+			service := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      t.service.Name,
+					Namespace: "other-service-ns",
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.253.9.2",
+				},
+			}
+
+			serviceExport := &mcsv1a1.ServiceExport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      service.Name,
+					Namespace: service.Namespace,
+				},
+			}
+
+			endpoints := &corev1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      service.Name,
+					Namespace: service.Namespace,
+				},
+			}
+
+			test.CreateResource(dynamicEndpointsClient(t.cluster1.localDynClient, endpoints.Namespace), endpoints)
+			test.CreateResource(t.cluster1.dynamicServiceClient().Namespace(service.Namespace), service)
+			test.CreateResource(serviceExportClient(t.cluster1.localDynClient, service.Namespace), serviceExport)
+
+			t.cluster1.awaitServiceImport(service, mcsv1a1.ClusterSetIP, service.Spec.ClusterIP)
+			awaitServiceImport(t.brokerServiceImportClient, service, mcsv1a1.ClusterSetIP, service.Spec.ClusterIP)
+			t.cluster2.awaitServiceImport(service, mcsv1a1.ClusterSetIP, service.Spec.ClusterIP)
+
+			awaitEndpointSlice(endpointSliceClient(t.cluster1.localDynClient, service.Namespace), endpoints.Namespace, endpoints.Name)
+			awaitEndpointSlice(t.brokerEndpointSliceClient, endpoints.Namespace, endpoints.Name)
+			awaitEndpointSlice(endpointSliceClient(t.cluster2.localDynClient, service.Namespace), endpoints.Namespace, endpoints.Name)
+
+			// Ensure the resources for the first Service weren't overwritten
+			t.cluster1.awaitServiceImport(t.service, mcsv1a1.ClusterSetIP, t.service.Spec.ClusterIP)
+			t.awaitBrokerServiceImport(mcsv1a1.ClusterSetIP, t.service.Spec.ClusterIP)
+			t.awaitEndpointSlice()
 		})
 	})
 })


### PR DESCRIPTION
Backport of #964 on release-0.14.

#964: Include namespace in EndpointSlice name

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.