### PR TITLE
Fix inadvertent deletion of aggregated ServiceImports on agent restart

### DIFF
--- a/pkg/agent/controller/controller_suite_test.go
+++ b/pkg/agent/controller/controller_suite_test.go
@@ -325,8 +325,8 @@ func newTestDiver() *testDriver {
 	t.brokerEndpointSliceClient = t.syncerConfig.BrokerClient.Resource(*test.GetGroupVersionResourceFor(t.syncerConfig.RestMapper,
 		&discovery.EndpointSlice{})).Namespace(test.RemoteNamespace)
 
-	t.cluster1.init(t.syncerConfig)
-	t.cluster2.init(t.syncerConfig)
+	t.cluster1.init(t.syncerConfig, nil)
+	t.cluster2.init(t.syncerConfig, nil)
 
 	return t
 }
@@ -340,15 +340,18 @@ func (t *testDriver) afterEach() {
 	close(t.stopCh)
 }
 
-func (c *cluster) init(syncerConfig *broker.SyncerConfig) {
+func (c *cluster) init(syncerConfig *broker.SyncerConfig, dynClient *dynamicfake.FakeDynamicClient) {
 	for k, v := range c.service.Labels {
 		c.serviceEndpointSlices[0].Labels[k] = v
 	}
 
 	c.serviceIP = c.service.Spec.ClusterIP
 
-	c.localDynClient = dynamicfake.NewSimpleDynamicClient(syncerConfig.Scheme)
-	fake.AddBasicReactors(&c.localDynClient.Fake)
+	c.localDynClient = dynClient
+	if c.localDynClient == nil {
+		c.localDynClient = dynamicfake.NewSimpleDynamicClient(syncerConfig.Scheme)
+		fake.AddBasicReactors(&c.localDynClient.Fake)
+	}
 
 	c.localServiceImportReactor = fake.NewFailingReactorForResource(&c.localDynClient.Fake, "serviceimports")
 

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -247,8 +247,8 @@ func (c *ServiceImportController) reconcileLocalAggregatedServiceImports() {
 		for i := range siList.Items {
 			si := c.converter.toServiceImport(&siList.Items[i])
 
-			if serviceImportSourceName(si) != "" {
-				// This is not an aggregated ServiceImport.
+			if serviceImportSourceName(si) != "" || si.Annotations[mcsv1a1.LabelServiceName] != "" {
+				// This is not a local aggregated ServiceImport.
 				continue
 			}
 


### PR DESCRIPTION
If the broker co-exists on a managed cluster, on LH agent restart, the aggregated `ServiceImports` on the broker are inadvertently deleted during reconciliation. Reconciliation should only process local aggregated `ServiceImports` and should ignore `ServiceImports` in the broker namespace. The latter are distinguished by the presence of the
 "_multicluster.kubernetes.io/service-name_" annotation.

The reconciliation unit test was adjusted to cover this case.

Fixes https://github.com/submariner-io/submariner/issues/3188
