### PR TITLE
Automated backport of #1675: Fix inadvertent deletion of aggregated ServiceImports on

### DIFF
--- a/pkg/agent/controller/reconciliation_test.go
+++ b/pkg/agent/controller/reconciliation_test.go
@@ -105,6 +105,11 @@ var _ = Describe("Reconciliation", func() {
 			t.afterEach()
 			t = newTestDiver()
 
+			brokerDynClient := t.syncerConfig.BrokerClient.(*fake.FakeDynamicClient)
+
+			// Use the broker client for cluster1 to simulate the broker being on the same cluster.
+			t.cluster1.init(t.syncerConfig, brokerDynClient)
+
 			test.CreateResource(t.cluster1.localServiceImportClient.Namespace(test.LocalNamespace), localServiceImport)
 			test.CreateResource(t.cluster1.localEndpointSliceClient, localEndpointSlice)
 			test.CreateResource(t.cluster1.localServiceExportClient, serviceExport)
@@ -117,12 +122,6 @@ var _ = Describe("Reconciliation", func() {
 			t.cluster1.start(t, *t.syncerConfig)
 			t.cluster2.start(t, *t.syncerConfig)
 
-			t.awaitNonHeadlessServiceExported(&t.cluster1)
-
-			testutil.EnsureNoActionsForResource(&t.cluster1.localDynClient.Fake, "serviceimports", "delete")
-			testutil.EnsureNoActionsForResource(&t.cluster1.localDynClient.Fake, "endpointslices", "delete")
-
-			brokerDynClient := t.syncerConfig.BrokerClient.(*fake.FakeDynamicClient)
 			testutil.EnsureNoActionsForResource(&brokerDynClient.Fake, "endpointslices", "delete")
 
 			// For migration cleanup, it may attempt to delete a local legacy ServiceImport from the broker so ignore it.
@@ -137,6 +136,8 @@ var _ = Describe("Reconciliation", func() {
 
 				return false
 			}).Should(BeFalse())
+
+			t.awaitNonHeadlessServiceExported(&t.cluster1)
 		})
 	})
 

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -197,8 +197,8 @@ func (c *ServiceImportController) reconcileLocalAggregatedServiceImports() {
 		for i := range siList.Items {
 			si := c.converter.toServiceImport(&siList.Items[i])
 
-			if serviceImportSourceName(si) != "" {
-				// This is not an aggregated ServiceImport.
+			if serviceImportSourceName(si) != "" || si.Annotations[mcsv1a1.LabelServiceName] != "" {
+				// This is not a local aggregated ServiceImport.
 				continue
 			}
 


### PR DESCRIPTION
Backport of #1675 on release-0.18.

#1675: Fix inadvertent deletion of aggregated ServiceImports on

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.