### PR TITLE
Automated backport of #1408: Allow halting on certificate errors

### DIFF
--- a/coredns/go.mod
+++ b/coredns/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/onsi/gomega v1.27.10
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0
-	github.com/submariner-io/admiral v0.16.0
+	github.com/submariner-io/admiral v0.16.1-0.20231025063702-858d0984799c
 	k8s.io/api v0.27.6
 	k8s.io/apimachinery v0.27.6
 	k8s.io/client-go v0.27.6

--- a/coredns/go.sum
+++ b/coredns/go.sum
@@ -458,8 +458,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/submariner-io/admiral v0.16.0 h1:uM7A6KrNDzG/DyY0VJObVs6KMqHUhRR5eBcqEjanp1A=
-github.com/submariner-io/admiral v0.16.0/go.mod h1:GP0TCJkt444r2ONKVHKBbSPaKjJb0S5Qj0MyNUl2keQ=
+github.com/submariner-io/admiral v0.16.1-0.20231025063702-858d0984799c h1:zy5mZZrB885JAuLPqpb/RoGhtd9N9tUCFE5OGAZEzWw=
+github.com/submariner-io/admiral v0.16.1-0.20231025063702-858d0984799c/go.mod h1:GP0TCJkt444r2ONKVHKBbSPaKjJb0S5Qj0MyNUl2keQ=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tinylib/msgp v1.1.8 h1:FCXC1xanKO4I8plpHGH2P7koL/RzZs12l/+r7vakfm0=
 github.com/tinylib/msgp v1.1.8/go.mod h1:qkpG+2ldGg4xRFmx+jfTvZPxfGFhi64BcnL9vkCm/Tw=

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/gomega v1.27.10
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0
-	github.com/submariner-io/admiral v0.16.0
+	github.com/submariner-io/admiral v0.16.1-0.20231025063702-858d0984799c
 	github.com/submariner-io/shipyard v0.16.0
 	github.com/uw-labs/lichen v0.1.7
 	k8s.io/api v0.27.6

--- a/go.sum
+++ b/go.sum
@@ -408,8 +408,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/submariner-io/admiral v0.16.0 h1:uM7A6KrNDzG/DyY0VJObVs6KMqHUhRR5eBcqEjanp1A=
-github.com/submariner-io/admiral v0.16.0/go.mod h1:GP0TCJkt444r2ONKVHKBbSPaKjJb0S5Qj0MyNUl2keQ=
+github.com/submariner-io/admiral v0.16.1-0.20231025063702-858d0984799c h1:zy5mZZrB885JAuLPqpb/RoGhtd9N9tUCFE5OGAZEzWw=
+github.com/submariner-io/admiral v0.16.1-0.20231025063702-858d0984799c/go.mod h1:GP0TCJkt444r2ONKVHKBbSPaKjJb0S5Qj0MyNUl2keQ=
 github.com/submariner-io/shipyard v0.16.0 h1:PTvp2aKNBoCkfC8nS38k+DW5ZaXNMq/wzzjGOvsiAQM=
 github.com/submariner-io/shipyard v0.16.0/go.mod h1:aKCotVktXJO3azjBOmhu/0KbRcYLY3eUcSNSDDJNbxs=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -62,6 +62,7 @@ type AgentSpecification struct {
 	Namespace        string
 	GlobalnetEnabled bool `split_words:"true"`
 	Uninstall        bool
+	HaltOnCertError  bool `split_words:"true"`
 }
 
 type ServiceImportAggregator struct {

--- a/pkg/agent/main.go
+++ b/pkg/agent/main.go
@@ -110,6 +110,8 @@ func main() {
 	exitOnError(err, "Error processing env config for agent spec")
 	logger.Infof("AgentSpec: %#v", agentSpec)
 
+	util.AddCertificateErrorHandler(agentSpec.HaltOnCertError)
+
 	err = mcsv1a1.AddToScheme(scheme.Scheme)
 	exitOnError(err, "Error adding Multicluster v1alpha1 to the scheme")
 


### PR DESCRIPTION
Backport of #1408 on release-0.16.

#1408: Allow halting on certificate errors

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.