### PR TITLE
Remove broker resync period for ServiceImport and EndpointSlices

### DIFF
--- a/pkg/agent/controller/endpoint_slice.go
+++ b/pkg/agent/controller/endpoint_slice.go
@@ -70,7 +70,6 @@ func newEndpointSliceController(spec *AgentSpecification, syncerConfig broker.Sy
 				c.enqueueForConflictCheck(context.TODO(), obj.(*discovery.EndpointSlice), op)
 				return false
 			},
-			BrokerResyncPeriod: BrokerResyncPeriod,
 		},
 	}
 

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -99,7 +99,6 @@ func newServiceImportController(spec *AgentSpecification, syncerMetricNames Agen
 		Transform:         controller.onRemoteServiceImport,
 		OnSuccessfulSync:  controller.serviceImportMigrator.onSuccessfulSyncFromBroker,
 		Scheme:            syncerConfig.Scheme,
-		ResyncPeriod:      BrokerResyncPeriod,
 		NamespaceInformer: syncerConfig.NamespaceInformer,
 		SyncCounterOpts: &prometheus.GaugeOpts{
 			Name: syncerMetricNames.ServiceImportCounterName,

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -20,7 +20,6 @@ package controller
 
 import (
 	"sync"
-	"time"
 
 	"github.com/submariner-io/admiral/pkg/federate"
 	"github.com/submariner-io/admiral/pkg/syncer"
@@ -41,8 +40,6 @@ const (
 	typeConflictReason = "ConflictingType"
 	portConflictReason = "ConflictingPorts"
 )
-
-var BrokerResyncPeriod = time.Minute * 2
 
 type EndpointSliceListerFn func(selector k8slabels.Selector) []runtime.Object
 


### PR DESCRIPTION
This has proven to be problematic at larger scale, significantly increasing latencies due to the rate limiting. It was put in to easily handle a hypothetical, unlikely edge case where a service namespace is deleted then recreated but the potential performance hit to handle it in this manner isn't worth it. Now that the resource syncer can watch namespaces, we can handle it there.

Fixes https://github.com/submariner-io/lighthouse/issues/1623
