### PR TITLE
Automated backport of #1230: Only update Synced condition if local ServiceImport created

### DIFF
--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -260,7 +260,8 @@ func (a *Controller) serviceExportToServiceImport(obj runtime.Object, numRequeue
 	a.serviceExportClient.updateStatusConditions(svcExport.Name, svcExport.Namespace, newServiceExportCondition(mcsv1a1.ServiceExportValid,
 		corev1.ConditionTrue, "", ""))
 
-	logger.V(log.DEBUG).Infof("Returning ServiceImport: %s", serviceImportStringer{serviceImport})
+	logger.V(log.DEBUG).Infof("Returning ServiceImport %s/%s: %s", svcExport.Namespace, svcExport.Name,
+		serviceImportStringer{serviceImport})
 
 	return serviceImport, false
 }

--- a/pkg/agent/controller/endpoint.go
+++ b/pkg/agent/controller/endpoint.go
@@ -220,9 +220,11 @@ func (e *EndpointController) endpointSliceFromEndpoints(endpoints *corev1.Endpoi
 	}
 
 	if op == syncer.Create {
-		logger.V(log.DEBUG).Infof("Returning EndpointSlice: %s", endpointSliceStringer{endpointSlice})
+		logger.V(log.DEBUG).Infof("Returning EndpointSlice %s/%s: %s", endpoints.Namespace, endpoints.Name,
+			endpointSliceStringer{endpointSlice})
 	} else {
-		logger.V(log.TRACE).Infof("Returning EndpointSlice: %s", endpointSliceStringer{endpointSlice})
+		logger.V(log.TRACE).Infof("Returning EndpointSlice %s/%s: %s", endpoints.Namespace, endpoints.Name,
+			endpointSliceStringer{endpointSlice})
 	}
 
 	return endpointSlice, false

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -276,11 +276,11 @@ func (c *ServiceImportController) onLocalServiceImport(obj runtime.Object, _ int
 				corev1.ConditionFalse, "NoServiceImport", "ServiceImport was deleted"))
 
 		return obj, false
+	} else if op == syncer.Create {
+		c.serviceExportClient.updateStatusConditions(serviceName, serviceImport.Labels[constants.LabelSourceNamespace],
+			newServiceExportCondition(constants.ServiceExportSynced,
+				corev1.ConditionFalse, "AwaitingExport", fmt.Sprintf("ServiceImport %sd - awaiting aggregation on the broker", op)))
 	}
-
-	c.serviceExportClient.updateStatusConditions(serviceName, serviceImport.Labels[constants.LabelSourceNamespace],
-		newServiceExportCondition(constants.ServiceExportSynced,
-			corev1.ConditionFalse, "AwaitingExport", fmt.Sprintf("ServiceImport %sd - awaiting aggregation on the broker", op)))
 
 	return obj, false
 }


### PR DESCRIPTION
Backport of #1230 on release-0.15.

#1230: Only update Synced condition if local ServiceImport created

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.