### PR TITLE
Fix flaky failure in awaitServiceExportCondition

### DIFF
--- a/pkg/agent/controller/clusterip_service_test.go
+++ b/pkg/agent/controller/clusterip_service_test.go
@@ -291,6 +291,8 @@ func testClusterIPServiceInTwoClusters() {
 
 	It("should export the service in both clusters", func() {
 		t.awaitNonHeadlessServiceExported(&t.cluster1, &t.cluster2)
+		t.cluster1.ensureLastServiceExportCondition(newServiceExportSyncedCondition(corev1.ConditionTrue, ""))
+		t.cluster1.ensureLastServiceExportCondition(newServiceExportValidCondition(corev1.ConditionTrue, ""))
 		t.cluster1.ensureNoServiceExportCondition(mcsv1a1.ServiceExportConflict)
 		t.cluster2.ensureNoServiceExportCondition(mcsv1a1.ServiceExportConflict)
 	})


### PR DESCRIPTION
After `awaitServiceExportCondition` verifies the expected status condition occurred, it waits a bit and ensures the current status condition still matches. This is done to ensure the condition is stable, eg once the `Synced` condition transitions to "_true_", normally we expect it to remain that way.

When a failure occurs, we expect the `Synced` condition to be "_false_" with reason "_ExportFailed_". However this is not stable as the controller will keep retrying and the condition will flipflop between "_AwaitingExport_" and "_ExportFailed_". If a test happens to catch it right when it transitioned back to "_AwaitingExport_", the test fails.

Instead of `awaitServiceExportCondition` ensuring the condition remain stable, move it to another function and selectively call it, ie we don't need to verify condition stability everywhere.

