### PR TITLE
Set up a base distribution in the images

### DIFF
--- a/package/Dockerfile.lighthouse-agent
+++ b/package/Dockerfile.lighthouse-agent
@@ -1,4 +1,5 @@
 ARG BASE_BRANCH
+ARG FEDORA_VERSION=40
 ARG SOURCE=/go/src/github.com/submariner-io/lighthouse
 
 FROM --platform=${BUILDPLATFORM} quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder
@@ -9,12 +10,23 @@ COPY . ${SOURCE}
 
 RUN make -C ${SOURCE} LOCAL_BUILD=1 bin/${TARGETPLATFORM}/lighthouse-agent
 
+FROM --platform=${BUILDPLATFORM} fedora:${FEDORA_VERSION} AS base
+ARG FEDORA_VERSION
+ARG SOURCE
+ARG TARGETPLATFORM
+
+COPY package/dnf_install /
+
+RUN /dnf_install -a ${TARGETPLATFORM} -v ${FEDORA_VERSION} -r /output/lighthouse-agent \
+    setup
+
 FROM --platform=${TARGETPLATFORM} scratch
 ARG SOURCE
 ARG TARGETPLATFORM
 
 WORKDIR /var/submariner
 
+COPY --from=base /output/lighthouse-agent /
 COPY --from=builder ${SOURCE}/bin/${TARGETPLATFORM}/lighthouse-agent /usr/local/bin/
 
 ENTRYPOINT ["/usr/local/bin/lighthouse-agent", "-alsologtostderr"]

--- a/package/Dockerfile.lighthouse-coredns
+++ b/package/Dockerfile.lighthouse-coredns
@@ -1,4 +1,5 @@
 ARG BASE_BRANCH
+ARG FEDORA_VERSION=40
 ARG SOURCE=/go/src/github.com/submariner-io/lighthouse
 
 FROM --platform=${BUILDPLATFORM} quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH} AS builder
@@ -8,6 +9,16 @@ ARG TARGETPLATFORM
 COPY . ${SOURCE}
 
 RUN make -C ${SOURCE} LOCAL_BUILD=1 bin/${TARGETPLATFORM}/lighthouse-coredns
+
+FROM --platform=${BUILDPLATFORM} fedora:${FEDORA_VERSION} AS base
+ARG FEDORA_VERSION
+ARG SOURCE
+ARG TARGETPLATFORM
+
+COPY package/dnf_install /
+
+RUN /dnf_install -a ${TARGETPLATFORM} -v ${FEDORA_VERSION} -r /output/lighthouse-coredns \
+    setup
 
 FROM --platform=${TARGETPLATFORM} debian:stable-slim AS certificates
 ARG SOURCE
@@ -19,6 +30,7 @@ FROM --platform=${TARGETPLATFORM} scratch
 ARG SOURCE
 ARG TARGETPLATFORM
 
+COPY --from=base /output/lighthouse-coredns /
 COPY --from=certificates /etc/ssl/certs /etc/ssl/certs
 COPY --from=builder ${SOURCE}/bin/${TARGETPLATFORM}/lighthouse-coredns /usr/local/bin/
 

--- a/package/Dockerfile.lighthouse-coredns
+++ b/package/Dockerfile.lighthouse-coredns
@@ -20,11 +20,15 @@ COPY package/dnf_install /
 RUN /dnf_install -a ${TARGETPLATFORM} -v ${FEDORA_VERSION} -r /output/lighthouse-coredns \
     setup
 
-FROM --platform=${TARGETPLATFORM} debian:stable-slim AS certificates
+FROM --platform=${TARGETPLATFORM} fedora:${FEDORA_VERSION} AS certificates
+ARG FEDORA_VERSION
 ARG SOURCE
 ARG TARGETPLATFORM
 
-RUN apt-get update && apt-get -y install ca-certificates && update-ca-certificates
+COPY package/dnf_install /
+
+RUN /dnf_install -a ${TARGETPLATFORM} -v ${FEDORA_VERSION} -r /output/lighthouse-coredns \
+    ca-certificates
 
 FROM --platform=${TARGETPLATFORM} scratch
 ARG SOURCE

--- a/package/dnf_install
+++ b/package/dnf_install
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Installs packages using dnf to a named root:
+# -a arch - use arch instead of the native arch
+# -k      - keep the package cache
+# -r root - install to the named root instead of /output/base
+# -v ver  - use the given Fedora version (required)
+#
+# %arch in the package references will be replaced with the chosen arch
+
+INSTALL_ROOT=/output/base
+
+# Limit the number of files so that dnf doesn't spend ages processing fds
+ulimit -n 1048576
+
+while getopts a:kr:v: o
+do
+    case "$o" in
+    a)
+        ARCH="$OPTARG"
+        ;;
+    k)
+        KEEP_CACHE=true
+        ;;
+    r)
+        INSTALL_ROOT="$OPTARG"
+        ;;
+    v)
+        FEDORA_VERSION="$OPTARG"
+        ;;
+    *)
+        echo "$0 doesn't support $o" >&2
+        exit 1
+        ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+if [[ -n "${ARCH}" ]]; then
+    # Convert container arch to Fedora arch
+    ARCH="${ARCH##*/}"
+    case "${ARCH}" in
+        amd64) ARCH=x86_64;;
+        arm64) ARCH=aarch64;;
+    esac
+    arch_args="--forcearch ${ARCH}"
+else
+    # This will be used later, but we won't force
+    ARCH="$(rpm -q --qf "%{arch}" rpm)"
+fi
+
+[[ -z "${FEDORA_VERSION}" ]] && echo I need to know which version of Fedora to install, specify it with -v >&2 && exit 1
+
+if [[ "${INSTALL_ROOT}" != /output/base ]] && [[ ! -d "${INSTALL_ROOT}" ]] && [[ -d /output/base ]]; then
+    cp -a /output/base "${INSTALL_ROOT}"
+fi
+
+dnf -y --setopt=install_weak_deps=0 --nodocs ${arch_args} \
+    --installroot "${INSTALL_ROOT}" --releasever "${FEDORA_VERSION}" \
+    install "${@//\%arch/${ARCH}}"
+
+[[ "${KEEP_CACHE}" == true ]] || dnf -y ${arch_args} --installroot "${INSTALL_ROOT}" --releasever "${FEDORA_VERSION}" clean all


### PR DESCRIPTION
This adds the minimum subset of packages required for Fedora, allowing scanners to understand the image and process them correctly (in exchange for a small size increase).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
