### PR TITLE
Update K8s versions tested in E2E

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,11 +46,15 @@ jobs:
       matrix:
         deploytool: ['operator']
         globalnet: ['', 'globalnet']
-        k8s_version: ['1.25']
+        # Run most tests against the latest K8s version
+        k8s_version: ['1.28']
         include:
-          - k8s_version: '1.22'
-          - k8s_version: '1.23'
-          - k8s_version: '1.24'
+          # Oldest Kubernetes version thought to work with SubM's Service Discovery.
+          # If this breaks, we may advance the oldest-working K8s version instead of fixing it. See:
+          # https://submariner.io/development/building-testing/ci-maintenance/
+          - k8s_version: '1.21'
+          # Bottom of supported K8s version range
+          - k8s_version: '1.26'
     steps:
       - name: Check out the repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -18,11 +18,11 @@ jobs:
       matrix:
         globalnet: ['', 'globalnet']
         deploytool: ['operator']
-        k8s_version: ['1.25']
+        # Run most tests against the latest K8s version
+        k8s_version: ['1.28']
         include:
-          - k8s_version: '1.22'
-          - k8s_version: '1.23'
-          - k8s_version: '1.24'
+          # Bottom of supported K8s version range
+          - k8s_version: '1.26'
     steps:
       - name: Check out the repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11


### PR DESCRIPTION
Add Kubernetes 1.26 and 1.28, remove end-of-life 1.22-1.25.

Add K8s 1.21, the oldest working version for Service Discovery.

Per discussions, only test ends of supported K8s version range. Don't
test versions in the middle of the range to avoid GHA runs that don't
add useful coverage.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
