### PR TITLE
Fix invalid ServiceExport Conflict status condition

### DIFF
--- a/pkg/agent/controller/clusterip_service_test.go
+++ b/pkg/agent/controller/clusterip_service_test.go
@@ -272,6 +272,9 @@ func testClusterIPServiceInOneCluster() {
 
 			// Ensure the resources for the first Service weren't overwritten
 			t.awaitAggregatedServiceImport(mcsv1a1.ClusterSetIP, t.cluster1.service.Name, t.cluster1.service.Namespace, &t.cluster1)
+
+			t.cluster1.ensureNoServiceExportCondition(mcsv1a1.ServiceExportConflict)
+			t.cluster1.ensureNoServiceExportCondition(mcsv1a1.ServiceExportConflict, serviceExport)
 		})
 	})
 

--- a/pkg/agent/controller/endpoint_slice.go
+++ b/pkg/agent/controller/endpoint_slice.go
@@ -237,7 +237,10 @@ func (c *EndpointSliceController) checkForConflicts(_, name, namespace string) (
 		return false, nil
 	}
 
-	epsList := c.syncer.ListLocalResources(&discovery.EndpointSlice{})
+	epsList := c.syncer.ListLocalResourcesBySelector(&discovery.EndpointSlice{}, k8slabels.SelectorFromSet(map[string]string{
+		constants.LabelSourceNamespace: namespace,
+		mcsv1a1.LabelServiceName:       name,
+	}))
 
 	var prevServicePorts []mcsv1a1.ServicePort
 	var intersectedServicePorts []mcsv1a1.ServicePort


### PR DESCRIPTION
This occurs if there's more than one service exported in a cluster. The conflict checking was processing all local `EndpointSlices` instead of only those corresponding to the service in question.
