### PR TITLE
Automated backport of #1653: E2E: use ServiceDiscovery CR to determine if clusterset IP is

### DIFF
--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -44,7 +44,7 @@ var _ = Describe("Test Service Discovery Across Clusters", Label(TestLabel), fun
 	f := lhframework.NewFramework("discovery")
 
 	BeforeEach(func() {
-		if lhframework.ClusterSetIPEnabled {
+		if lhframework.IsClusterSetIPEnabled() {
 			Skip("The clusterset IP feature is enabled globally - skipping the test")
 		}
 	})


### PR DESCRIPTION
Backport of #1653 on release-0.19.

#1653: E2E: use ServiceDiscovery CR to determine if clusterset IP is

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.