### PR TITLE
Automated backport of #1491: Add Makefile.shipyard to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ bin
 dist
 junit.xml
 Makefile.dapper
+Makefile.shipyard
 output
 package/.image.*
 vendor


### PR DESCRIPTION
Backport of #1491 on release-0.17.

#1491: Add Makefile.shipyard to .gitignore

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.