### PR TITLE
Replace quic-go to fix CVE-2024-53259

### DIFF
--- a/coredns/go.mod
+++ b/coredns/go.mod
@@ -2,6 +2,9 @@ module github.com/submariner-io/lighthouse/coredns
 
 go 1.22.0
 
+// Fixes CVE-2024-53259
+replace github.com/quic-go/quic-go v0.42.0 => github.com/quic-go/quic-go v0.48.2
+
 require (
 	github.com/coredns/caddy v1.1.1
 	github.com/coredns/coredns v1.11.3

--- a/coredns/go.sum
+++ b/coredns/go.sum
@@ -413,8 +413,8 @@ github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/quic-go/quic-go v0.42.0 h1:uSfdap0eveIl8KXnipv9K7nlwZ5IqLlYOpJ58u5utpM=
-github.com/quic-go/quic-go v0.42.0/go.mod h1:132kz4kL3F9vxhW3CtQJLDVwcFe5wdWeJXXijhsO57M=
+github.com/quic-go/quic-go v0.48.2 h1:wsKXZPeGWpMpCGSWqOcqpW2wZYic/8T3aqiOID0/KWE=
+github.com/quic-go/quic-go v0.48.2/go.mod h1:yBgs3rWBOADpga7F+jJsb6Ybg1LSYiQvwWlLX+/6HMs=
 github.com/richardartoul/molecule v1.0.1-0.20221107223329-32cfee06a052 h1:Qp27Idfgi6ACvFQat5+VJvlYToylpM/hcyLBI3WaKPA=
 github.com/richardartoul/molecule v1.0.1-0.20221107223329-32cfee06a052/go.mod h1:uvX/8buq8uVeiZiFht+0lqSLBHF+uGV8BrTv8W/SIwk=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=


### PR DESCRIPTION
There's a CVE in quic-go that's fixed in v0.48.2. We have an indirect
dependency on quic-go through CoreDNS. Instead of updating CoreDNS on a
release branch, replace the quic-go version.

Note that `go mod graph` still shows the older version, but it will not
actually be used. Graph reports the original module declarations, while
tidy and the build actually download the updated version.

    $ make BUILD_UPX=false build
    $ go version -m bin/linux/amd64/lighthouse-coredns | grep quic-go
          dep   github.com/quic-go/quic-go      v0.42.0
          =>    github.com/quic-go/quic-go      v0.48.2


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
