### PR TITLE
Automated backport of #1086: Properly disable gateway controller in SD-only install

### DIFF
--- a/coredns/plugin/setup_internal_test.go
+++ b/coredns/plugin/setup_internal_test.go
@@ -60,9 +60,16 @@ var _ = Describe("Plugin setup", func() {
 			Resource: "gateways",
 		}
 
+		submarinersGVR := schema.GroupVersionResource{
+			Group:    "submariner.io",
+			Version:  "v1alpha1",
+			Resource: "submariners",
+		}
+
 		gateway.NewClientset = func(c *rest.Config) (dynamic.Interface, error) {
 			return fakeClient.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), map[schema.GroupVersionResource]string{
-				gatewaysGVR: "GatewayList",
+				gatewaysGVR:    "GatewayList",
+				submarinersGVR: "SubmarinersList",
 			}), nil
 		}
 


### PR DESCRIPTION
Backport of #1086 on release-0.14.

#1086: Properly disable gateway controller in SD-only install

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.