### PR TITLE
Automated backport of #1562: Specify NamespaceInformer for SI and EPS resource syncers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/gomega v1.31.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.18.0
-	github.com/submariner-io/admiral v0.17.1
+	github.com/submariner-io/admiral v0.17.2-0.20240516172424-ba3d8efe4148
 	github.com/submariner-io/shipyard v0.17.1
 	k8s.io/api v0.29.3
 	k8s.io/apimachinery v0.29.3

--- a/go.sum
+++ b/go.sum
@@ -388,8 +388,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/submariner-io/admiral v0.17.1 h1:p7XkFfbKaQArlzwzZrU4tW5etGjzjlslLhG1p9b/vgs=
-github.com/submariner-io/admiral v0.17.1/go.mod h1:38k64mD4hRBQ2UR1VeaJsrIJmmxa3vo5TdevdEUM93k=
+github.com/submariner-io/admiral v0.17.2-0.20240516172424-ba3d8efe4148 h1:geJLegFPzA2YUkpPpewCgjnSsECQuWuRRnBQ4MWOA7A=
+github.com/submariner-io/admiral v0.17.2-0.20240516172424-ba3d8efe4148/go.mod h1:38k64mD4hRBQ2UR1VeaJsrIJmmxa3vo5TdevdEUM93k=
 github.com/submariner-io/shipyard v0.17.1 h1:CGKBOwl9cU9aVG7jS+PV7FjMZOmFKY0YuQJa8y2Yo1c=
 github.com/submariner-io/shipyard v0.17.1/go.mod h1:hhlOvzkProcAJe/3cm52FYUEknAzJlBmIkRfjl/SMSw=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/pkg/agent/controller/controller_suite_test.go
+++ b/pkg/agent/controller/controller_suite_test.go
@@ -109,8 +109,6 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-
-	controller.BrokerResyncPeriod = time.Millisecond * 100
 }
 
 func TestController(t *testing.T) {
@@ -293,7 +291,7 @@ func newTestDiver() *testDriver {
 		syncerConfig: &broker.SyncerConfig{
 			BrokerNamespace: test.RemoteNamespace,
 			RestMapper: test.GetRESTMapperFor(&mcsv1a1.ServiceExport{}, &mcsv1a1.ServiceImport{}, &corev1.Service{},
-				&corev1.Endpoints{}, &discovery.EndpointSlice{}, controller.GetGlobalIngressIPObj()),
+				&corev1.Endpoints{}, &corev1.Namespace{}, &discovery.EndpointSlice{}, controller.GetGlobalIngressIPObj()),
 			BrokerClient: brokerClient,
 			Scheme:       syncerScheme,
 		},

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -90,16 +90,17 @@ func newServiceImportController(spec *AgentSpecification, syncerMetricNames Agen
 	}
 
 	controller.remoteSyncer, err = syncer.NewResourceSyncer(&syncer.ResourceSyncerConfig{
-		Name:             "Remote ServiceImport",
-		SourceClient:     brokerClient,
-		SourceNamespace:  brokerNamespace,
-		RestMapper:       syncerConfig.RestMapper,
-		Federator:        federate.NewCreateOrUpdateFederator(syncerConfig.LocalClient, syncerConfig.RestMapper, corev1.NamespaceAll, ""),
-		ResourceType:     &mcsv1a1.ServiceImport{},
-		Transform:        controller.onRemoteServiceImport,
-		OnSuccessfulSync: controller.serviceImportMigrator.onSuccessfulSyncFromBroker,
-		Scheme:           syncerConfig.Scheme,
-		ResyncPeriod:     BrokerResyncPeriod,
+		Name:              "Remote ServiceImport",
+		SourceClient:      brokerClient,
+		SourceNamespace:   brokerNamespace,
+		RestMapper:        syncerConfig.RestMapper,
+		Federator:         federate.NewCreateOrUpdateFederator(syncerConfig.LocalClient, syncerConfig.RestMapper, corev1.NamespaceAll, ""),
+		ResourceType:      &mcsv1a1.ServiceImport{},
+		Transform:         controller.onRemoteServiceImport,
+		OnSuccessfulSync:  controller.serviceImportMigrator.onSuccessfulSyncFromBroker,
+		Scheme:            syncerConfig.Scheme,
+		ResyncPeriod:      BrokerResyncPeriod,
+		NamespaceInformer: syncerConfig.NamespaceInformer,
 		SyncCounterOpts: &prometheus.GaugeOpts{
 			Name: syncerMetricNames.ServiceImportCounterName,
 			Help: "Count of imported services",

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -32,6 +32,7 @@ import (
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/cache"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
@@ -59,6 +60,7 @@ type Controller struct {
 	serviceSyncer               syncer.Interface
 	serviceImportController     *ServiceImportController
 	localServiceImportFederator federate.Federator
+	namespaceInformer           cache.SharedInformer
 }
 
 type AgentSpecification struct {


### PR DESCRIPTION
Backport of #1562 on release-0.17.

#1562: Specify NamespaceInformer for SI and EPS resource syncers

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.