### PR TITLE
Automated backport of #1414: Bump admiral and adjust to Federator API changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/gomega v1.27.10
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0
-	github.com/submariner-io/admiral v0.16.1-0.20231025063702-858d0984799c
+	github.com/submariner-io/admiral v0.16.1-0.20231030143920-15adb86d8eca
 	github.com/submariner-io/shipyard v0.16.0
 	github.com/uw-labs/lichen v0.1.7
 	k8s.io/api v0.27.6

--- a/go.sum
+++ b/go.sum
@@ -408,8 +408,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/submariner-io/admiral v0.16.1-0.20231025063702-858d0984799c h1:zy5mZZrB885JAuLPqpb/RoGhtd9N9tUCFE5OGAZEzWw=
-github.com/submariner-io/admiral v0.16.1-0.20231025063702-858d0984799c/go.mod h1:GP0TCJkt444r2ONKVHKBbSPaKjJb0S5Qj0MyNUl2keQ=
+github.com/submariner-io/admiral v0.16.1-0.20231030143920-15adb86d8eca h1:O3gUAdYldm4LQJD/IpqaFcOlJVf9ikM+uBWsfVADmjg=
+github.com/submariner-io/admiral v0.16.1-0.20231030143920-15adb86d8eca/go.mod h1:GP0TCJkt444r2ONKVHKBbSPaKjJb0S5Qj0MyNUl2keQ=
 github.com/submariner-io/shipyard v0.16.0 h1:PTvp2aKNBoCkfC8nS38k+DW5ZaXNMq/wzzjGOvsiAQM=
 github.com/submariner-io/shipyard v0.16.0/go.mod h1:aKCotVktXJO3azjBOmhu/0KbRcYLY3eUcSNSDDJNbxs=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/pkg/agent/controller/cleanup_test.go
+++ b/pkg/agent/controller/cleanup_test.go
@@ -228,7 +228,7 @@ var _ = Describe("Cleanup", func() {
 	})
 
 	It("should correctly remove local and remote ServiceImports and EndpointSlices", func() {
-		Expect(t.cluster1.agentController.Cleanup()).To(Succeed())
+		Expect(t.cluster1.agentController.Cleanup(context.Background())).To(Succeed())
 
 		test.AwaitNoResource(t.cluster1.localServiceImportClient.Namespace(test.LocalNamespace), localServiceImport1.Name)
 		test.AwaitNoResource(t.cluster1.localServiceImportClient.Namespace(serviceNamespace), localAggregatedServiceImport1.Name)

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -232,12 +232,12 @@ func (c *ServiceImportController) startEndpointsController(serviceImport *mcsv1a
 	return nil
 }
 
-func (c *ServiceImportController) stopEndpointsController(key string) (bool, error) {
+func (c *ServiceImportController) stopEndpointsController(ctx context.Context, key string) (bool, error) {
 	if obj, found := c.endpointControllers.Load(key); found {
 		endpointController := obj.(*ServiceEndpointSliceController)
 		endpointController.stop()
 
-		found, err := endpointController.cleanup()
+		found, err := endpointController.cleanup(ctx)
 		if err == nil {
 			c.endpointControllers.Delete(key)
 		}
@@ -251,6 +251,7 @@ func (c *ServiceImportController) stopEndpointsController(key string) (bool, err
 func (c *ServiceImportController) onLocalServiceImport(obj runtime.Object, _ int, op syncer.Operation) (runtime.Object, bool) {
 	serviceImport := obj.(*mcsv1a1.ServiceImport)
 	key, _ := cache.MetaNamespaceKeyFunc(serviceImport)
+	ctx := context.TODO()
 
 	serviceName := serviceImportSourceName(serviceImport)
 
@@ -262,13 +263,13 @@ func (c *ServiceImportController) onLocalServiceImport(obj runtime.Object, _ int
 	logger.V(log.DEBUG).Infof("Local ServiceImport %q %sd", key, op)
 
 	if op == syncer.Delete {
-		c.serviceExportClient.updateStatusConditions(serviceName, serviceImport.Labels[constants.LabelSourceNamespace],
+		c.serviceExportClient.updateStatusConditions(ctx, serviceName, serviceImport.Labels[constants.LabelSourceNamespace],
 			newServiceExportCondition(constants.ServiceExportReady,
 				corev1.ConditionFalse, "NoServiceImport", "ServiceImport was deleted"))
 
 		return obj, false
 	} else if op == syncer.Create {
-		c.serviceExportClient.tryUpdateStatusConditions(serviceName, serviceImport.Labels[constants.LabelSourceNamespace],
+		c.serviceExportClient.tryUpdateStatusConditions(ctx, serviceName, serviceImport.Labels[constants.LabelSourceNamespace],
 			false, newServiceExportCondition(constants.ServiceExportReady,
 				corev1.ConditionFalse, "AwaitingExport", fmt.Sprintf("ServiceImport %sd - awaiting aggregation on the broker", op)))
 	}
@@ -276,7 +277,7 @@ func (c *ServiceImportController) onLocalServiceImport(obj runtime.Object, _ int
 	return obj, false
 }
 
-func (c *ServiceImportController) Distribute(obj runtime.Object) error {
+func (c *ServiceImportController) Distribute(ctx context.Context, obj runtime.Object) error {
 	localServiceImport := c.converter.toServiceImport(obj)
 	key, _ := cache.MetaNamespaceKeyFunc(localServiceImport)
 
@@ -306,7 +307,7 @@ func (c *ServiceImportController) Distribute(obj runtime.Object) error {
 	// is determined from the constituent clusters' EndpointSlices, thus each cluster must have a consistent view of all
 	// the EndpointSlices in order for the aggregated port information to be eventually consistent.
 
-	result, err := util.CreateOrUpdate(context.Background(), resource.ForDynamic(c.serviceImportAggregator.brokerServiceImportClient()),
+	result, err := util.CreateOrUpdate(ctx, resource.ForDynamic(c.serviceImportAggregator.brokerServiceImportClient()),
 		c.converter.toUnstructured(aggregate),
 		func(obj runtime.Object) (runtime.Object, error) {
 			existing := c.converter.toServiceImport(obj)
@@ -318,11 +319,12 @@ func (c *ServiceImportController) Distribute(obj runtime.Object) error {
 					fmt.Sprintf("The service type %q does not match the type (%q) of the existing service export",
 						localServiceImport.Spec.Type, existing.Spec.Type))
 
-				c.serviceExportClient.updateStatusConditions(serviceName, serviceNamespace, conflictCondition,
+				c.serviceExportClient.updateStatusConditions(ctx, serviceName, serviceNamespace, conflictCondition,
 					newServiceExportCondition(constants.ServiceExportReady,
 						corev1.ConditionFalse, exportFailedReason, "Unable to export due to an irresolvable conflict"))
 			} else {
-				c.serviceExportClient.removeStatusCondition(serviceName, serviceNamespace, mcsv1a1.ServiceExportConflict, typeConflictReason)
+				c.serviceExportClient.removeStatusCondition(ctx, serviceName, serviceNamespace, mcsv1a1.ServiceExportConflict,
+					typeConflictReason)
 			}
 
 			return obj, nil
@@ -332,7 +334,7 @@ func (c *ServiceImportController) Distribute(obj runtime.Object) error {
 	}
 
 	if err != nil {
-		c.serviceExportClient.updateStatusConditions(serviceName, serviceNamespace,
+		c.serviceExportClient.updateStatusConditions(ctx, serviceName, serviceNamespace,
 			newServiceExportCondition(constants.ServiceExportReady,
 				corev1.ConditionFalse, exportFailedReason, fmt.Sprintf("Unable to export: %v", err)))
 	}
@@ -344,7 +346,7 @@ func (c *ServiceImportController) Distribute(obj runtime.Object) error {
 	return err
 }
 
-func (c *ServiceImportController) Delete(obj runtime.Object) error {
+func (c *ServiceImportController) Delete(ctx context.Context, obj runtime.Object) error {
 	localServiceImport := c.converter.toServiceImport(obj)
 	key, _ := cache.MetaNamespaceKeyFunc(localServiceImport)
 
@@ -355,13 +357,13 @@ func (c *ServiceImportController) Delete(obj runtime.Object) error {
 	// was never started or if there are no local EndpointSlices, which can happen during reconciliation on startup or
 	// during clean up on uninstall, then we handle removal here.
 
-	found, err := c.stopEndpointsController(key)
+	found, err := c.stopEndpointsController(ctx, key)
 	if err != nil {
 		return err
 	}
 
 	if !found {
-		err = c.serviceImportAggregator.updateOnDelete(serviceImportSourceName(localServiceImport),
+		err = c.serviceImportAggregator.updateOnDelete(ctx, serviceImportSourceName(localServiceImport),
 			localServiceImport.Labels[constants.LabelSourceNamespace])
 	}
 
@@ -369,7 +371,7 @@ func (c *ServiceImportController) Delete(obj runtime.Object) error {
 		return err
 	}
 
-	return c.serviceImportMigrator.onLocalServiceImportDeleted(localServiceImport)
+	return c.serviceImportMigrator.onLocalServiceImportDeleted(ctx, localServiceImport)
 }
 
 func (c *ServiceImportController) onRemoteServiceImport(obj runtime.Object, _ int, _ syncer.Operation) (runtime.Object, bool) {

--- a/pkg/agent/controller/service_import_migrator.go
+++ b/pkg/agent/controller/service_import_migrator.go
@@ -110,7 +110,7 @@ func (c *ServiceImportMigrator) onSuccessfulSyncFromBroker(obj runtime.Object, o
 		logger.Infof("All remote clusters have been upgraded for service \"%s/%s\" - removing local ServiceImport %q from the broker",
 			aggregatedServiceImport.Namespace, aggregatedServiceImport.Name, localServiceImportName)
 
-		err := c.brokerClient.Delete(context.Background(), localServiceImportName, metav1.DeleteOptions{})
+		err := c.brokerClient.Delete(context.TODO(), localServiceImportName, metav1.DeleteOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			logger.Error(err, "error deleting legacy ServiceImport from the broker")
 			return true
@@ -122,14 +122,14 @@ func (c *ServiceImportMigrator) onSuccessfulSyncFromBroker(obj runtime.Object, o
 	return false
 }
 
-func (c *ServiceImportMigrator) onLocalServiceImportDeleted(serviceImport *mcsv1a1.ServiceImport) error {
+func (c *ServiceImportMigrator) onLocalServiceImportDeleted(ctx context.Context, serviceImport *mcsv1a1.ServiceImport) error {
 	if serviceImport.Labels[LegacySourceClusterLabel] != c.clusterID {
 		return nil
 	}
 
 	logger.Infof("Legacy local ServiceImport %q deleted - removing from the broker", serviceImport.Name)
 
-	err := c.brokerClient.Delete(context.Background(), serviceImport.Name, metav1.DeleteOptions{})
+	err := c.brokerClient.Delete(ctx, serviceImport.Name, metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		err = nil
 	}

--- a/pkg/agent/main.go
+++ b/pkg/agent/main.go
@@ -19,7 +19,6 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -141,7 +140,7 @@ func main() {
 	if agentSpec.Uninstall {
 		logger.Info("Uninstalling lighthouse")
 
-		err := lightHouseAgent.Cleanup()
+		err := lightHouseAgent.Cleanup(ctx)
 		exitOnError(err, "Error cleaning up the lighthouse agent controller")
 
 		return
@@ -156,7 +155,7 @@ func main() {
 
 	logger.Info("All controllers stopped or exited. Stopping main loop")
 
-	if err := httpServer.Shutdown(context.TODO()); err != nil {
+	if err := httpServer.Shutdown(ctx); err != nil {
 		logger.Error(err, "Error shutting down metrics HTTP server")
 	}
 }


### PR DESCRIPTION
Backport of #1414 on release-0.16.

#1414: Bump admiral and adjust to Federator API changes

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.