### PR TITLE
Group dependabot for devel branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: github-actions
     directory: /
     target-branch: release-0.14


### PR DESCRIPTION
This was accidently ommitted in a previos commit.
