### PR TITLE
Automated backport of #1186: Fix panic in AfterEach when test is skipped

### DIFF
--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -109,7 +109,9 @@ var _ = Describe("[discovery] Test Service Discovery Across Clusters", func() {
 		})
 
 		AfterEach(func() {
-			f.SetHealthCheckIP(framework.ClusterC, healthCheckIP, endpointName)
+			if endpointName != "" {
+				f.SetHealthCheckIP(framework.ClusterC, healthCheckIP, endpointName)
+			}
 		})
 	})
 })


### PR DESCRIPTION
Backport of #1186 on release-0.15.

#1186: Fix panic in AfterEach when test is skipped

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.