### PR TITLE
Automated backport of #1657: Use identifying labels for lookup of EPS on service EPS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/gomega v1.34.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.4
-	github.com/submariner-io/admiral v0.19.0-rc1
+	github.com/submariner-io/admiral v0.19.0-rc1.0.20241007115040-cd5bf4d54261
 	github.com/submariner-io/shipyard v0.19.0-rc1
 	k8s.io/api v0.31.1
 	k8s.io/apimachinery v0.31.1

--- a/go.sum
+++ b/go.sum
@@ -389,8 +389,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/submariner-io/admiral v0.19.0-rc1 h1:UBYQmbnsaICgs6Qyid5egN8uc7L4Ql0DTBx3sb4vihA=
-github.com/submariner-io/admiral v0.19.0-rc1/go.mod h1:2bmvHxnJ0piOMriKolIJ4/o5negeZ7ge/NIEeARXNS8=
+github.com/submariner-io/admiral v0.19.0-rc1.0.20241007115040-cd5bf4d54261 h1:b39I5740FgONLFymnRR36wtvjqXnwzC85A/Bwaw3dgw=
+github.com/submariner-io/admiral v0.19.0-rc1.0.20241007115040-cd5bf4d54261/go.mod h1:2bmvHxnJ0piOMriKolIJ4/o5negeZ7ge/NIEeARXNS8=
 github.com/submariner-io/shipyard v0.19.0-rc1 h1:KaQnYlGLZjUFAepgpHW0pmM9J74sjrOl5A1hsdLtWFQ=
 github.com/submariner-io/shipyard v0.19.0-rc1/go.mod h1:HrnoErg/rM3r+QjUePY0x/SZi1xaeyjuQ+JTEc1bkMM=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/pkg/agent/controller/clusterip_service_test.go
+++ b/pkg/agent/controller/clusterip_service_test.go
@@ -198,6 +198,41 @@ func testClusterIPServiceInOneCluster() {
 		})
 	})
 
+	When("the labels for an exported service are updated", func() {
+		JustBeforeEach(func() {
+			t.cluster1.createService()
+			t.cluster1.createServiceExport()
+			t.awaitNonHeadlessServiceExported(&t.cluster1)
+		})
+
+		It("should update the existing EndpointSlice labels", func() {
+			existingEPS := findEndpointSlices(t.cluster1.localEndpointSliceClient, t.cluster1.service.Namespace,
+				t.cluster1.service.Name, t.cluster1.clusterID)[0]
+
+			By("Updating service labels")
+
+			newLabelName := "new-label"
+			newLabelValue := "new-value"
+
+			t.cluster1.service.Labels[newLabelName] = newLabelValue
+			t.cluster1.serviceEndpointSlices[0].Labels[newLabelName] = newLabelValue
+
+			t.cluster1.updateServiceEndpointSlices()
+
+			Eventually(func() map[string]string {
+				eps, err := t.cluster1.localEndpointSliceClient.Get(context.TODO(), existingEPS.Name, metav1.GetOptions{})
+				Expect(err).To(Succeed())
+
+				return eps.GetLabels()
+			}).Should(HaveKeyWithValue(newLabelName, newLabelValue))
+
+			newSlices := findEndpointSlices(t.cluster1.localEndpointSliceClient, t.cluster1.service.Namespace,
+				t.cluster1.service.Name, t.cluster1.clusterID)
+			Expect(newSlices).To(HaveLen(1))
+			Expect(newSlices[0].Name).To(Equal(existingEPS.Name))
+		})
+	})
+
 	When("the session affinity is configured for an exported service", func() {
 		BeforeEach(func() {
 			t.cluster1.service.Spec.SessionAffinity = corev1.ServiceAffinityClientIP


### PR DESCRIPTION
Backport of #1657 on release-0.19.

#1657: Use identifying labels for lookup of EPS on service EPS

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

Depends on https://github.com/submariner-io/admiral/pull/1003