### PR TITLE
Address golangci-lint v1.60.3 errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,6 +43,7 @@ linters:
     - bidichk
     - bodyclose
     - contextcheck
+    - copyloopvar
     # - cyclop # This is equivalent to gocyclo
     # - depguard # depguard now denies by default, it should only be enabled if we actually use it
     - dogsled
@@ -53,7 +54,6 @@ linters:
     - errname
     - exhaustive
     # - exhaustivestruct # Not recommended for general use - meant to be used only for special cases
-    - exportloopref
     # - forbidigo # We don't forbid any statements
     # - forcetypeassert # There are many unchecked type assertions that would be the result of a programming error so the
     #                     reasonable recourse would be to panic anyway if checked so this doesn't seem useful

--- a/coredns/plugin/record.go
+++ b/coredns/plugin/record.go
@@ -88,7 +88,7 @@ func (lh *Lighthouse) createSRVRecords(dnsrecords []resolver.DNSRecord, state *r
 				Hdr:      dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeSRV, Class: state.QClass(), Ttl: lh.TTL},
 				Priority: 0,
 				Weight:   50,
-				Port:     uint16(port.Port),
+				Port:     uint16(port.Port), //nolint:gosec // Need to ignore integer conversion error
 				Target:   target,
 			}
 			records = append(records, record)

--- a/coredns/plugin/setup.go
+++ b/coredns/plugin/setup.go
@@ -177,7 +177,7 @@ func parseTTL(c *caddy.Controller) (uint32, error) {
 		return 0, c.ArgErr() //nolint:wrapcheck // No need to wrap this.
 	}
 
-	t, err := strconv.Atoi(args[0])
+	t, err := strconv.ParseInt(args[0], 10, 32)
 	if err != nil {
 		return 0, errors.Wrap(err, "error parsing TTL")
 	}
@@ -186,7 +186,7 @@ func parseTTL(c *caddy.Controller) (uint32, error) {
 		return 0, c.Errf("ttl must be in range [0, 3600]: %d", t) //nolint:wrapcheck // No need to wrap this.
 	}
 
-	return uint32(t), nil
+	return uint32(t), nil //nolint:gosec // We can safely ignore integer conversion error
 }
 
 func init() {


### PR DESCRIPTION
Specifically, gosec "integer overflow conversion" issues.

Depends on https://github.com/submariner-io/shipyard/pull/1715