### PR TITLE
Use the Admiral metrics/profile helper and enable profiling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/gomega v1.31.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.18.0
-	github.com/submariner-io/admiral v0.18.0-m0
+	github.com/submariner-io/admiral v0.18.0-m0.0.20240202125330-437b20afae61
 	github.com/submariner-io/shipyard v0.18.0-m0
 	k8s.io/api v0.29.1
 	k8s.io/apimachinery v0.29.1

--- a/go.sum
+++ b/go.sum
@@ -390,8 +390,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/submariner-io/admiral v0.18.0-m0 h1:kGXUY4a/j1STdC3I173WnjurlWd6ADmhC16qRB+cNV0=
-github.com/submariner-io/admiral v0.18.0-m0/go.mod h1:6WKEdEhKHUGbAz2EwMSALZpyT0iWKQX6noJyEezyDTI=
+github.com/submariner-io/admiral v0.18.0-m0.0.20240202125330-437b20afae61 h1:XVWSRQ959C0PRe6LkCMjvyWCOWh2Ns8WaIuMe8xLMz8=
+github.com/submariner-io/admiral v0.18.0-m0.0.20240202125330-437b20afae61/go.mod h1:6WKEdEhKHUGbAz2EwMSALZpyT0iWKQX6noJyEezyDTI=
 github.com/submariner-io/shipyard v0.18.0-m0 h1:d5iJP6LWyLprbMYdzVDh4mZn/Qsgt7X15Gamv1d5q+Y=
 github.com/submariner-io/shipyard v0.18.0-m0/go.mod h1:1TX7V+rxEEEZKm5t7kruTyBm52eOk7PSBJLAqMrqNNc=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=


### PR DESCRIPTION
The CoreDNS plugin uses the built-in profiling support.

Depends on https://github.com/submariner-io/admiral/pull/841

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
