### PR TITLE
Fix linting error with golangci-lint v1.57.1

### DIFF
--- a/coredns/gateway/controller.go
+++ b/coredns/gateway/controller.go
@@ -85,7 +85,6 @@ func (c *Controller) Start(client dynamic.Interface) error {
 
 	logger.Infof("Starting Gateway status Controller")
 
-	//nolint:wrapcheck // Let the caller wrap these errors.
 	c.store, c.informer = cache.NewInformer(&cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			return gwClientset.List(context.TODO(), options)


### PR DESCRIPTION
`wrapcheck` no longer flags anonymous functions.