### PR TITLE
Add E2E test for nonexistent imported service NS

### DIFF
--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -33,12 +33,10 @@ import (
 )
 
 const (
-	clustersetDomain = "clusterset.local"
-	not              = " not"
+	not = " not"
 )
 
-// Both domains need to be checked, until the operator is updated to use clusterset.
-var checkedDomains = []string{clustersetDomain}
+var checkedDomains = lhframework.CheckedDomains
 
 var _ = Describe("[discovery] Test Service Discovery Across Clusters", func() {
 	f := lhframework.NewFramework("discovery")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	_ "github.com/submariner-io/lighthouse/test/e2e/discovery"
+	_ "github.com/submariner-io/lighthouse/test/e2e/internal"
 	"github.com/submariner-io/shipyard/test/e2e"
 )
 

--- a/test/e2e/framework/deployments.go
+++ b/test/e2e/framework/deployments.go
@@ -28,10 +28,15 @@ import (
 )
 
 func (f *Framework) NewNetShootDeployment(cluster framework.ClusterIndex) *corev1.PodList {
+	return f.NewNetShootDeploymentInNS(cluster, f.Namespace)
+}
+
+func (f *Framework) NewNetShootDeploymentInNS(cluster framework.ClusterIndex, namespace string) *corev1.PodList {
 	var replicaCount int32 = 1
 	netShootDeployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "netshoot",
+			Namespace:    namespace,
 			Labels: map[string]string{
 				"run": "netshoot",
 			},
@@ -74,7 +79,8 @@ func (f *Framework) NewNginxDeployment(cluster framework.ClusterIndex) *corev1.P
 	var port int32 = 8080
 	nginxDeployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "nginx-demo",
+			Name:      "nginx-demo",
+			Namespace: f.Namespace,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
@@ -115,12 +121,12 @@ func (f *Framework) NewNginxDeployment(cluster framework.ClusterIndex) *corev1.P
 }
 
 func createDeployment(f *Framework, cluster framework.ClusterIndex, deployment *appsv1.Deployment) *corev1.PodList {
-	pc := framework.KubeClients[cluster].AppsV1().Deployments(f.Namespace)
+	pc := framework.KubeClients[cluster].AppsV1().Deployments(deployment.Namespace)
 	appName := deployment.Spec.Template.ObjectMeta.Labels["app"]
 
 	_ = framework.AwaitUntil("create deployment", func() (interface{}, error) {
 		return pc.Create(context.TODO(), deployment, metav1.CreateOptions{})
 	}, framework.NoopCheckResult).(*appsv1.Deployment)
 
-	return f.AwaitPodsByAppLabel(cluster, appName, f.Namespace, 1)
+	return f.AwaitPodsByAppLabel(cluster, appName, deployment.Namespace, 1)
 }

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -45,11 +45,14 @@ import (
 )
 
 const (
+	clustersetDomain    = "clusterset.local"
 	anyCount            = -1
 	statefulServiceName = "nginx-ss"
 	statefulSetName     = "web"
 	not                 = " not"
 )
+
+var CheckedDomains = []string{clustersetDomain}
 
 // Framework supports common operations used by e2e tests; it will keep a client & a namespace for you.
 type Framework struct {
@@ -649,7 +652,7 @@ func (f *Framework) VerifyIPWithDig(srcCluster framework.ClusterIndex, service *
 	framework.AwaitUntil("verify if service IP is discoverable", func() (interface{}, error) {
 		stdout, _, err := f.ExecWithOptions(context.TODO(), &framework.ExecOptions{
 			Command:       cmd,
-			Namespace:     f.Namespace,
+			Namespace:     targetPod.Items[0].Namespace,
 			PodName:       targetPod.Items[0].Name,
 			ContainerName: targetPod.Items[0].Spec.Containers[0].Name,
 			CaptureStdout: true,

--- a/test/e2e/internal/service_discovery.go
+++ b/test/e2e/internal/service_discovery.go
@@ -1,0 +1,99 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	lhframework "github.com/submariner-io/lighthouse/test/e2e/framework"
+	"github.com/submariner-io/shipyard/test/e2e/framework"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("[internal] Test Service Discovery Across Clusters", func() {
+	f := lhframework.NewFramework("internal")
+
+	When("the namespace for an imported remote service does not exist locally", func() {
+		It("should not resolve the remote service in the local cluster", func() {
+			RunNonexistentNamespaceDiscoveryTest(f)
+		})
+	})
+})
+
+func RunNonexistentNamespaceDiscoveryTest(f *lhframework.Framework) {
+	clusterAName := framework.TestContext.ClusterIDs[framework.ClusterA]
+	clusterBName := framework.TestContext.ClusterIDs[framework.ClusterB]
+
+	netshootNS, err := framework.KubeClients[framework.ClusterA].CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: fmt.Sprintf("e2e-tests-%v-", f.BaseName),
+		},
+	}, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred(), "Error creating namespace")
+
+	By(fmt.Sprintf("Created namespace %q for netshoot deployment on %q", netshootNS.Name, clusterAName))
+
+	f.AddNamespacesToDelete(netshootNS)
+
+	Expect(framework.KubeClients[framework.ClusterA].CoreV1().Namespaces().Delete(context.TODO(),
+		f.Namespace, metav1.DeleteOptions{})).To(Succeed())
+
+	By(fmt.Sprintf("Creating an Nginx Deployment on on %q", clusterBName))
+	f.NewNginxDeployment(framework.ClusterB)
+
+	By(fmt.Sprintf("Creating a Nginx Service on %q", clusterBName))
+
+	nginxServiceClusterB := f.NewNginxService(framework.ClusterB)
+
+	f.NewServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+
+	f.AwaitServiceExportedStatusCondition(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+
+	By(fmt.Sprintf("Creating a Netshoot Deployment on %q", clusterAName))
+
+	netshootPodList := f.NewNetShootDeploymentInNS(framework.ClusterA, netshootNS.Name)
+
+	svc, err := f.GetService(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+	Expect(err).NotTo(HaveOccurred())
+
+	nginxServiceClusterB = svc
+
+	for i := 1; i <= 5; i++ {
+		time.Sleep(500 * time.Millisecond)
+		f.VerifyServiceIPWithDig(framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, lhframework.CheckedDomains,
+			"", false)
+	}
+
+	By(fmt.Sprintf("Recreating namespace %q on %q", f.Namespace, clusterAName))
+
+	_, err = framework.KubeClients[framework.ClusterA].CoreV1().Namespaces().Create(context.TODO(), &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: f.Namespace,
+		},
+	}, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred(), "Error creating namespace")
+
+	f.VerifyServiceIPWithDig(framework.ClusterA, framework.ClusterB, nginxServiceClusterB, netshootPodList, lhframework.CheckedDomains,
+		"", true)
+}


### PR DESCRIPTION
...to verify an imported service is not accessible if the service namespace doesn't exist locally.

Since the service is created in the framework's generated namespace, the test deletes this namespace from the source cluster and creates another namespace to contain the netshoot deployment.

The test was placed in a new folder named "_internal_" so it isn't run with `subctl verify`. We should only need to verify this functionality in CI plus it has the overhead of an additional namespace.

Fixes https://github.com/submariner-io/lighthouse/issues/605
