### PR TITLE
Use RequeueResource when service is re-created

### DIFF
--- a/pkg/agent/controller/clusterip_service_test.go
+++ b/pkg/agent/controller/clusterip_service_test.go
@@ -97,11 +97,13 @@ func testClusterIPServiceInOneCluster() {
 			t.awaitNonHeadlessServiceExported(&t.cluster1)
 			t.cluster1.localDynClient.Fake.ClearActions()
 
+			By("Deleting the service")
 			t.cluster1.deleteService()
 			t.cluster1.awaitServiceUnavailableStatus()
 			t.cluster1.awaitServiceExportCondition(newServiceExportReadyCondition(corev1.ConditionFalse, "NoServiceImport"))
 			t.awaitServiceUnexported(&t.cluster1)
 
+			By("Re-creating the service")
 			t.cluster1.createService()
 			t.awaitNonHeadlessServiceExported(&t.cluster1)
 		})


### PR DESCRIPTION
...to re-queue the `ServiceExport` rather than calling `serviceExportToServiceImport` directly. This is safer and cleaner so that all `ServiceExport` notifications are handled from the same syncer.
