### PR TITLE
Use Gingko spec labels in E2E tests

### DIFF
--- a/test/e2e/discovery/headless_services.go
+++ b/test/e2e/discovery/headless_services.go
@@ -35,7 +35,7 @@ const (
 	opAre        = "are"
 )
 
-var _ = Describe("[discovery] Test Headless Service Discovery Across Clusters", func() {
+var _ = Describe("Test Headless Service Discovery Across Clusters", Label(TestLabel), func() {
 	f := lhframework.NewFramework("discovery")
 
 	When("a pod tries to resolve a headless service in a remote cluster", func() {

--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -34,12 +34,13 @@ import (
 )
 
 const (
-	not = " not"
+	not       = " not"
+	TestLabel = "service-discovery"
 )
 
 var checkedDomains = lhframework.CheckedDomains
 
-var _ = Describe("[discovery] Test Service Discovery Across Clusters", func() {
+var _ = Describe("Test Service Discovery Across Clusters", Label(TestLabel), func() {
 	f := lhframework.NewFramework("discovery")
 
 	When("a pod tries to resolve a service in a remote cluster", func() {

--- a/test/e2e/discovery/statefulsets.go
+++ b/test/e2e/discovery/statefulsets.go
@@ -30,7 +30,7 @@ import (
 	discovery "k8s.io/api/discovery/v1"
 )
 
-var _ = Describe("[discovery] Test Stateful Sets Discovery Across Clusters", func() {
+var _ = Describe("Test Stateful Sets Discovery Across Clusters", Label(TestLabel), func() {
 	f := lhframework.NewFramework("discovery")
 
 	When("a pod tries to resolve a podname from stateful set in a remote cluster", func() {


### PR DESCRIPTION
...to explicitly categorize them rather than prepending a string to the the spec description.

Related to submariner-io/subctl#697
