### PR TITLE
Implement aggregated ServiceImport port merging

### DIFF
--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -400,9 +400,10 @@ func (a *Controller) getPortsForService(service *corev1.Service) []mcsv1a1.Servi
 
 	for _, port := range service.Spec.Ports {
 		mcsPorts = append(mcsPorts, mcsv1a1.ServicePort{
-			Name:     port.Name,
-			Protocol: port.Protocol,
-			Port:     port.Port,
+			Name:        port.Name,
+			Protocol:    port.Protocol,
+			Port:        port.Port,
+			AppProtocol: port.AppProtocol,
 		})
 	}
 
@@ -495,9 +496,10 @@ func (c converter) toServicePorts(from []discovery.EndpointPort) []mcsv1a1.Servi
 	to := make([]mcsv1a1.ServicePort, len(from))
 	for i := range from {
 		to[i] = mcsv1a1.ServicePort{
-			Name:     *from[i].Name,
-			Protocol: *from[i].Protocol,
-			Port:     *from[i].Port,
+			Name:        *from[i].Name,
+			Protocol:    *from[i].Protocol,
+			Port:        *from[i].Port,
+			AppProtocol: from[i].AppProtocol,
 		}
 	}
 

--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -32,6 +32,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/util"
 	"github.com/submariner-io/lighthouse/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -479,6 +480,26 @@ func (c converter) toUnstructured(obj runtime.Object) *unstructured.Unstructured
 func (c converter) toServiceExport(obj runtime.Object) *mcsv1a1.ServiceExport {
 	to := &mcsv1a1.ServiceExport{}
 	utilruntime.Must(c.scheme.Convert(obj, to, nil))
+
+	return to
+}
+
+func (c converter) toEndpointSlice(obj runtime.Object) *discovery.EndpointSlice {
+	to := &discovery.EndpointSlice{}
+	utilruntime.Must(c.scheme.Convert(obj, to, nil))
+
+	return to
+}
+
+func (c converter) toServicePorts(from []discovery.EndpointPort) []mcsv1a1.ServicePort {
+	to := make([]mcsv1a1.ServicePort, len(from))
+	for i := range from {
+		to[i] = mcsv1a1.ServicePort{
+			Name:     *from[i].Name,
+			Protocol: *from[i].Protocol,
+			Port:     *from[i].Port,
+		}
+	}
 
 	return to
 }

--- a/pkg/agent/controller/controller_suite_test.go
+++ b/pkg/agent/controller/controller_suite_test.go
@@ -82,9 +82,10 @@ var (
 	}
 
 	port3 = mcsv1a1.ServicePort{
-		Name:     "POP3",
-		Protocol: corev1.ProtocolUDP,
-		Port:     110,
+		Name:        "POP3",
+		Protocol:    corev1.ProtocolUDP,
+		Port:        110,
+		AppProtocol: pointer.String("smtp"),
 	}
 )
 
@@ -670,9 +671,10 @@ func (t *testDriver) awaitEndpointSlice(c *cluster) {
 
 		for i := range c.endpoints.Subsets[0].Ports {
 			expected.Ports = append(expected.Ports, discovery.EndpointPort{
-				Name:     &c.endpoints.Subsets[0].Ports[i].Name,
-				Protocol: &c.endpoints.Subsets[0].Ports[i].Protocol,
-				Port:     &c.endpoints.Subsets[0].Ports[i].Port,
+				Name:        &c.endpoints.Subsets[0].Ports[i].Name,
+				Protocol:    &c.endpoints.Subsets[0].Ports[i].Protocol,
+				Port:        &c.endpoints.Subsets[0].Ports[i].Port,
+				AppProtocol: c.endpoints.Subsets[0].Ports[i].AppProtocol,
 			})
 		}
 	} else {
@@ -685,9 +687,10 @@ func (t *testDriver) awaitEndpointSlice(c *cluster) {
 
 		for i := range c.service.Spec.Ports {
 			expected.Ports = append(expected.Ports, discovery.EndpointPort{
-				Name:     &c.service.Spec.Ports[i].Name,
-				Protocol: &c.service.Spec.Ports[i].Protocol,
-				Port:     &c.service.Spec.Ports[i].Port,
+				Name:        &c.service.Spec.Ports[i].Name,
+				Protocol:    &c.service.Spec.Ports[i].Protocol,
+				Port:        &c.service.Spec.Ports[i].Port,
+				AppProtocol: c.service.Spec.Ports[i].AppProtocol,
 			})
 		}
 	}
@@ -816,8 +819,9 @@ func setIngressAllocatedIP(ingressIP *unstructured.Unstructured, ip string) {
 
 func toServicePort(port mcsv1a1.ServicePort) corev1.ServicePort {
 	return corev1.ServicePort{
-		Name:     port.Name,
-		Protocol: port.Protocol,
-		Port:     port.Port,
+		Name:        port.Name,
+		Protocol:    port.Protocol,
+		Port:        port.Port,
+		AppProtocol: port.AppProtocol,
 	}
 }

--- a/pkg/agent/controller/endpoint.go
+++ b/pkg/agent/controller/endpoint.go
@@ -178,9 +178,10 @@ func (e *EndpointController) endpointSliceFromEndpoints(endpoints *corev1.Endpoi
 		if e.isHeadless() {
 			for i := range subset.Ports {
 				endpointSlice.Ports = append(endpointSlice.Ports, discovery.EndpointPort{
-					Port:     &subset.Ports[i].Port,
-					Name:     &subset.Ports[i].Name,
-					Protocol: &subset.Ports[i].Protocol,
+					Port:        &subset.Ports[i].Port,
+					Name:        &subset.Ports[i].Name,
+					Protocol:    &subset.Ports[i].Protocol,
+					AppProtocol: subset.Ports[i].AppProtocol,
 				})
 			}
 		}
@@ -207,9 +208,10 @@ func (e *EndpointController) endpointSliceFromEndpoints(endpoints *corev1.Endpoi
 
 		for i := range e.serviceImportSpec.Ports {
 			endpointSlice.Ports = append(endpointSlice.Ports, discovery.EndpointPort{
-				Port:     &e.serviceImportSpec.Ports[i].Port,
-				Name:     &e.serviceImportSpec.Ports[i].Name,
-				Protocol: &e.serviceImportSpec.Ports[i].Protocol,
+				Port:        &e.serviceImportSpec.Ports[i].Port,
+				Name:        &e.serviceImportSpec.Ports[i].Name,
+				Protocol:    &e.serviceImportSpec.Ports[i].Protocol,
+				AppProtocol: e.serviceImportSpec.Ports[i].AppProtocol,
 			})
 		}
 	}

--- a/pkg/agent/controller/service_export_failures_test.go
+++ b/pkg/agent/controller/service_export_failures_test.go
@@ -124,4 +124,17 @@ var _ = Describe("Service export failures", func() {
 			t.awaitServiceUnexported(&t.cluster1)
 		})
 	})
+
+	When("listing the broker EndpointSlices initially fails", func() {
+		BeforeEach(func() {
+			t.brokerEndpointSliceReactor.SetFailOnList(errors.New("mock list error"))
+		})
+
+		It("should eventually export the service", func() {
+			t.cluster1.awaitServiceExportCondition(newServiceExportSyncedCondition(corev1.ConditionFalse, "ExportFailed"))
+
+			t.brokerEndpointSliceReactor.SetFailOnList(nil)
+			t.awaitNonHeadlessServiceExported(&t.cluster1)
+		})
+	})
 })


### PR DESCRIPTION
Compute the union of the constituent cluster's ports contained in their `EndpointSlices` as per the MCS spec. This is only done for ClusterIP services.
