### PR TITLE
Handle conflicting service ports when merging per MCS spec

### DIFF
--- a/coredns/resolver/service_info.go
+++ b/coredns/resolver/service_info.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/submariner-io/admiral/pkg/slices"
+	"k8s.io/utils/ptr"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
@@ -44,7 +45,7 @@ func (si *serviceInfo) mergePorts() {
 			si.ports = info.endpointRecords[0].Ports
 		} else {
 			si.ports = slices.Intersect(si.ports, info.endpointRecords[0].Ports, func(p mcsv1a1.ServicePort) string {
-				return fmt.Sprintf("%s%s%d", p.Name, p.Protocol, p.Port)
+				return fmt.Sprintf("%s:%s:%d:%s", p.Name, p.Protocol, p.Port, ptr.Deref(p.AppProtocol, ""))
 			})
 		}
 	}


### PR DESCRIPTION
The spec states that if the properties of service ports between clusters don't match, the clusterset service should expose the union of the ports. We're doing this however we're not properly handle conflicts as per the spec. If multiple clusters have a matching port by name but the other properties don't match, it should be considered a conflict and the conflict resolution policy should be applied, ie the port from the cluster with the oldest export timestamp should be used. When merging, we need to sort the ports by cluster timestamp and use just the port name when computing the union rather than all the port properties as we did before.

Also when checking for conflicts, we should also check the `AppProtocol` property.
