### PR TITLE
Automated backport of #1551: Requeue ServiceExport when the global IP becomes available

### DIFF
--- a/pkg/agent/controller/controller_suite_test.go
+++ b/pkg/agent/controller/controller_suite_test.go
@@ -926,7 +926,7 @@ func assertEquivalentConditions(actual, expected *mcsv1a1.ServiceExportCondition
 	Expect(actual.Message).To(Not(BeNil()), "Actual: %s", out)
 
 	if expected.Message != nil {
-		Expect(*actual.Message).To(Equal(*expected.Message), "Actual: %s", out)
+		Expect(*actual.Message).To(ContainSubstring(*expected.Message), "Actual: %s", out)
 	}
 }
 

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -28,6 +28,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/watcher"
 	"github.com/submariner-io/admiral/pkg/workqueue"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
@@ -129,10 +130,21 @@ type ServiceExportClient struct {
 	localSyncer syncer.Interface
 }
 
-type globalIngressIPCache struct {
+type globalIngressIPEntry struct {
+	obj           *unstructured.Unstructured
+	onAddOrUpdate func()
+}
+
+type globalIngressIPTransformFn func(obj *unstructured.Unstructured) (any, bool)
+
+type globalIngressIPMap struct {
 	sync.Mutex
-	byService   sync.Map
-	byPod       sync.Map
-	byEndpoints sync.Map
+	entries map[string]*globalIngressIPEntry
+}
+
+type globalIngressIPCache struct {
+	byService   globalIngressIPMap
+	byPod       globalIngressIPMap
+	byEndpoints globalIngressIPMap
 	watcher     watcher.Interface
 }


### PR DESCRIPTION
Backport of #1551 on release-0.17.

#1551: Requeue ServiceExport when the global IP becomes available

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.