### PR TITLE
Fix SRV records not returned for clusterset IP service

### DIFF
--- a/coredns/resolver/clusterip_service_test.go
+++ b/coredns/resolver/clusterip_service_test.go
@@ -450,9 +450,13 @@ func testClusterSetIP() {
 
 	BeforeEach(func() {
 		si := newAggregatedServiceImport(namespace1, service1)
-		si.Spec.IPs = []string{clusterSetIP}
-		si.Spec.Ports = []mcsv1a1.ServicePort{port1, port2}
 
+		si.Spec.IPs = []string{clusterSetIP}
+		t.resolver.PutServiceImport(si)
+
+		// We call PutServiceImport separately with the ports to ensure it updates the cache. This simulates the
+		// real behavior where the port information is added/updated in the ServiceImport some time after creation.
+		si.Spec.Ports = []mcsv1a1.ServicePort{port1, port2}
 		t.resolver.PutServiceImport(si)
 
 		t.putEndpointSlice(newClusterIPEndpointSlice(namespace1, service1, clusterID1, serviceIP1, true, port1))

--- a/coredns/resolver/service_import.go
+++ b/coredns/resolver/service_import.go
@@ -43,11 +43,11 @@ func (i *Interface) PutServiceImport(serviceImport *mcsv1a1.ServiceImport) {
 			balancer: loadbalancer.NewSmoothWeightedRR(),
 		}
 
-		if !isLegacy {
-			svcInfo.spec = serviceImport.Spec
-		}
-
 		i.serviceMap[key] = svcInfo
+	}
+
+	if !isLegacy {
+		svcInfo.spec = serviceImport.Spec
 	}
 
 	svcInfo.isExported = true


### PR DESCRIPTION
With clusterset IP enabled, we extract the ports from the aggregated `ServiceImport` instead of the `EndpointSlices`. However the ports are populated in the `ServiceImport` sometime after creation so `PutServiceImport` needs to update the cached spec if it already exists.
