### PR TITLE
Automated backport of #1241: Include not-ready addresses in EndpointSlice

### DIFF
--- a/coredns/constants/constants.go
+++ b/coredns/constants/constants.go
@@ -19,9 +19,10 @@ limitations under the License.
 package constants
 
 const (
-	KubernetesServiceName = "kubernetes.io/service-name"
-	LabelValueManagedBy   = "lighthouse-agent.submariner.io"
-	LabelSourceNamespace  = "lighthouse.submariner.io/sourceNamespace"
-	MCSLabelSourceCluster = "multicluster.kubernetes.io/source-cluster"
-	LabelIsHeadless       = "lighthouse.submariner.io/is-headless"
+	KubernetesServiceName    = "kubernetes.io/service-name"
+	LabelValueManagedBy      = "lighthouse-agent.submariner.io"
+	LabelSourceNamespace     = "lighthouse.submariner.io/sourceNamespace"
+	MCSLabelSourceCluster    = "multicluster.kubernetes.io/source-cluster"
+	LabelIsHeadless          = "lighthouse.submariner.io/is-headless"
+	PublishNotReadyAddresses = "lighthouse.submariner.io/publish-not-ready-addresses"
 )

--- a/coredns/resolver/endpoint_slice.go
+++ b/coredns/resolver/endpoint_slice.go
@@ -21,6 +21,7 @@ package resolver
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/lighthouse/coredns/constants"
@@ -132,12 +133,15 @@ func (i *Interface) putHeadlessEndpointSlice(key, clusterID string, endpointSlic
 
 	mcsPorts := mcsServicePortsFrom(endpointSlice.Ports)
 
+	publishNotReadyAddresses := endpointSlice.Annotations[constants.PublishNotReadyAddresses] == strconv.FormatBool(true)
+
 	for i := range endpointSlice.Endpoints {
 		endpoint := &endpointSlice.Endpoints[i]
 
-		// Skip if not ready. Note: we're treating nil as ready to be on the safe side as the EndpointConditions doc
-		// states "In most cases consumers should interpret this unknown state (ie nil) as ready".
-		if endpoint.Conditions.Ready != nil && !*endpoint.Conditions.Ready {
+		// Skip if not ready and the user does not want to publish not-ready addresses. Note: we're treating nil as ready
+		// to be on the safe side as the EndpointConditions doc states "In most cases consumers should interpret this
+		// unknown state (ie nil) as ready".
+		if endpoint.Conditions.Ready != nil && !*endpoint.Conditions.Ready && !publishNotReadyAddresses {
 			continue
 		}
 

--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strconv"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/federate"
@@ -221,6 +222,7 @@ func (a *Controller) serviceExportToServiceImport(obj runtime.Object, numRequeue
 	}
 
 	serviceImport := a.newServiceImport(svcExport.Name, svcExport.Namespace)
+	serviceImport.Annotations[constants.PublishNotReadyAddresses] = strconv.FormatBool(svc.Spec.PublishNotReadyAddresses)
 
 	serviceImport.Spec = mcsv1a1.ServiceImportSpec{
 		Ports:                 []mcsv1a1.ServicePort{},

--- a/pkg/agent/controller/clusterip_service_test.go
+++ b/pkg/agent/controller/clusterip_service_test.go
@@ -59,6 +59,8 @@ func testClusterIPServiceInOneCluster() {
 				t.cluster1.createService()
 				t.cluster1.createServiceExport()
 				t.awaitNonHeadlessServiceExported(&t.cluster1)
+				t.cluster1.awaitServiceExportCondition(newServiceExportSyncedCondition(corev1.ConditionFalse, "AwaitingExport"),
+					newServiceExportSyncedCondition(corev1.ConditionTrue, ""))
 				t.cluster1.ensureNoServiceExportCondition(mcsv1a1.ServiceExportConflict)
 			})
 		})

--- a/pkg/agent/controller/controller_suite_test.go
+++ b/pkg/agent/controller/controller_suite_test.go
@@ -635,6 +635,10 @@ func awaitEndpointSlice(client dynamic.ResourceInterface, expected *discovery.En
 		Expect(endpointSlice.Labels).To(HaveKeyWithValue(k, v))
 	}
 
+	for k, v := range expected.Annotations {
+		Expect(endpointSlice.Annotations).To(HaveKeyWithValue(k, v))
+	}
+
 	Expect(endpointSlice.AddressType).To(Equal(expected.AddressType))
 	Expect(endpointSlice.Endpoints).To(Equal(expected.Endpoints))
 	Expect(endpointSlice.Ports).To(Equal(expected.Ports))
@@ -704,6 +708,7 @@ func (t *testDriver) awaitEndpointSlice(c *cluster) {
 				constants.LabelSourceNamespace:  c.service.Namespace,
 				constants.LabelIsHeadless:       strconv.FormatBool(isHeadless),
 			},
+			Annotations: map[string]string{},
 		},
 		AddressType: discovery.AddressTypeIPv4,
 	}
@@ -719,6 +724,8 @@ func (t *testDriver) awaitEndpointSlice(c *cluster) {
 				AppProtocol: c.endpoints.Subsets[0].Ports[i].AppProtocol,
 			})
 		}
+
+		expected.Annotations[constants.PublishNotReadyAddresses] = strconv.FormatBool(c.service.Spec.PublishNotReadyAddresses)
 	} else {
 		expected.Endpoints = []discovery.Endpoint{
 			{

--- a/pkg/agent/controller/controller_suite_test.go
+++ b/pkg/agent/controller/controller_suite_test.go
@@ -63,6 +63,7 @@ const (
 	serviceNamespace = "service-ns"
 	globalIP1        = "242.254.1.1"
 	globalIP2        = "242.254.1.2"
+	globalIP3        = "242.254.1.3"
 )
 
 var (
@@ -294,6 +295,11 @@ func newTestDiver() *testDriver {
 			Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
 			Hostname:   &t.cluster1.endpoints.Subsets[0].Addresses[1].TargetRef.Name,
 			NodeName:   t.cluster1.endpoints.Subsets[0].Addresses[1].NodeName,
+		},
+		{
+			Addresses:  []string{t.cluster1.endpoints.Subsets[0].NotReadyAddresses[0].IP},
+			Conditions: discovery.EndpointConditions{Ready: pointer.Bool(false)},
+			Hostname:   &t.cluster1.endpoints.Subsets[0].NotReadyAddresses[0].TargetRef.Name,
 		},
 	}
 

--- a/pkg/agent/controller/globalnet_test.go
+++ b/pkg/agent/controller/globalnet_test.go
@@ -121,12 +121,14 @@ var _ = Describe("Globalnet enabled", func() {
 
 			t.cluster1.endpointSliceAddresses[0].Addresses = []string{globalIP1}
 			t.cluster1.endpointSliceAddresses[1].Addresses = []string{globalIP2}
+			t.cluster1.endpointSliceAddresses[2].Addresses = []string{globalIP3}
 		})
 
 		Context("and it has global IPs for all endpoint addresses", func() {
 			BeforeEach(func() {
 				t.cluster1.createGlobalIngressIP(t.cluster1.newHeadlessGlobalIngressIP("one", globalIP1))
 				t.cluster1.createGlobalIngressIP(t.cluster1.newHeadlessGlobalIngressIP("two", globalIP2))
+				t.cluster1.createGlobalIngressIP(t.cluster1.newHeadlessGlobalIngressIP("not-ready", globalIP3))
 			})
 
 			It("should export the service with the global IPs", func() {
@@ -143,6 +145,7 @@ var _ = Describe("Globalnet enabled", func() {
 				t.cluster1.ensureNoEndpointSlice()
 
 				t.cluster1.createGlobalIngressIP(t.cluster1.newHeadlessGlobalIngressIP("two", globalIP2))
+				t.cluster1.createGlobalIngressIP(t.cluster1.newHeadlessGlobalIngressIP("not-ready", globalIP3))
 
 				t.awaitEndpointSlice(&t.cluster1)
 			})

--- a/pkg/agent/controller/headless_service_test.go
+++ b/pkg/agent/controller/headless_service_test.go
@@ -45,6 +45,10 @@ var _ = Describe("Headless Service export", func() {
 
 	When("a ServiceExport is created", func() {
 		Context("and the Service already exists", func() {
+			BeforeEach(func() {
+				t.cluster1.service.Spec.PublishNotReadyAddresses = true
+			})
+
 			It("should export the service", func() {
 				t.cluster1.createEndpoints()
 				t.cluster1.createServiceExport()

--- a/pkg/agent/controller/headless_service_test.go
+++ b/pkg/agent/controller/headless_service_test.go
@@ -71,10 +71,14 @@ var _ = Describe("Headless Service export", func() {
 			t.awaitHeadlessServiceExported(&t.cluster1)
 
 			t.cluster1.endpoints.Subsets[0].Addresses = append(t.cluster1.endpoints.Subsets[0].Addresses, corev1.EndpointAddress{IP: "192.168.5.3"})
-			t.cluster1.endpointSliceAddresses = append(t.cluster1.endpointSliceAddresses, discovery.Endpoint{
+
+			index := 2
+			t.cluster1.endpointSliceAddresses = append(t.cluster1.endpointSliceAddresses[:index+1],
+				t.cluster1.endpointSliceAddresses[index:]...)
+			t.cluster1.endpointSliceAddresses[index] = discovery.Endpoint{
 				Addresses:  []string{"192.168.5.3"},
 				Conditions: discovery.EndpointConditions{Ready: pointer.Bool(true)},
-			})
+			}
 
 			t.cluster1.updateEndpoints()
 			t.awaitEndpointSlice(&t.cluster1)

--- a/pkg/agent/controller/reconciliation_test.go
+++ b/pkg/agent/controller/reconciliation_test.go
@@ -40,6 +40,7 @@ import (
 var _ = Describe("Reconciliation", func() {
 	var (
 		t                    *testDriver
+		serviceExport        *mcsv1a1.ServiceExport
 		localServiceImport   *mcsv1a1.ServiceImport
 		localEndpointSlice   *discovery.EndpointSlice
 		brokerServiceImports *unstructured.UnstructuredList
@@ -71,6 +72,10 @@ var _ = Describe("Reconciliation", func() {
 
 		localEndpointSlice = t.cluster1.findLocalEndpointSlice()
 		Expect(localEndpointSlice).ToNot(BeNil())
+
+		obj, err := t.cluster1.localServiceExportClient.Get(context.Background(), t.cluster1.serviceExport.Name, metav1.GetOptions{})
+		Expect(err).To(Succeed())
+		serviceExport = toServiceExport(obj)
 	})
 
 	AfterEach(func() {
@@ -94,12 +99,12 @@ var _ = Describe("Reconciliation", func() {
 
 			test.CreateResource(t.cluster1.localServiceImportClient.Namespace(test.LocalNamespace), localServiceImport)
 			test.CreateResource(t.cluster1.localEndpointSliceClient, localEndpointSlice)
+			test.CreateResource(t.cluster1.localServiceExportClient, serviceExport)
 
 			restoreBrokerResources()
 
 			t.cluster1.createEndpoints()
 			t.cluster1.createService()
-			t.cluster1.createServiceExport()
 
 			t.cluster1.start(t, *t.syncerConfig)
 			t.cluster2.start(t, *t.syncerConfig)

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -277,8 +277,8 @@ func (c *ServiceImportController) onLocalServiceImport(obj runtime.Object, _ int
 
 		return obj, false
 	} else if op == syncer.Create {
-		c.serviceExportClient.updateStatusConditions(serviceName, serviceImport.Labels[constants.LabelSourceNamespace],
-			newServiceExportCondition(constants.ServiceExportSynced,
+		c.serviceExportClient.tryUpdateStatusConditions(serviceName, serviceImport.Labels[constants.LabelSourceNamespace],
+			false, newServiceExportCondition(constants.ServiceExportSynced,
 				corev1.ConditionFalse, "AwaitingExport", fmt.Sprintf("ServiceImport %sd - awaiting aggregation on the broker", op)))
 	}
 

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -90,16 +90,17 @@ type ServiceImportController struct {
 // that listen only for the Service's endpoints. It creates an EndpointSlice corresponding to an Endpoints object that is
 // distributed to other clusters.
 type EndpointController struct {
-	clusterID            string
-	serviceName          string
-	serviceNamespace     string
-	serviceImportSpec    *mcsv1a1.ServiceImportSpec
-	stopCh               chan struct{}
-	stopOnce             sync.Once
-	localClient          dynamic.Interface
-	ingressIPClient      dynamic.NamespaceableResourceInterface
-	globalIngressIPCache *globalIngressIPCache
-	epsSyncer            syncer.Interface
+	clusterID                string
+	serviceName              string
+	serviceNamespace         string
+	serviceImportSpec        *mcsv1a1.ServiceImportSpec
+	publishNotReadyAddresses string
+	stopCh                   chan struct{}
+	stopOnce                 sync.Once
+	localClient              dynamic.Interface
+	ingressIPClient          dynamic.NamespaceableResourceInterface
+	globalIngressIPCache     *globalIngressIPCache
+	epsSyncer                syncer.Interface
 }
 
 // EndpointSliceController encapsulates a syncer that syncs EndpointSlices to and from that broker.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -23,10 +23,11 @@ import (
 )
 
 const (
-	LabelSourceNamespace  = "lighthouse.submariner.io/sourceNamespace"
-	LabelValueManagedBy   = "lighthouse-agent.submariner.io"
-	MCSLabelSourceCluster = "multicluster.kubernetes.io/source-cluster"
-	LabelIsHeadless       = "lighthouse.submariner.io/is-headless"
+	LabelSourceNamespace     = "lighthouse.submariner.io/sourceNamespace"
+	LabelValueManagedBy      = "lighthouse-agent.submariner.io"
+	MCSLabelSourceCluster    = "multicluster.kubernetes.io/source-cluster"
+	LabelIsHeadless          = "lighthouse.submariner.io/is-headless"
+	PublishNotReadyAddresses = "lighthouse.submariner.io/publish-not-ready-addresses"
 )
 
 const ServiceExportSynced v1alpha1.ServiceExportConditionType = "Synced"


### PR DESCRIPTION
Backport of #1241 on release-0.15.

#1241: Include not-ready addresses in EndpointSlice

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.