### PR TITLE
Wrap the contents of fake.ClusterStatus

### DIFF
--- a/coredns/resolver/clusterip_service_test.go
+++ b/coredns/resolver/clusterip_service_test.go
@@ -69,7 +69,7 @@ func testClusterIPServiceInOneCluster() {
 
 	Context("and it becomes disconnected", func() {
 		BeforeEach(func() {
-			t.clusterStatus.ConnectedClusterIDs.RemoveAll()
+			t.clusterStatus.DisconnectAll()
 		})
 
 		It("should return no DNS records", func() {
@@ -139,7 +139,7 @@ func testClusterIPServiceInTwoClusters() {
 
 	Context("and one is the local cluster", func() {
 		BeforeEach(func() {
-			t.clusterStatus.LocalClusterID.Store(clusterID1)
+			t.clusterStatus.SetLocalClusterID(clusterID1)
 		})
 
 		It("should consistently return its DNS record", func() {
@@ -157,7 +157,7 @@ func testClusterIPServiceInTwoClusters() {
 		}
 
 		BeforeEach(func() {
-			t.clusterStatus.ConnectedClusterIDs.Remove(clusterID1)
+			t.clusterStatus.DisconnectClusterID(clusterID1)
 		})
 
 		Context("and no specific cluster is requested", func() {
@@ -187,7 +187,7 @@ func testClusterIPServiceInTwoClusters() {
 
 	Context("and both become disconnected", func() {
 		BeforeEach(func() {
-			t.clusterStatus.ConnectedClusterIDs.RemoveAll()
+			t.clusterStatus.DisconnectAll()
 		})
 
 		It("should return no DNS records", func() {
@@ -251,7 +251,7 @@ func testClusterIPServiceInTwoClusters() {
 
 	Context("and a non-existent local cluster is specified", func() {
 		BeforeEach(func() {
-			t.clusterStatus.LocalClusterID.Store("non-existent")
+			t.clusterStatus.SetLocalClusterID("non-existent")
 		})
 
 		It("should consistently return the DNS records round-robin", func() {
@@ -301,7 +301,7 @@ func testClusterIPServiceInThreeClusters() {
 
 	Context("and one becomes disconnected", func() {
 		BeforeEach(func() {
-			t.clusterStatus.ConnectedClusterIDs.Remove(clusterID3)
+			t.clusterStatus.DisconnectClusterID(clusterID3)
 		})
 
 		It("should consistently return the connected clusters' DNS records round-robin", func() {
@@ -333,7 +333,7 @@ func testClusterIPServiceInThreeClusters() {
 
 	Context("and one becomes disconnected and one becomes unhealthy", func() {
 		BeforeEach(func() {
-			t.clusterStatus.ConnectedClusterIDs.Remove(clusterID2)
+			t.clusterStatus.DisconnectClusterID(clusterID2)
 			t.putEndpointSlice(newClusterIPEndpointSlice(namespace1, service1, clusterID3, serviceIP3, false))
 		})
 

--- a/coredns/resolver/headless_service_test.go
+++ b/coredns/resolver/headless_service_test.go
@@ -137,7 +137,7 @@ func testHeadlessServiceInMultipleClusters() {
 
 	Context("and one is on the local cluster", func() {
 		BeforeEach(func() {
-			t.clusterStatus.LocalClusterID.Store(clusterID3)
+			t.clusterStatus.SetLocalClusterID(clusterID3)
 
 			// If the local cluster EndpointSlice is created before the local K8s EndpointSlice, PutEndpointSlice should
 			// return true to requeue.
@@ -183,7 +183,7 @@ func testHeadlessServiceInMultipleClusters() {
 
 	Context("and one becomes disconnected", func() {
 		JustBeforeEach(func() {
-			t.clusterStatus.ConnectedClusterIDs.Remove(clusterID3)
+			t.clusterStatus.DisconnectClusterID(clusterID3)
 		})
 
 		Context("and no specific cluster is requested", func() {


### PR DESCRIPTION
This allows the implementation to switch to unsynchronized k8s.io sets, and makes accesses to LocalClusterID symmetric.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
