### PR TITLE
Alleviate excessive periodic logging during conflict check

### DIFF
--- a/pkg/agent/controller/clusterip_service_test.go
+++ b/pkg/agent/controller/clusterip_service_test.go
@@ -66,6 +66,11 @@ func testClusterIPServiceInOneCluster() {
 				t.cluster1.awaitServiceExportCondition(newServiceExportReadyCondition(corev1.ConditionFalse, "AwaitingExport"),
 					newServiceExportReadyCondition(corev1.ConditionTrue, ""))
 				t.cluster1.ensureNoServiceExportCondition(mcsv1a1.ServiceExportConflict)
+
+				By(fmt.Sprintf("Ensure cluster %q does not try to update the status for a non-existent ServiceExport",
+					t.cluster2.clusterID))
+
+				t.cluster2.ensureNoServiceExportActions()
 			})
 		})
 
@@ -329,6 +334,10 @@ func testClusterIPServiceInTwoClusters() {
 		t.cluster1.ensureLastServiceExportCondition(newServiceExportValidCondition(corev1.ConditionTrue, ""))
 		t.cluster1.ensureNoServiceExportCondition(mcsv1a1.ServiceExportConflict)
 		t.cluster2.ensureNoServiceExportCondition(mcsv1a1.ServiceExportConflict)
+
+		By("Ensure conflict checking does not try to unnecessarily update the ServiceExport status")
+
+		t.cluster1.ensureNoServiceExportActions()
 	})
 
 	Context("with differing ports", func() {

--- a/pkg/agent/controller/service_export_client.go
+++ b/pkg/agent/controller/service_export_client.go
@@ -104,7 +104,7 @@ func (c *ServiceExportClient) doUpdate(name, namespace string, update func(toUpd
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		obj, err := c.Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
-			logger.Infof("ServiceExport (%s/%s) not found - unable to update status", namespace, name)
+			logger.V(log.TRACE).Infof("ServiceExport (%s/%s) not found - unable to update status", namespace, name)
 			return nil
 		} else if err != nil {
 			return errors.Wrap(err, "error retrieving ServiceExport")
@@ -125,6 +125,15 @@ func (c *ServiceExportClient) doUpdate(name, namespace string, update func(toUpd
 	if err != nil {
 		logger.Errorf(err, "Error updating status for ServiceExport (%s/%s)", namespace, name)
 	}
+}
+
+func (c *ServiceExportClient) getLocalInstance(name, namespace string) *mcsv1a1.ServiceExport {
+	obj, found, _ := c.localSyncer.GetResource(name, namespace)
+	if !found {
+		return nil
+	}
+
+	return obj.(*mcsv1a1.ServiceExport)
 }
 
 func serviceExportConditionEqual(c1, c2 *mcsv1a1.ServiceExportCondition) bool {

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -96,7 +96,7 @@ func newServiceImportController(spec *AgentSpecification, syncerMetricNames Agen
 		Transform:        controller.onRemoteServiceImport,
 		OnSuccessfulSync: controller.serviceImportMigrator.onSuccessfulSyncFromBroker,
 		Scheme:           syncerConfig.Scheme,
-		ResyncPeriod:     brokerResyncePeriod,
+		ResyncPeriod:     BrokerResyncPeriod,
 		SyncCounterOpts: &prometheus.GaugeOpts{
 			Name: syncerMetricNames.ServiceImportCounterName,
 			Help: "Count of imported services",

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -39,7 +39,7 @@ const (
 	portConflictReason = "ConflictingPorts"
 )
 
-var brokerResyncePeriod = time.Minute * 2
+var BrokerResyncPeriod = time.Minute * 2
 
 type converter struct {
 	scheme *runtime.Scheme
@@ -118,6 +118,7 @@ type EndpointSliceController struct {
 type ServiceExportClient struct {
 	dynamic.NamespaceableResourceInterface
 	converter
+	localSyncer syncer.Interface
 }
 
 type globalIngressIPCache struct {


### PR DESCRIPTION
If a service is imported without a local service export, the conflict checking tries to update the status of a non-existent `ServiceExport`, specifically to remove the Conflict status condition. This results in a log message: _ServiceExport (...) not found - unable to update status_
    
Due to the 2 minute resync intervaL for the `EndpointSlice` syncer, this can exhaust the pod disk storage over time.
    
([first commit](https://github.com/submariner-io/lighthouse/pull/1400/commits/16a68a73b66fd69f0747e3efc160bfab8a45bde8)) To alleviate this issue, check the local cache for a ServiceExport and, if non-existent, skip the conflict checking. If it does exist but the Conflict status condition doesn't exist in the local ServiceExport then elide trying to remove the status condition. Also, change the log level to TRACE for the offending message.
    
([second commit](https://github.com/submariner-io/lighthouse/pull/1400/commits/05d99653edeee932fa71c78fc50048ca5a11c88e)) Optimize conflict checking using the local cache to list the `EndpointSlices` instead of the API server client.