### PR TITLE
Ignore broker EndplointSlices in the resolver controller

### DIFF
--- a/coredns/resolver/controller.go
+++ b/coredns/resolver/controller.go
@@ -120,7 +120,7 @@ func (c *controller) getAllEndpointSlices(forEPS *discovery.EndpointSlice) []*di
 	var epSlices []*discovery.EndpointSlice
 	for i := range list {
 		eps := list[i].(*discovery.EndpointSlice)
-		if !isLegacyEndpointSlice(eps) {
+		if !isOnBroker(eps) && !isLegacyEndpointSlice(eps) {
 			epSlices = append(epSlices, eps)
 		}
 	}
@@ -157,8 +157,11 @@ func (c *controller) onServiceImportDelete(obj runtime.Object, _ int) bool {
 }
 
 func (c *controller) ignoreEndpointSlice(eps *discovery.EndpointSlice) bool {
-	isOnBroker := eps.Namespace != eps.Labels[constants.LabelSourceNamespace]
-	return isOnBroker || (isLegacyEndpointSlice(eps) && len(c.getAllEndpointSlices(eps)) > 0)
+	return isOnBroker(eps) || (isLegacyEndpointSlice(eps) && len(c.getAllEndpointSlices(eps)) > 0)
+}
+
+func isOnBroker(eps *discovery.EndpointSlice) bool {
+	return eps.Namespace != eps.Labels[constants.LabelSourceNamespace]
 }
 
 func isLegacyEndpointSlice(eps *discovery.EndpointSlice) bool {

--- a/coredns/resolver/controller_test.go
+++ b/coredns/resolver/controller_test.go
@@ -134,6 +134,10 @@ var _ = Describe("Controller", func() {
 			)
 			epsName2 = eps.Name
 			t.createEndpointSlice(eps)
+
+			epsOnBroker := eps.DeepCopy()
+			epsOnBroker.Namespace = test.RemoteNamespace
+			t.createEndpointSlice(epsOnBroker)
 		})
 
 		Specify("GetDNSRecords should return their DNS record", func() {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -723,13 +723,13 @@ func (f *Framework) VerifyIPsWithDig(cluster framework.ClusterIndex, service *v1
 			return false, fmt.Sprintf("expected execution result %q to be empty", result), nil
 		}
 		for _, ip := range ipList {
-			doesContain := strings.Contains(result.(string), ip)
-			if doesContain && !shouldContain {
+			count := strings.Count(result.(string), ip)
+			if count > 0 && !shouldContain {
 				return false, fmt.Sprintf("expected execution result %q not to contain %q", result, ip), nil
 			}
 
-			if !doesContain && shouldContain {
-				return false, fmt.Sprintf("expected execution result %q to contain %q", result, ip), nil
+			if count != 1 && shouldContain {
+				return false, fmt.Sprintf("expected execution result %q to contain one occurrence of %q", result, ip), nil
 			}
 		}
 


### PR DESCRIPTION
...in `getAllEndpointSlices` to avoid duplicate DNS records being added. This has also caused failures in the E2E test case that removes all headless services pod replicas - it expects no DNS records returned but residual addresses on the broker `EndplointSlice` can remain.