### PR TITLE
Implement legacy ServiceImport migration in the agent controller

### DIFF
--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -403,16 +403,6 @@ func newServiceExportCondition(condType mcsv1a1.ServiceExportConditionType, stat
 	}
 }
 
-// This function also checks the legacy source name label for migration - this can be removed after 0.15.
-func serviceImportSourceName(serviceImport *mcsv1a1.ServiceImport) string {
-	name, ok := serviceImport.Labels[mcsv1a1.LabelServiceName]
-	if ok {
-		return name
-	}
-
-	return serviceImport.GetLabels()["lighthouse.submariner.io/sourceName"]
-}
-
 func (c converter) toServiceImport(obj runtime.Object) *mcsv1a1.ServiceImport {
 	to := &mcsv1a1.ServiceImport{}
 	utilruntime.Must(c.scheme.Convert(obj, to, nil))

--- a/pkg/agent/controller/endpoint.go
+++ b/pkg/agent/controller/endpoint.go
@@ -49,7 +49,7 @@ func startEndpointController(localClient dynamic.Interface, restMapper meta.REST
 	serviceImport *mcsv1a1.ServiceImport, clusterID string, globalIngressIPCache *globalIngressIPCache,
 ) (*EndpointController, error) {
 	serviceNamespace := serviceImport.Labels[constants.LabelSourceNamespace]
-	serviceName := serviceImport.Labels[mcsv1a1.LabelServiceName]
+	serviceName := serviceImportSourceName(serviceImport)
 
 	logger.V(log.DEBUG).Infof("Starting Endpoints controller for service %s/%s", serviceNamespace, serviceName)
 

--- a/pkg/agent/controller/service_import_migration_test.go
+++ b/pkg/agent/controller/service_import_migration_test.go
@@ -1,0 +1,297 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/syncer/test"
+	"github.com/submariner-io/lighthouse/pkg/agent/controller"
+	"github.com/submariner-io/lighthouse/pkg/constants"
+	discovery "k8s.io/api/discovery/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes/scheme"
+	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+)
+
+var _ = Describe("ServiceImport migration", func() {
+	Describe("after restart on upgrade with a service that was previously exported", testServiceImportMigration)
+})
+
+func testServiceImportMigration() {
+	var (
+		t                   *testDriver
+		legacyServiceImport *mcsv1a1.ServiceImport
+	)
+
+	BeforeEach(func() {
+		t = newTestDiver()
+
+		t.cluster1.createEndpoints()
+		t.cluster1.createService()
+
+		legacyServiceImport = t.newLegacyServiceImport(t.cluster1.clusterID)
+
+		test.CreateResource(t.cluster1.localServiceImportClient.Namespace(test.LocalNamespace), legacyServiceImport)
+
+		test.CreateResource(t.brokerServiceImportClient.Namespace(test.RemoteNamespace),
+			test.SetClusterIDLabel(legacyServiceImport, t.cluster1.clusterID))
+
+		legacyEndpointSlice := &discovery.EndpointSlice{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("%s-%s-%s", t.cluster1.service.Name, t.cluster1.service.Namespace, t.cluster1.clusterID),
+				Labels: map[string]string{
+					discovery.LabelManagedBy:        constants.LabelValueManagedBy,
+					constants.MCSLabelSourceCluster: t.cluster1.clusterID,
+					mcsv1a1.LabelServiceName:        t.cluster1.service.Name,
+					constants.LabelSourceNamespace:  t.cluster1.service.Namespace,
+				},
+			},
+			AddressType: discovery.AddressTypeIPv4,
+			Endpoints:   t.cluster1.endpointSliceAddresses,
+			Ports: []discovery.EndpointPort{
+				{
+					Name:     &t.cluster1.service.Spec.Ports[0].Name,
+					Protocol: &t.cluster1.service.Spec.Ports[0].Protocol,
+					Port:     &t.cluster1.service.Spec.Ports[0].Port,
+				},
+				{
+					Name:     &t.cluster1.service.Spec.Ports[1].Name,
+					Protocol: &t.cluster1.service.Spec.Ports[1].Protocol,
+					Port:     &t.cluster1.service.Spec.Ports[1].Port,
+				},
+			},
+		}
+
+		test.CreateResource(t.cluster1.localEndpointSliceClient, legacyEndpointSlice)
+
+		legacyEndpointSlice.Labels["submariner-io/originatingNamespace"] = t.cluster1.service.Namespace
+		test.CreateResource(t.brokerEndpointSliceClient, test.SetClusterIDLabel(legacyEndpointSlice, t.cluster1.clusterID))
+
+		t.cluster1.createServiceExport()
+	})
+
+	JustBeforeEach(func() {
+		t.justBeforeEach()
+	})
+
+	AfterEach(func() {
+		t.afterEach()
+	})
+
+	It("should update the local legacy ServiceImport labels and re-export the service", func() {
+		t.awaitNonHeadlessServiceExported(&t.cluster1)
+		test.AwaitNoResource(t.brokerServiceImportClient.Namespace(test.RemoteNamespace), legacyServiceImport.Name)
+	})
+
+	Context("", func() {
+		BeforeEach(func() {
+			Expect(t.cluster1.localServiceImportClient.Namespace(test.LocalNamespace).Delete(context.Background(),
+				legacyServiceImport.Name, metav1.DeleteOptions{})).To(Succeed())
+			t.cluster1.deleteServiceExport()
+		})
+
+		It("should not sync the local legacy ServiceImport from the broker", func() {
+			Consistently(func() bool {
+				_, err := t.cluster1.localServiceImportClient.Namespace(test.LocalNamespace).Get(context.Background(),
+					legacyServiceImport.Name, metav1.GetOptions{})
+				return apierrors.IsNotFound(err)
+			}, time.Millisecond*300).Should(BeTrue())
+		})
+	})
+
+	Context("and the ServiceExport no longer exists", func() {
+		BeforeEach(func() {
+			t.cluster1.deleteServiceExport()
+		})
+
+		It("should delete the local legacy ServiceImport", func() {
+			test.AwaitNoResource(t.cluster1.localServiceImportClient.Namespace(test.LocalNamespace), legacyServiceImport.Name)
+			t.awaitNoEndpointSlice(&t.cluster1)
+			test.AwaitNoResource(t.brokerServiceImportClient.Namespace(test.RemoteNamespace), legacyServiceImport.Name)
+		})
+	})
+
+	When("there's existing legacy ServiceImports for other clusters", func() {
+		var (
+			remoteServiceImport1 *mcsv1a1.ServiceImport
+			remoteServiceImport2 *mcsv1a1.ServiceImport
+			remoteServiceImport3 *mcsv1a1.ServiceImport
+		)
+
+		BeforeEach(func() {
+			remoteServiceImport1 = t.newLegacyServiceImport("region1")
+			test.CreateResource(t.cluster1.localServiceImportClient.Namespace(test.LocalNamespace), remoteServiceImport1)
+			test.CreateResource(t.brokerServiceImportClient.Namespace(test.RemoteNamespace),
+				test.SetClusterIDLabel(remoteServiceImport1, remoteServiceImport1.Status.Clusters[0].Cluster))
+
+			remoteServiceImport2 = t.newLegacyServiceImport("region2")
+			test.CreateResource(t.cluster1.localServiceImportClient.Namespace(test.LocalNamespace), remoteServiceImport2)
+			test.CreateResource(t.brokerServiceImportClient.Namespace(test.RemoteNamespace),
+				test.SetClusterIDLabel(remoteServiceImport2, remoteServiceImport2.Status.Clusters[0].Cluster))
+
+			remoteServiceImport3 = t.newLegacyServiceImport("region3")
+			test.CreateResource(t.cluster1.localServiceImportClient.Namespace(test.LocalNamespace), remoteServiceImport3)
+			test.CreateResource(t.brokerServiceImportClient.Namespace(test.RemoteNamespace),
+				test.SetClusterIDLabel(remoteServiceImport3, remoteServiceImport3.Status.Clusters[0].Cluster))
+		})
+
+		Context("that haven't been upgraded yet", func() {
+			It("should retain the local legacy ServiceImport on the broker", func() {
+				t.awaitNonHeadlessServiceExported(&t.cluster1)
+				ensureServiceImport(t.brokerServiceImportClient.Namespace(test.RemoteNamespace), legacyServiceImport.Name)
+			})
+		})
+
+		Context("and after upgrading the clusters", func() {
+			It("should eventually remove the local legacy ServiceImport from the broker", func() {
+				t.awaitAggregatedServiceImport(mcsv1a1.ClusterSetIP, t.cluster1.service.Name, t.cluster1.service.Namespace, &t.cluster1)
+
+				// Get the aggregated ServiceImport on the broker.
+
+				obj, err := t.brokerServiceImportClient.Namespace(test.RemoteNamespace).Get(context.Background(),
+					fmt.Sprintf("%s-%s", t.cluster1.service.Name, t.cluster1.service.Namespace), metav1.GetOptions{})
+				Expect(err).To(Succeed())
+
+				aggregatedServiceImport := &mcsv1a1.ServiceImport{}
+				Expect(scheme.Scheme.Convert(obj, aggregatedServiceImport, nil)).To(Succeed())
+
+				By(fmt.Sprintf("Upgrade the first remote cluster %q", remoteServiceImport1.Status.Clusters[0].Cluster))
+
+				aggregatedServiceImport.Status.Clusters = append(aggregatedServiceImport.Status.Clusters, mcsv1a1.ClusterStatus{
+					Cluster: remoteServiceImport1.Status.Clusters[0].Cluster,
+				})
+
+				test.UpdateResource(t.brokerServiceImportClient.Namespace(test.RemoteNamespace), aggregatedServiceImport)
+
+				// Since the other remote clusters aren't upgraded yet, it shouldn't delete the local legacy ServiceImport
+				// from the broker yet.
+
+				ensureServiceImport(t.brokerServiceImportClient.Namespace(test.RemoteNamespace), legacyServiceImport.Name)
+
+				// Remove the legacy ServiceImport for remote cluster 3 from the broker.
+
+				Expect(t.brokerServiceImportClient.Namespace(test.RemoteNamespace).Delete(context.Background(),
+					remoteServiceImport3.Name, metav1.DeleteOptions{})).To(Succeed())
+				test.AwaitNoResource(t.cluster1.localServiceImportClient.Namespace(test.LocalNamespace), remoteServiceImport3.Name)
+
+				By(fmt.Sprintf("Upgrade the second remote cluster %q", remoteServiceImport2.Status.Clusters[0].Cluster))
+
+				aggregatedServiceImport.Status.Clusters = append(aggregatedServiceImport.Status.Clusters, mcsv1a1.ClusterStatus{
+					Cluster: remoteServiceImport2.Status.Clusters[0].Cluster,
+				})
+
+				test.UpdateResource(t.brokerServiceImportClient.Namespace(test.RemoteNamespace), aggregatedServiceImport)
+
+				// Since we also deleted the legacy ServiceImport from remote cluster 3, it should observe that all remote
+				// clusters have effectively been upgraded and thus should delete the local legacy ServiceImport from the broker.
+
+				test.AwaitNoResource(t.brokerServiceImportClient.Namespace(test.RemoteNamespace), legacyServiceImport.Name)
+
+				// Ensure the sync from the broker doesn't delete the local ServiceImport.
+
+				ensureServiceImport(t.cluster1.localServiceImportClient.Namespace(test.LocalNamespace), legacyServiceImport.Name)
+
+				Expect(t.brokerServiceImportClient.Namespace(test.RemoteNamespace).Delete(context.Background(),
+					remoteServiceImport1.Name, metav1.DeleteOptions{})).To(Succeed())
+				test.AwaitNoResource(t.cluster1.localServiceImportClient.Namespace(test.LocalNamespace), remoteServiceImport1.Name)
+			})
+		})
+
+		Context("that have already been upgraded", func() {
+			BeforeEach(func() {
+				test.CreateResource(t.brokerServiceImportClient.Namespace(test.RemoteNamespace), &mcsv1a1.ServiceImport{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: fmt.Sprintf("%s-%s", t.cluster1.service.Name, t.cluster1.service.Namespace),
+						Annotations: map[string]string{
+							mcsv1a1.LabelServiceName:       t.cluster1.service.Name,
+							constants.LabelSourceNamespace: t.cluster1.service.Namespace,
+						},
+					},
+					Spec: mcsv1a1.ServiceImportSpec{
+						Type:  mcsv1a1.ClusterSetIP,
+						Ports: []mcsv1a1.ServicePort{port1, port2},
+					},
+					Status: mcsv1a1.ServiceImportStatus{
+						Clusters: []mcsv1a1.ClusterStatus{
+							{
+								Cluster: remoteServiceImport1.Status.Clusters[0].Cluster,
+							},
+							{
+								Cluster: remoteServiceImport2.Status.Clusters[0].Cluster,
+							},
+							{
+								Cluster: remoteServiceImport3.Status.Clusters[0].Cluster,
+							},
+						},
+					},
+				})
+			})
+
+			It("should remove the local legacy ServiceImport from the broker", func() {
+				test.AwaitNoResource(t.brokerServiceImportClient.Namespace(test.RemoteNamespace), legacyServiceImport.Name)
+			})
+		})
+	})
+}
+
+func ensureServiceImport(client dynamic.ResourceInterface, name string) {
+	Consistently(func() bool {
+		_, err := client.Get(context.Background(), name, metav1.GetOptions{})
+		return apierrors.IsNotFound(err)
+	}, time.Millisecond*300).Should(BeFalse())
+}
+
+func (t *testDriver) newLegacyServiceImport(clusterID string) *mcsv1a1.ServiceImport {
+	name := t.cluster1.service.Name
+	namespace := t.cluster1.service.Namespace
+
+	return &mcsv1a1.ServiceImport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s-%s-%s", name, namespace, clusterID),
+			Annotations: map[string]string{
+				"origin-name":      name,
+				"origin-namespace": namespace,
+			},
+			Labels: map[string]string{
+				controller.LegacySourceNameLabel:    name,
+				constants.LabelSourceNamespace:      namespace,
+				controller.LegacySourceClusterLabel: clusterID,
+			},
+		},
+		Spec: mcsv1a1.ServiceImportSpec{
+			Type:  mcsv1a1.ClusterSetIP,
+			IPs:   []string{"1.2.3.4"},
+			Ports: []mcsv1a1.ServicePort{port1, port2},
+		},
+		Status: mcsv1a1.ServiceImportStatus{
+			Clusters: []mcsv1a1.ClusterStatus{
+				{
+					Cluster: clusterID,
+				},
+			},
+		},
+	}
+}

--- a/pkg/agent/controller/service_import_migrator.go
+++ b/pkg/agent/controller/service_import_migrator.go
@@ -1,0 +1,147 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/submariner-io/admiral/pkg/slices"
+	"github.com/submariner-io/admiral/pkg/syncer"
+	"github.com/submariner-io/lighthouse/pkg/constants"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/dynamic"
+	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+)
+
+const (
+	LegacySourceNameLabel    = "lighthouse.submariner.io/sourceName"
+	LegacySourceClusterLabel = "lighthouse.submariner.io/sourceCluster"
+)
+
+// ServiceImportMigrator handles migration from the legacy per-cluster ServiceImports to aggregated ServiceImports added in 0.15.
+type ServiceImportMigrator struct {
+	brokerClient                       dynamic.ResourceInterface
+	listLocalServiceImports            func() ([]runtime.Object, error)
+	clusterID                          string
+	localNamespace                     string
+	converter                          converter
+	deletedLocalServiceImportsOnBroker sets.Set[string]
+}
+
+func (c *ServiceImportMigrator) onRemoteServiceImport(serviceImport *mcsv1a1.ServiceImport) (runtime.Object, bool) {
+	// Ignore a legacy ServiceImport from the broker for this cluster.
+	if serviceImport.Labels[LegacySourceClusterLabel] == c.clusterID {
+		return nil, false
+	}
+
+	// Remote legacy ServiceImports are synced to the local submariner namespace.
+	serviceImport.Namespace = c.localNamespace
+
+	return serviceImport, false
+}
+
+func (c *ServiceImportMigrator) onSuccessfulSyncFromBroker(obj runtime.Object, op syncer.Operation) bool {
+	if op == syncer.Delete {
+		return false
+	}
+
+	aggregatedServiceImport := obj.(*mcsv1a1.ServiceImport)
+
+	_, ok := aggregatedServiceImport.Labels[LegacySourceNameLabel]
+	if ok {
+		// This is not an aggregated ServiceImport.
+		return false
+	}
+
+	localServiceImportName := fmt.Sprintf("%s-%s-%s", aggregatedServiceImport.Name, aggregatedServiceImport.Namespace, c.clusterID)
+	if c.deletedLocalServiceImportsOnBroker.Has(localServiceImportName) {
+		// We've already deleted our legacy local ServiceImport from the broker for this service.
+		return false
+	}
+
+	siList, err := c.listLocalServiceImports()
+	if err != nil {
+		logger.Error(err, "error listing legacy ServiceImports")
+		return true
+	}
+
+	totalRemoteClusters := 0
+	totalRemoteClustersUpgraded := 0
+	foundLocalServiceImport := false
+
+	for _, obj := range siList {
+		si := obj.(*mcsv1a1.ServiceImport)
+
+		if serviceImportSourceName(si) != aggregatedServiceImport.Name ||
+			si.Labels[constants.LabelSourceNamespace] != aggregatedServiceImport.Namespace {
+			continue
+		}
+
+		clusterID := sourceClusterName(si)
+		if clusterID == c.clusterID {
+			foundLocalServiceImport = true
+			continue
+		}
+
+		totalRemoteClusters++
+
+		if slices.IndexOf(aggregatedServiceImport.Status.Clusters, clusterID, clusterStatusKey) >= 0 {
+			totalRemoteClustersUpgraded++
+		}
+	}
+
+	if foundLocalServiceImport && totalRemoteClustersUpgraded == totalRemoteClusters {
+		logger.Infof("All remote clusters have been upgraded for service \"%s/%s\" - removing local ServiceImport %q from the broker",
+			aggregatedServiceImport.Namespace, aggregatedServiceImport.Name, localServiceImportName)
+
+		err := c.brokerClient.Delete(context.Background(), localServiceImportName, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			logger.Error(err, "error deleting legacy ServiceImport from the broker")
+			return true
+		}
+
+		c.deletedLocalServiceImportsOnBroker.Insert(localServiceImportName)
+	}
+
+	return false
+}
+
+func serviceImportSourceName(serviceImport *mcsv1a1.ServiceImport) string {
+	// This function also checks the legacy source name label for migration.
+	name, ok := serviceImport.Labels[mcsv1a1.LabelServiceName]
+	if ok {
+		return name
+	}
+
+	return serviceImport.Labels[LegacySourceNameLabel]
+}
+
+func sourceClusterName(serviceImport *mcsv1a1.ServiceImport) string {
+	// This function also checks the legacy source cluster label for migration.
+	name, ok := serviceImport.Labels[constants.MCSLabelSourceCluster]
+	if ok {
+		return name
+	}
+
+	return serviceImport.Labels[LegacySourceClusterLabel]
+}

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -75,6 +75,7 @@ type ServiceImportController struct {
 	localClient             dynamic.Interface
 	restMapper              meta.RESTMapper
 	serviceImportAggregator *ServiceImportAggregator
+	serviceImportMigrator   *ServiceImportMigrator
 	serviceExportClient     *ServiceExportClient
 	localSyncer             syncer.Interface
 	remoteSyncer            syncer.Interface


### PR DESCRIPTION
Legacy per-cluster `ServiceImports` are no longer created but, for rolling cluster upgrades, there may be a period of time where there is a mix of upgraded and non-upgraded clusters. The latter still need to observe the per-cluster `ServiceImports` so they need to remain on the broker during the transition period.
    
An upgraded cluster can remove its legacy per-cluster `ServiceImport` from the broker when it observes that all of the legacy `ServiceImport` cluster names are present in the aggregated `ServiceImport` status cluster name list. This indicates that all constituent clusters have been upgraded.
    
Introduced a `ServiceImportMigrator` that integrates with the `ServiceImportController` to handle syncing of legacy `ServiceImports` from the broker and removing the local legacy `ServiceImport` from the broker based on the criteria above. The latter is triggered whenever an aggregated `ServiceImport` is synced from the broker, either new or updated.

Depends on https://github.com/submariner-io/lighthouse/pull/1155
