### PR TITLE
Implement clusterset VIP for ServiceImports in LH agent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
+	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
+github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/submariner-io/admiral/pkg/federate"
+	"github.com/submariner-io/admiral/pkg/ipam"
 	"github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/syncer/broker"
 	"github.com/submariner-io/admiral/pkg/watcher"
@@ -36,11 +37,12 @@ import (
 )
 
 const (
-	ExportFailedReason                  = "ExportFailed"
-	TypeConflictReason                  = "ConflictingType"
-	PortConflictReason                  = "ConflictingPorts"
-	SessionAffinityConflictReason       = "ConflictingSessionAffinity"
-	SessionAffinityConfigConflictReason = "ConflictingSessionAffinityConfig"
+	ExportFailedReason                   = "ExportFailed"
+	TypeConflictReason                   = "ConflictingType"
+	PortConflictReason                   = "ConflictingPorts"
+	SessionAffinityConflictReason        = "ConflictingSessionAffinity"
+	SessionAffinityConfigConflictReason  = "ConflictingSessionAffinityConfig"
+	ClusterSetIPEnablementConflictReason = "ConflictingClusterSetIPEnablement"
 )
 
 type EndpointSliceListerFn func(selector k8slabels.Selector) []runtime.Object
@@ -63,13 +65,15 @@ type Controller struct {
 }
 
 type AgentSpecification struct {
-	ClusterID        string
-	Namespace        string
-	Verbosity        int
-	GlobalnetEnabled bool `split_words:"true"`
-	Uninstall        bool
-	HaltOnCertError  bool `split_words:"true"`
-	Debug            bool
+	ClusterID           string
+	Namespace           string
+	Verbosity           int
+	ClustersetIPCidr    string `split_words:"true"`
+	ClustersetIPEnabled bool   `split_words:"true"`
+	GlobalnetEnabled    bool   `split_words:"true"`
+	Uninstall           bool
+	HaltOnCertError     bool `split_words:"true"`
+	Debug               bool
 }
 
 type ServiceImportAggregator struct {
@@ -96,6 +100,8 @@ type ServiceImportController struct {
 	converter                  converter
 	globalIngressIPCache       *globalIngressIPCache
 	localLHEndpointSliceLister EndpointSliceListerFn
+	clustersetIPPool           *ipam.IPPool
+	clustersetIPEnabled        bool
 }
 
 // Each ServiceEndpointSliceController watches for the EndpointSlices that backs a Service and have a ServiceImport.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -30,6 +30,8 @@ const (
 	LabelSourceName          = "lighthouse.submariner.io/source-name"
 	PublishNotReadyAddresses = "lighthouse.submariner.io/publish-not-ready-addresses"
 	GlobalnetEnabled         = "lighthouse.submariner.io/globalnet-enabled"
+	UseClustersetIP          = "lighthouse.submariner.io/use-clusterset-ip"
+	ClustersetIPAllocatedBy  = "lighthouse.submariner.io/clusterset-ip-allocated-by"
 )
 
 const ServiceExportReady v1alpha1.ServiceExportConditionType = "Ready"


### PR DESCRIPTION
As per https://github.com/submariner-io/enhancements/blob/devel/lighthouse/mcs-compliance.md

Highlights:

- The clusterset IP enabled flag and clusterset IP CIDR are passed vi env vars `SUBMARINER_CLUSTERSET_IP_ENABLED` and `SUBMARINER_CLUSTERSET_IP_CIDR`.

- If no CIDR is passed, then clusterset IP functionality is disabled

- Clusterset IP allocation is determined by the `ServiceExport` annotation "_lighthouse.submariner.io/use-clusterset-ip_" or, if not set, the global enablement flag.

- Clusterset allocation is done only on creation of the aggregated `ServiceImport`. The "_lighthouse.submariner.io/clusterset-ip-allocated-by_" annotation is added by the allocating cluster.

- The "_lighthouse.submariner.io/use-clusterset-ip_" annotation is always set on the aggregated `ServiceImport`.

- If an exporting cluster's local clusterset enablement does not match the annotation setting on the aggregated `ServiceImport`, a "_ConflictingClusterSetIPEnablement_" Conflict condition is set.

- If the allocating cluster's service is un-exported, the `ServiceImport`'s clusterset IP remains and is not release to the pool.

- When a service is unexported from all clusters and the aggregated `ServiceImport` is deleted, the allocating cluster releases the clusterset IP back to the pool.

- On restart, before starting the syncers, the controller iterates thru all the local aggregated `ServiceImports` and reserves any clusterset IPs that were allocated from its pool, ie that are in its CIDR range.
