### PR TITLE
Automated backport of #1430: Delete stale EndpointSlices on restart

### DIFF
--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -28,6 +28,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/watcher"
 	"github.com/submariner-io/admiral/pkg/workqueue"
 	"k8s.io/apimachinery/pkg/api/meta"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
@@ -40,6 +41,8 @@ const (
 )
 
 var BrokerResyncPeriod = time.Minute * 2
+
+type EndpointSliceListerFn func(selector k8slabels.Selector) []runtime.Object
 
 type converter struct {
 	scheme *runtime.Scheme
@@ -76,18 +79,19 @@ type ServiceImportAggregator struct {
 // from the submariner namespace and creates/updates the aggregated ServiceImport on the broker; the other that syncs
 // aggregated ServiceImports from the broker to the local service namespace. It also creates a ServiceEndpointSliceController.
 type ServiceImportController struct {
-	localClient             dynamic.Interface
-	restMapper              meta.RESTMapper
-	serviceImportAggregator *ServiceImportAggregator
-	serviceImportMigrator   *ServiceImportMigrator
-	serviceExportClient     *ServiceExportClient
-	localSyncer             syncer.Interface
-	remoteSyncer            syncer.Interface
-	endpointControllers     sync.Map
-	clusterID               string
-	localNamespace          string
-	converter               converter
-	globalIngressIPCache    *globalIngressIPCache
+	localClient                dynamic.Interface
+	restMapper                 meta.RESTMapper
+	serviceImportAggregator    *ServiceImportAggregator
+	serviceImportMigrator      *ServiceImportMigrator
+	serviceExportClient        *ServiceExportClient
+	localSyncer                syncer.Interface
+	remoteSyncer               syncer.Interface
+	endpointControllers        sync.Map
+	clusterID                  string
+	localNamespace             string
+	converter                  converter
+	globalIngressIPCache       *globalIngressIPCache
+	localLHEndpointSliceLister EndpointSliceListerFn
 }
 
 // Each ServiceEndpointSliceController watches for the EndpointSlices that backs a Service and have a ServiceImport.
@@ -113,6 +117,7 @@ type EndpointSliceController struct {
 	syncer                  *broker.Syncer
 	serviceImportAggregator *ServiceImportAggregator
 	serviceExportClient     *ServiceExportClient
+	serviceSyncer           syncer.Interface
 	conflictCheckWorkQueue  workqueue.Interface
 }
 


### PR DESCRIPTION
Backport of #1430 on release-0.16.

#1430: Delete stale EndpointSlices on restart

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.