### PR TITLE
Automated backport of #1400: Alleviate excessive periodic logging during conflict

### DIFF
--- a/pkg/agent/controller/clusterip_service_test.go
+++ b/pkg/agent/controller/clusterip_service_test.go
@@ -66,6 +66,11 @@ func testClusterIPServiceInOneCluster() {
 				t.cluster1.awaitServiceExportCondition(newServiceExportReadyCondition(corev1.ConditionFalse, "AwaitingExport"),
 					newServiceExportReadyCondition(corev1.ConditionTrue, ""))
 				t.cluster1.ensureNoServiceExportCondition(mcsv1a1.ServiceExportConflict)
+
+				By(fmt.Sprintf("Ensure cluster %q does not try to update the status for a non-existent ServiceExport",
+					t.cluster2.clusterID))
+
+				t.cluster2.ensureNoServiceExportActions()
 			})
 		})
 
@@ -329,6 +334,10 @@ func testClusterIPServiceInTwoClusters() {
 		t.cluster1.ensureLastServiceExportCondition(newServiceExportValidCondition(corev1.ConditionTrue, ""))
 		t.cluster1.ensureNoServiceExportCondition(mcsv1a1.ServiceExportConflict)
 		t.cluster2.ensureNoServiceExportCondition(mcsv1a1.ServiceExportConflict)
+
+		By("Ensure conflict checking does not try to unnecessarily update the ServiceExport status")
+
+		t.cluster1.ensureNoServiceExportActions()
 	})
 
 	Context("with differing ports", func() {

--- a/pkg/agent/controller/service_export_client.go
+++ b/pkg/agent/controller/service_export_client.go
@@ -104,7 +104,7 @@ func (c *ServiceExportClient) doUpdate(name, namespace string, update func(toUpd
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		obj, err := c.Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
-			logger.Infof("ServiceExport (%s/%s) not found - unable to update status", namespace, name)
+			logger.V(log.TRACE).Infof("ServiceExport (%s/%s) not found - unable to update status", namespace, name)
 			return nil
 		} else if err != nil {
 			return errors.Wrap(err, "error retrieving ServiceExport")
@@ -125,6 +125,15 @@ func (c *ServiceExportClient) doUpdate(name, namespace string, update func(toUpd
 	if err != nil {
 		logger.Errorf(err, "Error updating status for ServiceExport (%s/%s)", namespace, name)
 	}
+}
+
+func (c *ServiceExportClient) getLocalInstance(name, namespace string) *mcsv1a1.ServiceExport {
+	obj, found, _ := c.localSyncer.GetResource(name, namespace)
+	if !found {
+		return nil
+	}
+
+	return obj.(*mcsv1a1.ServiceExport)
 }
 
 func serviceExportConditionEqual(c1, c2 *mcsv1a1.ServiceExportCondition) bool {

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -96,7 +96,7 @@ func newServiceImportController(spec *AgentSpecification, syncerMetricNames Agen
 		Transform:        controller.onRemoteServiceImport,
 		OnSuccessfulSync: controller.serviceImportMigrator.onSuccessfulSyncFromBroker,
 		Scheme:           syncerConfig.Scheme,
-		ResyncPeriod:     brokerResyncePeriod,
+		ResyncPeriod:     BrokerResyncPeriod,
 		SyncCounterOpts: &prometheus.GaugeOpts{
 			Name: syncerMetricNames.ServiceImportCounterName,
 			Help: "Count of imported services",

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -39,7 +39,7 @@ const (
 	portConflictReason = "ConflictingPorts"
 )
 
-var brokerResyncePeriod = time.Minute * 2
+var BrokerResyncPeriod = time.Minute * 2
 
 type converter struct {
 	scheme *runtime.Scheme
@@ -118,6 +118,7 @@ type EndpointSliceController struct {
 type ServiceExportClient struct {
 	dynamic.NamespaceableResourceInterface
 	converter
+	localSyncer syncer.Interface
 }
 
 type globalIngressIPCache struct {


### PR DESCRIPTION
Backport of #1400 on release-0.16.

#1400: Alleviate excessive periodic logging during conflict

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.