### PR TITLE
Only update Synced condition if local ServiceImport created

### DIFF
--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -260,7 +260,8 @@ func (a *Controller) serviceExportToServiceImport(obj runtime.Object, _ int, op 
 	a.serviceExportClient.updateStatusConditions(svcExport.Name, svcExport.Namespace, newServiceExportCondition(mcsv1a1.ServiceExportValid,
 		corev1.ConditionTrue, "", ""))
 
-	logger.V(log.DEBUG).Infof("Returning ServiceImport: %s", serviceImportStringer{serviceImport})
+	logger.V(log.DEBUG).Infof("Returning ServiceImport %s/%s: %s", svcExport.Namespace, svcExport.Name,
+		serviceImportStringer{serviceImport})
 
 	return serviceImport, false
 }

--- a/pkg/agent/controller/endpoint.go
+++ b/pkg/agent/controller/endpoint.go
@@ -220,9 +220,11 @@ func (e *EndpointController) endpointSliceFromEndpoints(endpoints *corev1.Endpoi
 	}
 
 	if op == syncer.Create {
-		logger.V(log.DEBUG).Infof("Returning EndpointSlice: %s", endpointSliceStringer{endpointSlice})
+		logger.V(log.DEBUG).Infof("Returning EndpointSlice %s/%s: %s", endpoints.Namespace, endpoints.Name,
+			endpointSliceStringer{endpointSlice})
 	} else {
-		logger.V(log.TRACE).Infof("Returning EndpointSlice: %s", endpointSliceStringer{endpointSlice})
+		logger.V(log.TRACE).Infof("Returning EndpointSlice %s/%s: %s", endpoints.Namespace, endpoints.Name,
+			endpointSliceStringer{endpointSlice})
 	}
 
 	return endpointSlice, false

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -276,11 +276,11 @@ func (c *ServiceImportController) onLocalServiceImport(obj runtime.Object, _ int
 				corev1.ConditionFalse, "NoServiceImport", "ServiceImport was deleted"))
 
 		return obj, false
+	} else if op == syncer.Create {
+		c.serviceExportClient.updateStatusConditions(serviceName, serviceImport.Labels[constants.LabelSourceNamespace],
+			newServiceExportCondition(constants.ServiceExportSynced,
+				corev1.ConditionFalse, "AwaitingExport", fmt.Sprintf("ServiceImport %sd - awaiting aggregation on the broker", op)))
 	}
-
-	c.serviceExportClient.updateStatusConditions(serviceName, serviceImport.Labels[constants.LabelSourceNamespace],
-		newServiceExportCondition(constants.ServiceExportSynced,
-			corev1.ConditionFalse, "AwaitingExport", fmt.Sprintf("ServiceImport %sd - awaiting aggregation on the broker", op)))
 
 	return obj, false
 }


### PR DESCRIPTION
On local `ServiceImport`, we update the `Synced` condition to status false with reason "_AwaitingExport_", expecting it to get subsequently updated to status true when the local `EndpointSlice` is synced to the broker. However, it was observed in a real deployment where the condition remained in the "_AwaitingExport_" state. The scenario was that the status was set to true but later the controller lost connection to the API server. When connection was restored, the informer re-synced and notified of the local `ServiceImport` updated so the condition was set to "_AwaitingExport_" but this occurred after the notification of the `EndpointSlice` updated so the condition remained in that state.

We really only need to set the condition to "_AwaitingExport_" when the service is first exported, ie when the local `ServiceImport` is created so elide updating the condition on update.

Also improved a couple log statements to include the resource name which helps in debugging when there's many exported services.
