### PR TITLE
Automated backport of #1625: Remove broker resync period for ServiceImport and

### DIFF
--- a/pkg/agent/controller/controller_suite_test.go
+++ b/pkg/agent/controller/controller_suite_test.go
@@ -109,8 +109,6 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-
-	controller.BrokerResyncPeriod = time.Millisecond * 100
 }
 
 func TestController(t *testing.T) {

--- a/pkg/agent/controller/endpoint_slice.go
+++ b/pkg/agent/controller/endpoint_slice.go
@@ -70,7 +70,6 @@ func newEndpointSliceController(spec *AgentSpecification, syncerConfig broker.Sy
 				c.enqueueForConflictCheck(context.TODO(), obj.(*discovery.EndpointSlice), op)
 				return false
 			},
-			BrokerResyncPeriod: BrokerResyncPeriod,
 		},
 	}
 

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -98,7 +98,6 @@ func newServiceImportController(spec *AgentSpecification, syncerMetricNames Agen
 		Transform:        controller.onRemoteServiceImport,
 		OnSuccessfulSync: controller.serviceImportMigrator.onSuccessfulSyncFromBroker,
 		Scheme:           syncerConfig.Scheme,
-		ResyncPeriod:     BrokerResyncPeriod,
 		SyncCounterOpts: &prometheus.GaugeOpts{
 			Name: syncerMetricNames.ServiceImportCounterName,
 			Help: "Count of imported services",

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -20,7 +20,6 @@ package controller
 
 import (
 	"sync"
-	"time"
 
 	"github.com/submariner-io/admiral/pkg/federate"
 	"github.com/submariner-io/admiral/pkg/syncer"
@@ -39,8 +38,6 @@ const (
 	typeConflictReason = "ConflictingType"
 	portConflictReason = "ConflictingPorts"
 )
-
-var BrokerResyncPeriod = time.Minute * 2
 
 type EndpointSliceListerFn func(selector k8slabels.Selector) []runtime.Object
 


### PR DESCRIPTION
Backport of #1625 on release-0.16.

#1625: Remove broker resync period for ServiceImport and

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.