### PR TITLE
Implement clusterset IP in the CoredDNS plugin

### DIFF
--- a/coredns/resolver/endpoint_slice.go
+++ b/coredns/resolver/endpoint_slice.go
@@ -76,7 +76,7 @@ func (i *Interface) PutEndpointSlices(endpointSlices ...*discovery.EndpointSlice
 		return true
 	}
 
-	if !serviceInfo.isHeadless {
+	if !serviceInfo.isHeadless() {
 		return i.putClusterIPEndpointSlice(key, clusterID, endpointSlices[0], serviceInfo)
 	}
 
@@ -264,7 +264,7 @@ func (i *Interface) RemoveEndpointSlice(endpointSlice *discovery.EndpointSlice) 
 
 	if len(serviceInfo.clusters) == 0 && !serviceInfo.isExported {
 		delete(i.serviceMap, key)
-	} else if !serviceInfo.isHeadless {
+	} else if !serviceInfo.isHeadless() {
 		serviceInfo.mergePorts()
 		serviceInfo.resetLoadBalancing()
 	}

--- a/coredns/resolver/resolver.go
+++ b/coredns/resolver/resolver.go
@@ -39,7 +39,7 @@ func (i *Interface) GetDNSRecords(namespace, name, clusterID, hostname string) (
 		return nil, false, false
 	}
 
-	if !serviceInfo.isHeadless {
+	if !serviceInfo.isHeadless() {
 		record, found := i.getClusterIPRecord(serviceInfo, clusterID)
 		if record != nil {
 			return []DNSRecord{*record}, false, true
@@ -62,6 +62,13 @@ func (i *Interface) getClusterIPRecord(serviceInfo *serviceInfo, clusterID strin
 		}
 
 		return &clusterInfo.endpointRecords[0], true
+	}
+
+	if len(serviceInfo.spec.IPs) > 0 {
+		return &DNSRecord{
+			IP:    serviceInfo.spec.IPs[0],
+			Ports: serviceInfo.spec.Ports,
+		}, true
 	}
 
 	// If we are aware of the local cluster and we found some accessible IP, we shall return it.

--- a/coredns/resolver/service_import.go
+++ b/coredns/resolver/service_import.go
@@ -39,9 +39,12 @@ func (i *Interface) PutServiceImport(serviceImport *mcsv1a1.ServiceImport) {
 
 	if !found {
 		svcInfo = &serviceInfo{
-			clusters:   make(map[string]*clusterInfo),
-			balancer:   loadbalancer.NewSmoothWeightedRR(),
-			isHeadless: serviceImport.Spec.Type == mcsv1a1.Headless,
+			clusters: make(map[string]*clusterInfo),
+			balancer: loadbalancer.NewSmoothWeightedRR(),
+		}
+
+		if !isLegacy {
+			svcInfo.spec = serviceImport.Spec
 		}
 
 		i.serviceMap[key] = svcInfo
@@ -49,7 +52,7 @@ func (i *Interface) PutServiceImport(serviceImport *mcsv1a1.ServiceImport) {
 
 	svcInfo.isExported = true
 
-	if svcInfo.isHeadless || !isLegacy {
+	if svcInfo.isHeadless() || !isLegacy {
 		return
 	}
 

--- a/coredns/resolver/service_info.go
+++ b/coredns/resolver/service_info.go
@@ -88,3 +88,7 @@ func (si *serviceInfo) selectIP(checkCluster func(string) bool) *DNSRecord {
 
 	return nil
 }
+
+func (si *serviceInfo) isHeadless() bool {
+	return si.spec.Type == mcsv1a1.Headless
+}

--- a/coredns/resolver/types.go
+++ b/coredns/resolver/types.go
@@ -55,7 +55,7 @@ type clusterInfo struct {
 type serviceInfo struct {
 	clusters   map[string]*clusterInfo
 	balancer   loadbalancer.Interface
-	isHeadless bool
 	isExported bool
 	ports      []mcsv1a1.ServicePort
+	spec       mcsv1a1.ServiceImportSpec
 }


### PR DESCRIPTION
Modify the resolver to return the `ServiceImport'`s IP if it's set and a specific cluster name wasn't requested. If the latter then return the cluster's DNS record info as it normally does.

