### PR TITLE
Remove or ignore unused function parameters

### DIFF
--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -174,7 +174,7 @@ func (a *Controller) Start(stopCh <-chan struct{}) error {
 	return nil
 }
 
-func (a *Controller) serviceExportToServiceImport(obj runtime.Object, numRequeues int, op syncer.Operation) (runtime.Object, bool) {
+func (a *Controller) serviceExportToServiceImport(obj runtime.Object, _ int, op syncer.Operation) (runtime.Object, bool) {
 	svcExport := obj.(*mcsv1a1.ServiceExport)
 
 	logger.V(log.DEBUG).Infof("ServiceExport %s/%s %sd", svcExport.Namespace, svcExport.Name, op)

--- a/pkg/agent/controller/endpoint.go
+++ b/pkg/agent/controller/endpoint.go
@@ -132,7 +132,7 @@ func (e *EndpointController) cleanup() (bool, error) {
 	return true, nil
 }
 
-func (e *EndpointController) endpointsToEndpointSlice(obj runtime.Object, numRequeues int, op syncer.Operation) (runtime.Object, bool) {
+func (e *EndpointController) endpointsToEndpointSlice(obj runtime.Object, _ int, op syncer.Operation) (runtime.Object, bool) {
 	endPoints := obj.(*corev1.Endpoints)
 
 	if op == syncer.Delete {

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -377,7 +377,7 @@ func (c *ServiceImportController) Delete(obj runtime.Object) error {
 	return err
 }
 
-func (c *ServiceImportController) onRemoteServiceImport(obj runtime.Object, _ int, op syncer.Operation) (runtime.Object, bool) {
+func (c *ServiceImportController) onRemoteServiceImport(obj runtime.Object, _ int, _ syncer.Operation) (runtime.Object, bool) {
 	serviceImport := obj.(*mcsv1a1.ServiceImport)
 
 	serviceName, ok := serviceImport.Annotations[mcsv1a1.LabelServiceName]

--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -474,11 +474,11 @@ func RunServiceDiscoveryRoundRobinTest(f *lhframework.Framework) {
 
 	var serviceIPList []string
 
-	serviceIPClusterB := f.GetServiceIP(framework.ClusterB, nginxServiceClusterB, false)
+	serviceIPClusterB := f.GetServiceIP(framework.ClusterB, nginxServiceClusterB)
 
 	serviceIPList = append(serviceIPList, serviceIPClusterB)
 
-	serviceIPClusterC := f.GetServiceIP(framework.ClusterC, nginxServiceClusterB, false)
+	serviceIPClusterC := f.GetServiceIP(framework.ClusterC, nginxServiceClusterB)
 
 	serviceIPList = append(serviceIPList, serviceIPClusterC)
 

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -550,7 +550,7 @@ func (f *Framework) SetHealthCheckIP(cluster framework.ClusterIndex, ip, endpoin
 func (f *Framework) VerifyServiceIPWithDig(srcCluster, targetCluster framework.ClusterIndex, service *v1.Service, targetPod *v1.PodList,
 	domains []string, clusterName string, shouldContain bool,
 ) {
-	serviceIP := f.GetServiceIP(targetCluster, service, srcCluster == targetCluster)
+	serviceIP := f.GetServiceIP(targetCluster, service)
 	f.VerifyIPWithDig(srcCluster, service, targetPod, domains, clusterName, serviceIP, shouldContain)
 }
 
@@ -657,7 +657,7 @@ func (f *Framework) VerifyIPsWithDig(cluster framework.ClusterIndex, service *v1
 	})
 }
 
-func (f *Framework) GetServiceIP(svcCluster framework.ClusterIndex, service *v1.Service, isLocal bool) string {
+func (f *Framework) GetServiceIP(svcCluster framework.ClusterIndex, service *v1.Service) string {
 	Expect(service.Spec.Type).To(Equal(v1.ServiceTypeClusterIP))
 
 	if !framework.TestContext.GlobalnetEnabled {


### PR DESCRIPTION
These are flagged by golangci-lint 1.52:
* various resource syncer transform functions ignore some of their parameters, rename them to _;
* the test framework's GetServiceIP function doesn't use its isLocal parameter, drop it.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
