### PR TITLE
Automated backport of #1521: Add cluster name to aggregated SI status on local SI creation

### DIFF
--- a/pkg/agent/controller/headless_service_test.go
+++ b/pkg/agent/controller/headless_service_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Headless Service export", func() {
 		Context("and no backend service EndpointSlice initially exists", func() {
 			It("should eventually export the EndpointSlice", func() {
 				t.cluster1.createServiceExport()
-				t.awaitAggregatedServiceImport(mcsv1a1.Headless, t.cluster1.service.Name, t.cluster1.service.Namespace)
+				t.awaitAggregatedServiceImport(mcsv1a1.Headless, t.cluster1.service.Name, t.cluster1.service.Namespace, &t.cluster1)
 
 				t.cluster1.createServiceEndpointSlices()
 				t.awaitEndpointSlice(&t.cluster1)

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -301,6 +301,13 @@ func (c *ServiceImportController) Distribute(ctx context.Context, obj runtime.Ob
 			Type:  localServiceImport.Spec.Type,
 			Ports: []mcsv1a1.ServicePort{},
 		},
+		Status: mcsv1a1.ServiceImportStatus{
+			Clusters: []mcsv1a1.ClusterStatus{
+				{
+					Cluster: c.clusterID,
+				},
+			},
+		},
 	}
 
 	conflict := false
@@ -329,9 +336,19 @@ func (c *ServiceImportController) Distribute(ctx context.Context, obj runtime.Ob
 			} else {
 				c.serviceExportClient.removeStatusCondition(ctx, serviceName, serviceNamespace, mcsv1a1.ServiceExportConflict,
 					typeConflictReason)
+
+				var added bool
+
+				existing.Status.Clusters, added = slices.AppendIfNotPresent(existing.Status.Clusters,
+					mcsv1a1.ClusterStatus{Cluster: c.clusterID}, clusterStatusKey)
+
+				if added {
+					logger.V(log.DEBUG).Infof("Added cluster name %q to aggregated ServiceImport %q. New status: %#v",
+						c.clusterID, existing.Name, existing.Status.Clusters)
+				}
 			}
 
-			return obj, nil
+			return c.converter.toUnstructured(existing), nil
 		})
 	if err == nil && !conflict {
 		err = c.startEndpointsController(localServiceImport)
@@ -344,7 +361,7 @@ func (c *ServiceImportController) Distribute(ctx context.Context, obj runtime.Ob
 	}
 
 	if result == util.OperationResultCreated {
-		logger.V(log.DEBUG).Infof("Created aggregated ServiceImport %q", aggregate.Name)
+		logger.V(log.DEBUG).Infof("Created aggregated ServiceImport %s", resource.ToJSON(aggregate))
 	}
 
 	return err

--- a/pkg/agent/controller/service_import_aggregator.go
+++ b/pkg/agent/controller/service_import_aggregator.go
@@ -51,16 +51,6 @@ func newServiceImportAggregator(brokerClient dynamic.Interface, brokerNamespace,
 
 func (a *ServiceImportAggregator) updateOnCreateOrUpdate(ctx context.Context, name, namespace string) error {
 	return a.update(ctx, name, namespace, func(existing *mcsv1a1.ServiceImport) error {
-		var added bool
-
-		existing.Status.Clusters, added = slices.AppendIfNotPresent(existing.Status.Clusters,
-			mcsv1a1.ClusterStatus{Cluster: a.clusterID}, clusterStatusKey)
-
-		if added {
-			logger.V(log.DEBUG).Infof("Added cluster name %q to aggregated ServiceImport %q. New status: %#v",
-				a.clusterID, existing.Name, existing.Status.Clusters)
-		}
-
 		return a.setServicePorts(ctx, existing)
 	})
 }


### PR DESCRIPTION
Backport of #1521 on release-0.17.

#1521: Add cluster name to aggregated SI status on local SI creation

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.