### PR TITLE
Use envconfig for all SUBMARINER_ variables

### DIFF
--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -60,9 +60,11 @@ type Controller struct {
 type AgentSpecification struct {
 	ClusterID        string
 	Namespace        string
+	Verbosity        int
 	GlobalnetEnabled bool `split_words:"true"`
 	Uninstall        bool
 	HaltOnCertError  bool `split_words:"true"`
+	Debug            bool
 }
 
 type ServiceImportAggregator struct {


### PR DESCRIPTION
In the Lighthouse agent, logging settings are specified using SUBMARINER_ variables but parsed manually. Since envconfig is used for all other SUBMARINER_ variables, extend it to cover these settings as well.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
