### PR TITLE
Use log.Debugf to format instead of fmt.Sprintf

### DIFF
--- a/coredns/plugin/handler.go
+++ b/coredns/plugin/handler.go
@@ -21,7 +21,6 @@ package lighthouse
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/request"
@@ -47,8 +46,7 @@ func (lh *Lighthouse) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns
 	}
 
 	if state.QType() != dns.TypeA && state.QType() != dns.TypeAAAA && state.QType() != dns.TypeSRV {
-		msg := fmt.Sprintf("Query of type %d is not supported", state.QType())
-		log.Debugf(msg)
+		log.Debugf("Query of type %d is not supported", state.QType())
 
 		return lh.nextOrFailure(ctx, state, r, dns.RcodeNotImplemented)
 	}


### PR DESCRIPTION
This is caught by golangci-lint 1.60.1.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
