### PR TITLE
Automated backport of #1498: Use the Admiral metrics/profile helper and enable profiling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/gomega v1.31.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.18.0
-	github.com/submariner-io/admiral v0.17.0
+	github.com/submariner-io/admiral v0.17.1-0.20240326134036-98f201ca3674
 	github.com/submariner-io/shipyard v0.17.0
 	k8s.io/api v0.29.1
 	k8s.io/apimachinery v0.29.1

--- a/go.sum
+++ b/go.sum
@@ -390,8 +390,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/submariner-io/admiral v0.17.0 h1:Hz722z70W8hPAlKv/Y70MhNGwmmjl4eMZ+bDw9S+BAQ=
-github.com/submariner-io/admiral v0.17.0/go.mod h1:OYkNN5EYaMZ1w1qxzVzD5q8hVNtojQkVoNPcO8/LL+Y=
+github.com/submariner-io/admiral v0.17.1-0.20240326134036-98f201ca3674 h1:gAVNTHz4scVMNGnBvjdB4Dk3BGhpit+Qs8cN18yxpJ0=
+github.com/submariner-io/admiral v0.17.1-0.20240326134036-98f201ca3674/go.mod h1:OYkNN5EYaMZ1w1qxzVzD5q8hVNtojQkVoNPcO8/LL+Y=
 github.com/submariner-io/shipyard v0.17.0 h1:MMs7LkptS4QabYzRrvxxauJov0uQ0gAcdSjBkebpyNU=
 github.com/submariner-io/shipyard v0.17.0/go.mod h1:1TX7V+rxEEEZKm5t7kruTyBm52eOk7PSBJLAqMrqNNc=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=


### PR DESCRIPTION
Backport of #1498 on release-0.17.

#1498: Use the Admiral metrics/profile helper and enable profiling

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.