### PR TITLE
Automated backport of #1625: Remove broker resync period for ServiceImport and

### DIFF
--- a/pkg/agent/controller/endpoint_slice.go
+++ b/pkg/agent/controller/endpoint_slice.go
@@ -70,7 +70,6 @@ func newEndpointSliceController(spec *AgentSpecification, syncerConfig broker.Sy
 				c.enqueueForConflictCheck(context.TODO(), obj.(*discovery.EndpointSlice), op)
 				return false
 			},
-			BrokerResyncPeriod: BrokerResyncPeriod,
 		},
 	}
 

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -99,7 +99,6 @@ func newServiceImportController(spec *AgentSpecification, syncerMetricNames Agen
 		Transform:         controller.onRemoteServiceImport,
 		OnSuccessfulSync:  controller.serviceImportMigrator.onSuccessfulSyncFromBroker,
 		Scheme:            syncerConfig.Scheme,
-		ResyncPeriod:      BrokerResyncPeriod,
 		NamespaceInformer: syncerConfig.NamespaceInformer,
 		SyncCounterOpts: &prometheus.GaugeOpts{
 			Name: syncerMetricNames.ServiceImportCounterName,

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -20,7 +20,6 @@ package controller
 
 import (
 	"sync"
-	"time"
 
 	"github.com/submariner-io/admiral/pkg/federate"
 	"github.com/submariner-io/admiral/pkg/syncer"
@@ -41,8 +40,6 @@ const (
 	typeConflictReason = "ConflictingType"
 	portConflictReason = "ConflictingPorts"
 )
-
-var BrokerResyncPeriod = time.Minute * 2
 
 type EndpointSliceListerFn func(selector k8slabels.Selector) []runtime.Object
 


### PR DESCRIPTION
Backport of #1625 on release-0.17.

#1625: Remove broker resync period for ServiceImport and

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.