### PR TITLE
E2E: use ServiceDiscovery CR to determine if clusterset IP is enabled

### DIFF
--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -44,7 +44,7 @@ var _ = Describe("Test Service Discovery Across Clusters", Label(TestLabel), fun
 	f := lhframework.NewFramework("discovery")
 
 	BeforeEach(func() {
-		if lhframework.ClusterSetIPEnabled {
+		if lhframework.IsClusterSetIPEnabled() {
 			Skip("The clusterset IP feature is enabled globally - skipping the test")
 		}
 	})


### PR DESCRIPTION
...in E2E tests coz lighthouse agent may not be present if service-discovery is disabled.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
