### PR TITLE
Remove release-notes files

### DIFF
--- a/release-notes/20221011-new-synced-condition.md
+++ b/release-notes/20221011-new-synced-condition.md
@@ -1,3 +1,0 @@
-<!-- markdownlint-disable MD041 -->
-A new ServiceExport status condition type named Synced was added that indicates whether or not the ServiceImport
-was successfully synced to the broker.

--- a/release-notes/20221018-service-updates.md
+++ b/release-notes/20221018-service-updates.md
@@ -1,2 +1,0 @@
-<!-- markdownlint-disable MD041 -->
-Service Discovery now handles updates to an exported service and updates/deletes the corresponding ServiceImport accordingly.

--- a/release-notes/20221102-no-records-dns.md
+++ b/release-notes/20221102-no-records-dns.md
@@ -1,3 +1,0 @@
-<!-- markdownlint-disable MD041 -->
-Service Discovery now returns a DNS error message in the response body when no matching records are found for the query to
-"clusterset.local". This prevents unnecessary retries.


### PR DESCRIPTION
We're no longer checking in such files to the projects, also once the notes were merged into the web-site doc, the files no longer serve any purpose.
