### PR TITLE
Implement conflict checking for SessionAffinity

### DIFF
--- a/pkg/agent/controller/endpoint_slice.go
+++ b/pkg/agent/controller/endpoint_slice.go
@@ -268,7 +268,7 @@ func (c *EndpointSliceController) checkForConflicts(_, name, namespace string) (
 			fmt.Sprintf("The service ports conflict between the constituent clusters %s. "+
 				"The service will expose the intersection of all the ports: %s",
 				fmt.Sprintf("[%s]", strings.Join(clusterNames, ", ")), servicePortsToString(intersectedServicePorts))))
-	} else if FindServiceExportStatusCondition(localServiceExport.Status.Conditions, mcsv1a1.ServiceExportConflict) != nil {
+	} else if c.serviceExportClient.hasCondition(name, namespace, mcsv1a1.ServiceExportConflict, PortConflictReason) {
 		c.serviceExportClient.UpdateStatusConditions(ctx, name, namespace, newServiceExportCondition(
 			mcsv1a1.ServiceExportConflict, corev1.ConditionFalse, PortConflictReason, ""))
 	}

--- a/pkg/agent/controller/reconciliation_test.go
+++ b/pkg/agent/controller/reconciliation_test.go
@@ -35,7 +35,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic/fake"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/testing"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
@@ -174,12 +173,7 @@ var _ = Describe("Reconciliation", func() {
 
 	When("a remote aggregated ServiceImport is stale in the local datastore on startup", func() {
 		It("should delete it from the local datastore on reconciliation", func() {
-			obj, err := t.cluster2.localServiceImportClient.Namespace(t.cluster1.service.Namespace).Get(context.TODO(),
-				t.cluster1.service.Name, metav1.GetOptions{})
-			Expect(err).To(Succeed())
-
-			serviceImport := &mcsv1a1.ServiceImport{}
-			Expect(scheme.Scheme.Convert(obj, serviceImport, nil)).To(Succeed())
+			serviceImport := getServiceImport(t.cluster2.localServiceImportClient, t.cluster1.service.Namespace, t.cluster1.service.Name)
 
 			t.afterEach()
 			t = newTestDiver()

--- a/pkg/agent/controller/service_import_aggregator.go
+++ b/pkg/agent/controller/service_import_aggregator.go
@@ -101,6 +101,8 @@ func (a *ServiceImportAggregator) updateOnDelete(ctx context.Context, name, name
 		logger.V(log.DEBUG).Infof("Removed cluster name %q from aggregated ServiceImport %q. New status: %#v",
 			a.clusterID, existing.Name, existing.Status.Clusters)
 
+		delete(existing.Annotations, makeTimestampAnnotationKey(a.clusterID))
+
 		return a.setServicePorts(ctx, existing)
 	})
 }

--- a/pkg/agent/controller/service_import_migration_test.go
+++ b/pkg/agent/controller/service_import_migration_test.go
@@ -32,7 +32,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes/scheme"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
@@ -171,12 +170,8 @@ func testServiceImportMigration() {
 
 				// Get the aggregated ServiceImport on the broker.
 
-				obj, err := t.brokerServiceImportClient.Namespace(test.RemoteNamespace).Get(context.Background(),
-					fmt.Sprintf("%s-%s", t.cluster1.service.Name, t.cluster1.service.Namespace), metav1.GetOptions{})
-				Expect(err).To(Succeed())
-
-				aggregatedServiceImport := &mcsv1a1.ServiceImport{}
-				Expect(scheme.Scheme.Convert(obj, aggregatedServiceImport, nil)).To(Succeed())
+				aggregatedServiceImport := getServiceImport(t.brokerServiceImportClient, test.RemoteNamespace,
+					fmt.Sprintf("%s-%s", t.cluster1.service.Name, t.cluster1.service.Namespace))
 
 				By(fmt.Sprintf("Upgrade the first remote cluster %q", remoteServiceImport1.Status.Clusters[0].Cluster))
 

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -36,9 +36,11 @@ import (
 )
 
 const (
-	ExportFailedReason = "ExportFailed"
-	TypeConflictReason = "ConflictingType"
-	PortConflictReason = "ConflictingPorts"
+	ExportFailedReason                  = "ExportFailed"
+	TypeConflictReason                  = "ConflictingType"
+	PortConflictReason                  = "ConflictingPorts"
+	SessionAffinityConflictReason       = "ConflictingSessionAffinity"
+	SessionAffinityConfigConflictReason = "ConflictingSessionAffinityConfig"
 )
 
 type EndpointSliceListerFn func(selector k8slabels.Selector) []runtime.Object


### PR DESCRIPTION
The MCS spec's conflict resolution policy states that a "_conflict will be resolved by assigning precedence based on each ServiceExport's creationTimestamp, from oldest to newest_". We don't have a central MCS controller with access to all cluster's `ServiceExports` but we can store each cluster's `ServiceExport` `creationTimestamp` as annotations in the aggregated `ServiceImport` and use them to resolve conflicts. The `SessionAffinity` and `SessionAffinityConfig` fields on the aggregated `ServiceImport` will be set by the cluster with the oldest timestamp. The other clusters will set a `ServiceExportConflict` condition if their corresponding local service's fields do not match those on the aggregated `ServiceImport`. If a local service is updated in any cluster, each cluster re-evaluates the updated aggregated `ServiceImport` and either clears or sets the conflict condition. Also if the service from the precedent cluster is un-exported, the next precedent cluster will set the fields.
