### PR TITLE
Aggregate ServiceExport conflict conditions

### DIFF
--- a/pkg/agent/controller/controller_suite_test.go
+++ b/pkg/agent/controller/controller_suite_test.go
@@ -584,18 +584,6 @@ func (c *cluster) ensureNoServiceExportCondition(condType mcsv1a1.ServiceExportC
 	}
 }
 
-func (c *cluster) awaitNoServiceExportCondition(condType mcsv1a1.ServiceExportConditionType, serviceExports ...*mcsv1a1.ServiceExport) {
-	if len(serviceExports) == 0 {
-		serviceExports = []*mcsv1a1.ServiceExport{c.serviceExport}
-	}
-
-	for _, se := range serviceExports {
-		Eventually(func() interface{} {
-			return c.retrieveServiceExportCondition(se, condType)
-		}).Should(BeNil(), "Unexpected ServiceExport status condition")
-	}
-}
-
 func (c *cluster) awaitServiceUnavailableStatus() {
 	c.awaitServiceExportCondition(newServiceExportValidCondition(corev1.ConditionFalse, "ServiceUnavailable"))
 }

--- a/pkg/agent/controller/endpoint_slice.go
+++ b/pkg/agent/controller/endpoint_slice.go
@@ -184,11 +184,11 @@ func (c *EndpointSliceController) onLocalEndpointSliceSynced(obj runtime.Object,
 	} else {
 		err = c.serviceImportAggregator.updateOnCreateOrUpdate(ctx, serviceName, serviceNamespace)
 		if err != nil {
-			c.serviceExportClient.updateStatusConditions(ctx, serviceName, serviceNamespace,
+			c.serviceExportClient.UpdateStatusConditions(ctx, serviceName, serviceNamespace,
 				newServiceExportCondition(constants.ServiceExportReady, corev1.ConditionFalse, exportFailedReason,
 					fmt.Sprintf("Unable to export: %v", err)))
 		} else {
-			c.serviceExportClient.updateStatusConditions(ctx, serviceName, serviceNamespace,
+			c.serviceExportClient.UpdateStatusConditions(ctx, serviceName, serviceNamespace,
 				newServiceExportCondition(constants.ServiceExportReady, corev1.ConditionTrue, "",
 					"Service was successfully exported to the broker"))
 
@@ -263,13 +263,13 @@ func (c *EndpointSliceController) checkForConflicts(_, name, namespace string) (
 	}
 
 	if conflict {
-		c.serviceExportClient.updateStatusConditions(ctx, name, namespace, newServiceExportCondition(
+		c.serviceExportClient.UpdateStatusConditions(ctx, name, namespace, newServiceExportCondition(
 			mcsv1a1.ServiceExportConflict, corev1.ConditionTrue, portConflictReason,
 			fmt.Sprintf("The service ports conflict between the constituent clusters %s. "+
 				"The service will expose the intersection of all the ports: %s",
 				fmt.Sprintf("[%s]", strings.Join(clusterNames, ", ")), servicePortsToString(intersectedServicePorts))))
 	} else if FindServiceExportStatusCondition(localServiceExport.Status.Conditions, mcsv1a1.ServiceExportConflict) != nil {
-		c.serviceExportClient.removeStatusCondition(ctx, name, namespace, mcsv1a1.ServiceExportConflict, portConflictReason)
+		c.serviceExportClient.RemoveStatusCondition(ctx, name, namespace, mcsv1a1.ServiceExportConflict, portConflictReason)
 	}
 
 	return false, nil

--- a/pkg/agent/controller/endpoint_slice.go
+++ b/pkg/agent/controller/endpoint_slice.go
@@ -185,7 +185,7 @@ func (c *EndpointSliceController) onLocalEndpointSliceSynced(obj runtime.Object,
 		err = c.serviceImportAggregator.updateOnCreateOrUpdate(ctx, serviceName, serviceNamespace)
 		if err != nil {
 			c.serviceExportClient.UpdateStatusConditions(ctx, serviceName, serviceNamespace,
-				newServiceExportCondition(constants.ServiceExportReady, corev1.ConditionFalse, exportFailedReason,
+				newServiceExportCondition(constants.ServiceExportReady, corev1.ConditionFalse, ExportFailedReason,
 					fmt.Sprintf("Unable to export: %v", err)))
 		} else {
 			c.serviceExportClient.UpdateStatusConditions(ctx, serviceName, serviceNamespace,
@@ -264,12 +264,13 @@ func (c *EndpointSliceController) checkForConflicts(_, name, namespace string) (
 
 	if conflict {
 		c.serviceExportClient.UpdateStatusConditions(ctx, name, namespace, newServiceExportCondition(
-			mcsv1a1.ServiceExportConflict, corev1.ConditionTrue, portConflictReason,
+			mcsv1a1.ServiceExportConflict, corev1.ConditionTrue, PortConflictReason,
 			fmt.Sprintf("The service ports conflict between the constituent clusters %s. "+
 				"The service will expose the intersection of all the ports: %s",
 				fmt.Sprintf("[%s]", strings.Join(clusterNames, ", ")), servicePortsToString(intersectedServicePorts))))
 	} else if FindServiceExportStatusCondition(localServiceExport.Status.Conditions, mcsv1a1.ServiceExportConflict) != nil {
-		c.serviceExportClient.RemoveStatusCondition(ctx, name, namespace, mcsv1a1.ServiceExportConflict, portConflictReason)
+		c.serviceExportClient.UpdateStatusConditions(ctx, name, namespace, newServiceExportCondition(
+			mcsv1a1.ServiceExportConflict, corev1.ConditionFalse, PortConflictReason, ""))
 	}
 
 	return false, nil

--- a/pkg/agent/controller/service_export_client.go
+++ b/pkg/agent/controller/service_export_client.go
@@ -21,17 +21,21 @@ package controller
 import (
 	"context"
 	"reflect"
+	goslices "slices"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/slices"
 	"github.com/submariner-io/lighthouse/pkg/constants"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
@@ -96,12 +100,24 @@ func (c *ServiceExportClient) tryUpdateStatusConditions(ctx context.Context, nam
 			condition := &conditions[i]
 
 			prevCond := findStatusCondition(toUpdate.Status.Conditions, condition.Type)
+
 			if prevCond == nil {
+				if condition.Type == mcsv1a1.ServiceExportConflict && condition.Status == corev1.ConditionFalse {
+					continue
+				}
+
 				logger.V(log.DEBUG).Infof("Add status condition for ServiceExport (%s/%s): Type: %q, Status: %q, Reason: %q, Message: %q",
 					namespace, name, condition.Type, condition.Status, *condition.Reason, *condition.Message)
 
 				toUpdate.Status.Conditions = append(toUpdate.Status.Conditions, *condition)
 				updated = true
+			} else if condition.Type == mcsv1a1.ServiceExportConflict {
+				updated = updated || c.mergeConflictCondition(prevCond, condition)
+				if updated {
+					logger.V(log.DEBUG).Infof(
+						"Update status condition for ServiceExport (%s/%s): Type: %q, Status: %q, Reason: %q, Message: %q",
+						namespace, name, condition.Type, prevCond.Status, *prevCond.Reason, *prevCond.Message)
+				}
 			} else if serviceExportConditionEqual(prevCond, condition) {
 				logger.V(log.TRACE).Infof("Last ServiceExportCondition for (%s/%s) is equal - not updating status: %#v",
 					namespace, name, prevCond)
@@ -116,6 +132,55 @@ func (c *ServiceExportClient) tryUpdateStatusConditions(ctx context.Context, nam
 
 		return updated
 	})
+}
+
+func (c *ServiceExportClient) mergeConflictCondition(to, from *mcsv1a1.ServiceExportCondition) bool {
+	var reasons, messages []string
+
+	if ptr.Deref(to.Reason, "") != "" {
+		reasons = strings.Split(ptr.Deref(to.Reason, ""), ",")
+	}
+
+	if ptr.Deref(to.Message, "") != "" {
+		messages = strings.Split(ptr.Deref(to.Message, ""), "\n")
+	}
+
+	index := goslices.Index(reasons, *from.Reason)
+	if index >= 0 {
+		if from.Status == corev1.ConditionTrue {
+			if index < len(messages) {
+				messages[index] = *from.Message
+			}
+		} else {
+			reasons = goslices.Delete(reasons, index, index+1)
+
+			if index < len(messages) {
+				messages = goslices.Delete(messages, index, index+1)
+			}
+		}
+	} else if from.Status == corev1.ConditionTrue {
+		reasons = append(reasons, *from.Reason)
+		messages = append(messages, *from.Message)
+	}
+
+	newReason := strings.Join(reasons, ",")
+	newMessage := strings.Join(messages, "\n")
+	updated := newReason != ptr.Deref(to.Reason, "") || newMessage != ptr.Deref(to.Message, "")
+
+	to.Reason = ptr.To(newReason)
+	to.Message = ptr.To(newMessage)
+
+	if *to.Reason != "" {
+		to.Status = corev1.ConditionTrue
+	} else {
+		to.Status = corev1.ConditionFalse
+	}
+
+	if updated {
+		to.LastTransitionTime = from.LastTransitionTime
+	}
+
+	return updated
 }
 
 func (c *ServiceExportClient) doUpdate(ctx context.Context, name, namespace string, update func(toUpdate *mcsv1a1.ServiceExport) bool) {

--- a/pkg/agent/controller/service_export_client.go
+++ b/pkg/agent/controller/service_export_client.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
-	"github.com/submariner-io/admiral/pkg/slices"
 	"github.com/submariner-io/lighthouse/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -48,27 +47,6 @@ func NewServiceExportClient(client dynamic.Interface, scheme *runtime.Scheme) *S
 		}),
 		converter: converter{scheme: scheme},
 	}
-}
-
-func (c *ServiceExportClient) RemoveStatusCondition(ctx context.Context, name, namespace string,
-	condType mcsv1a1.ServiceExportConditionType, reason string,
-) {
-	c.doUpdate(ctx, name, namespace, func(toUpdate *mcsv1a1.ServiceExport) bool {
-		condition := FindServiceExportStatusCondition(toUpdate.Status.Conditions, condType)
-		if condition != nil && reflect.DeepEqual(condition.Reason, &reason) {
-			logger.V(log.DEBUG).Infof("Removing status condition (Type: %q, Reason: %q) from ServiceExport (%s/%s)",
-				condType, reason, namespace, name)
-
-			toUpdate.Status.Conditions, _ = slices.Remove(toUpdate.Status.Conditions, *condition,
-				func(c mcsv1a1.ServiceExportCondition) mcsv1a1.ServiceExportConditionType {
-					return c.Type
-				})
-
-			return true
-		}
-
-		return false
-	})
 }
 
 func (c *ServiceExportClient) UpdateStatusConditions(ctx context.Context, name, namespace string,

--- a/pkg/agent/controller/service_export_client_test.go
+++ b/pkg/agent/controller/service_export_client_test.go
@@ -100,34 +100,6 @@ var _ = Describe("ServiceExportClient", func() {
 		})
 	})
 
-	Context("RemoveStatusCondition", func() {
-		BeforeEach(func() {
-			initialServiceExport.Status.Conditions = []mcsv1a1.ServiceExportCondition{
-				{
-					Type:   constants.ServiceExportReady,
-					Status: corev1.ConditionFalse,
-					Reason: ptr.To("Failed"),
-				},
-			}
-		})
-
-		It("should remove the condition if the reason matches", func() {
-			serviceExportClient.RemoveStatusCondition(context.TODO(), serviceName, serviceNamespace,
-				constants.ServiceExportReady, "Failed")
-
-			Expect(controller.FindServiceExportStatusCondition(getServiceExport().Status.Conditions,
-				constants.ServiceExportReady)).To(BeNil())
-		})
-
-		It("should not remove the condition if the reason does not match", func() {
-			serviceExportClient.RemoveStatusCondition(context.TODO(), serviceName, serviceNamespace,
-				constants.ServiceExportReady, "NotMatching")
-
-			Expect(controller.FindServiceExportStatusCondition(getServiceExport().Status.Conditions,
-				constants.ServiceExportReady)).ToNot(BeNil())
-		})
-	})
-
 	Context("with Conflict condition type", func() {
 		It("should aggregate the different reasons and messages", func() {
 			// The condition shouldn't be added with Status False.

--- a/pkg/agent/controller/service_export_client_test.go
+++ b/pkg/agent/controller/service_export_client_test.go
@@ -1,0 +1,129 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/test"
+	"github.com/submariner-io/lighthouse/pkg/agent/controller"
+	"github.com/submariner-io/lighthouse/pkg/constants"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+)
+
+var _ = Describe("ServiceExportClient", func() {
+	var (
+		serviceExportClient  *controller.ServiceExportClient
+		dynClient            *dynamicfake.FakeDynamicClient
+		initialServiceExport *mcsv1a1.ServiceExport
+	)
+
+	BeforeEach(func() {
+		initialServiceExport = &mcsv1a1.ServiceExport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceName,
+				Namespace: serviceNamespace,
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		dynClient = dynamicfake.NewSimpleDynamicClient(scheme.Scheme, initialServiceExport)
+		serviceExportClient = controller.NewServiceExportClient(dynClient, scheme.Scheme)
+	})
+
+	getServiceExport := func() *mcsv1a1.ServiceExport {
+		obj, err := serviceExportClientFor(dynClient, serviceNamespace).Get(context.TODO(), serviceName, metav1.GetOptions{})
+		Expect(err).To(Succeed())
+
+		return toServiceExport(obj)
+	}
+
+	Context("UpdateStatusConditions", func() {
+		It("should correctly add/update conditions", func() {
+			cond1 := mcsv1a1.ServiceExportCondition{
+				Type:    constants.ServiceExportReady,
+				Status:  corev1.ConditionFalse,
+				Reason:  ptr.To("Failed"),
+				Message: ptr.To("A failure occurred"),
+			}
+
+			cond2 := mcsv1a1.ServiceExportCondition{
+				Type:    mcsv1a1.ServiceExportValid,
+				Status:  corev1.ConditionFalse,
+				Reason:  ptr.To("NotValid"),
+				Message: ptr.To("Not valid"),
+			}
+
+			serviceExportClient.UpdateStatusConditions(context.TODO(), serviceName, serviceNamespace, cond1, cond2)
+
+			se := getServiceExport()
+			Expect(controller.FindServiceExportStatusCondition(se.Status.Conditions, cond1.Type)).To(Equal(&cond1))
+			Expect(controller.FindServiceExportStatusCondition(se.Status.Conditions, cond2.Type)).To(Equal(&cond2))
+
+			cond1.Status = corev1.ConditionTrue
+			cond1.Reason = ptr.To("")
+			cond1.Message = ptr.To("")
+
+			serviceExportClient.UpdateStatusConditions(context.TODO(), serviceName, serviceNamespace, cond1)
+
+			Expect(controller.FindServiceExportStatusCondition(getServiceExport().Status.Conditions, cond1.Type)).To(Equal(&cond1))
+
+			dynClient.ClearActions()
+			serviceExportClient.UpdateStatusConditions(context.TODO(), serviceName, serviceNamespace, cond1)
+
+			test.EnsureNoActionsForResource(&dynClient.Fake, "serviceexports", "update")
+		})
+	})
+
+	Context("RemoveStatusCondition", func() {
+		BeforeEach(func() {
+			initialServiceExport.Status.Conditions = []mcsv1a1.ServiceExportCondition{
+				{
+					Type:   constants.ServiceExportReady,
+					Status: corev1.ConditionFalse,
+					Reason: ptr.To("Failed"),
+				},
+			}
+		})
+
+		It("should remove the condition if the reason matches", func() {
+			serviceExportClient.RemoveStatusCondition(context.TODO(), serviceName, serviceNamespace,
+				constants.ServiceExportReady, "Failed")
+
+			Expect(controller.FindServiceExportStatusCondition(getServiceExport().Status.Conditions,
+				constants.ServiceExportReady)).To(BeNil())
+		})
+
+		It("should not remove the condition if the reason does not match", func() {
+			serviceExportClient.RemoveStatusCondition(context.TODO(), serviceName, serviceNamespace,
+				constants.ServiceExportReady, "NotMatching")
+
+			Expect(controller.FindServiceExportStatusCondition(getServiceExport().Status.Conditions,
+				constants.ServiceExportReady)).ToNot(BeNil())
+		})
+	})
+})

--- a/pkg/agent/controller/service_export_failures_test.go
+++ b/pkg/agent/controller/service_export_failures_test.go
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/submariner-io/admiral/pkg/fake"
+	"github.com/submariner-io/lighthouse/pkg/agent/controller"
 	"github.com/submariner-io/lighthouse/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -67,7 +68,7 @@ var _ = Describe("Service export failures", func() {
 		})
 
 		It("should eventually export the service", func() {
-			t.cluster1.awaitServiceExportCondition(newServiceExportReadyCondition(corev1.ConditionFalse, "ExportFailed"))
+			t.cluster1.awaitServiceExportCondition(newServiceExportReadyCondition(corev1.ConditionFalse, controller.ExportFailedReason))
 
 			t.brokerServiceImportReactor.SetFailOnCreate(nil)
 			t.awaitNonHeadlessServiceExported(&t.cluster1)
@@ -80,7 +81,7 @@ var _ = Describe("Service export failures", func() {
 		})
 
 		It("should eventually export the service", func() {
-			t.cluster1.awaitServiceExportCondition(newServiceExportReadyCondition(corev1.ConditionFalse, "ExportFailed"))
+			t.cluster1.awaitServiceExportCondition(newServiceExportReadyCondition(corev1.ConditionFalse, controller.ExportFailedReason))
 
 			t.brokerServiceImportReactor.SetFailOnUpdate(nil)
 			t.awaitNonHeadlessServiceExported(&t.cluster1)
@@ -131,7 +132,7 @@ var _ = Describe("Service export failures", func() {
 		})
 
 		It("should eventually export the service", func() {
-			t.cluster1.awaitServiceExportCondition(newServiceExportReadyCondition(corev1.ConditionFalse, "ExportFailed"))
+			t.cluster1.awaitServiceExportCondition(newServiceExportReadyCondition(corev1.ConditionFalse, controller.ExportFailedReason))
 
 			t.brokerEndpointSliceReactor.SetFailOnList(nil)
 			t.awaitNonHeadlessServiceExported(&t.cluster1)

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -267,7 +267,7 @@ func (c *ServiceImportController) onLocalServiceImport(obj runtime.Object, _ int
 	logger.V(log.DEBUG).Infof("Local ServiceImport %q %sd", key, op)
 
 	if op == syncer.Delete {
-		c.serviceExportClient.updateStatusConditions(ctx, serviceName, serviceImport.Labels[constants.LabelSourceNamespace],
+		c.serviceExportClient.UpdateStatusConditions(ctx, serviceName, serviceImport.Labels[constants.LabelSourceNamespace],
 			newServiceExportCondition(constants.ServiceExportReady,
 				corev1.ConditionFalse, "NoServiceImport", "ServiceImport was deleted"))
 
@@ -333,11 +333,11 @@ func (c *ServiceImportController) Distribute(ctx context.Context, obj runtime.Ob
 					fmt.Sprintf("The service type %q does not match the type (%q) of the existing service export",
 						localServiceImport.Spec.Type, existing.Spec.Type))
 
-				c.serviceExportClient.updateStatusConditions(ctx, serviceName, serviceNamespace, conflictCondition,
+				c.serviceExportClient.UpdateStatusConditions(ctx, serviceName, serviceNamespace, conflictCondition,
 					newServiceExportCondition(constants.ServiceExportReady,
 						corev1.ConditionFalse, exportFailedReason, "Unable to export due to an irresolvable conflict"))
 			} else {
-				c.serviceExportClient.removeStatusCondition(ctx, serviceName, serviceNamespace, mcsv1a1.ServiceExportConflict,
+				c.serviceExportClient.RemoveStatusCondition(ctx, serviceName, serviceNamespace, mcsv1a1.ServiceExportConflict,
 					typeConflictReason)
 
 				if existing.Spec.SessionAffinity == "" || existing.Spec.SessionAffinity == corev1.ServiceAffinityNone {
@@ -366,7 +366,7 @@ func (c *ServiceImportController) Distribute(ctx context.Context, obj runtime.Ob
 	}
 
 	if err != nil {
-		c.serviceExportClient.updateStatusConditions(ctx, serviceName, serviceNamespace,
+		c.serviceExportClient.UpdateStatusConditions(ctx, serviceName, serviceNamespace,
 			newServiceExportCondition(constants.ServiceExportReady,
 				corev1.ConditionFalse, exportFailedReason, fmt.Sprintf("Unable to export: %v", err)))
 	}

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -329,16 +329,16 @@ func (c *ServiceImportController) Distribute(ctx context.Context, obj runtime.Ob
 			if localServiceImport.Spec.Type != existing.Spec.Type {
 				conflict = true
 				conflictCondition := newServiceExportCondition(
-					mcsv1a1.ServiceExportConflict, corev1.ConditionTrue, typeConflictReason,
+					mcsv1a1.ServiceExportConflict, corev1.ConditionTrue, TypeConflictReason,
 					fmt.Sprintf("The service type %q does not match the type (%q) of the existing service export",
 						localServiceImport.Spec.Type, existing.Spec.Type))
 
 				c.serviceExportClient.UpdateStatusConditions(ctx, serviceName, serviceNamespace, conflictCondition,
 					newServiceExportCondition(constants.ServiceExportReady,
-						corev1.ConditionFalse, exportFailedReason, "Unable to export due to an irresolvable conflict"))
+						corev1.ConditionFalse, ExportFailedReason, "Unable to export due to an irresolvable conflict"))
 			} else {
-				c.serviceExportClient.RemoveStatusCondition(ctx, serviceName, serviceNamespace, mcsv1a1.ServiceExportConflict,
-					typeConflictReason)
+				c.serviceExportClient.UpdateStatusConditions(ctx, serviceName, serviceNamespace, newServiceExportCondition(
+					mcsv1a1.ServiceExportConflict, corev1.ConditionFalse, TypeConflictReason, ""))
 
 				if existing.Spec.SessionAffinity == "" || existing.Spec.SessionAffinity == corev1.ServiceAffinityNone {
 					existing.Spec.SessionAffinity = localServiceImport.Spec.SessionAffinity
@@ -368,7 +368,7 @@ func (c *ServiceImportController) Distribute(ctx context.Context, obj runtime.Ob
 	if err != nil {
 		c.serviceExportClient.UpdateStatusConditions(ctx, serviceName, serviceNamespace,
 			newServiceExportCondition(constants.ServiceExportReady,
-				corev1.ConditionFalse, exportFailedReason, fmt.Sprintf("Unable to export: %v", err)))
+				corev1.ConditionFalse, ExportFailedReason, fmt.Sprintf("Unable to export: %v", err)))
 	}
 
 	if result == util.OperationResultCreated {

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -36,9 +36,9 @@ import (
 )
 
 const (
-	exportFailedReason = "ExportFailed"
-	typeConflictReason = "ConflictingType"
-	portConflictReason = "ConflictingPorts"
+	ExportFailedReason = "ExportFailed"
+	TypeConflictReason = "ConflictingType"
+	PortConflictReason = "ConflictingPorts"
 )
 
 type EndpointSliceListerFn func(selector k8slabels.Selector) []runtime.Object


### PR DESCRIPTION
It's possible there could be more than one concurrent conflict however the MCS API only defines one conflict type so a second conflict would overwrite the first. We could define our own conflict types but the MCS spec does specifically reference the `ServiceExportConflict` type, defined as "_Conflict_", in the [conflict resolution](https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#global-properties) section. It doesn't mention what the behavior should be if there's more than one conflict.
    
To represent multiple conflicts, we can still use the `ServiceExportConflict` type but aggregate the differing condition reasons and messages. For the `Reason` field, join multiple reasons separated by a comma and, for the `Message` field, join with a new line. When a particular conflict is resolved, remove its reason and message. When there's no more conflicts, ie `Reason` is empty, set the condition `Status` to `False`.

See individual commits for details.
