### PR TITLE
Automated backport of #1757: Prevent duplicate LH EndpointSlices resources

### DIFF
--- a/coredns/gateway/controller.go
+++ b/coredns/gateway/controller.go
@@ -112,7 +112,7 @@ func (c *Controller) Start(client dynamic.Interface) error {
 		return errors.New("failed to wait for informer cache to sync")
 	}
 
-	go c.queue.Run(c.stopCh, c.processNextGateway)
+	go c.queue.Run(c.processNextGateway)
 
 	return nil
 }

--- a/coredns/go.mod
+++ b/coredns/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/onsi/gomega v1.36.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.5
-	github.com/submariner-io/admiral v0.20.0
+	github.com/submariner-io/admiral v0.20.1-0.20250409042613-8f51af59e8a8
 	k8s.io/api v0.32.2
 	k8s.io/apimachinery v0.32.2
 	k8s.io/client-go v0.32.2

--- a/coredns/go.sum
+++ b/coredns/go.sum
@@ -513,8 +513,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/submariner-io/admiral v0.20.0 h1:o0uF+hNpyABChGQ7ZckTVRD3bLFtjA7Bq43m03nUhqM=
-github.com/submariner-io/admiral v0.20.0/go.mod h1:FBLUUZH8U0MnPDI+q5eFD6vjcefPrOKaXcmsbCnqXEY=
+github.com/submariner-io/admiral v0.20.1-0.20250409042613-8f51af59e8a8 h1:5nuUImmwepEz3M5quSFlxzy0gRn1LhuXbCa9tcwxGL8=
+github.com/submariner-io/admiral v0.20.1-0.20250409042613-8f51af59e8a8/go.mod h1:FBLUUZH8U0MnPDI+q5eFD6vjcefPrOKaXcmsbCnqXEY=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tinylib/msgp v1.2.1 h1:6ypy2qcCznxpP4hpORzhtXyTqrBs7cfM9MCCWY8zsmU=
 github.com/tinylib/msgp v1.2.1/go.mod h1:2vIGs3lcUo8izAATNobrCHevYZC/LMsJtw4JPiYPHro=

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/gomega v1.36.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.5
-	github.com/submariner-io/admiral v0.20.0
+	github.com/submariner-io/admiral v0.20.1-0.20250409042613-8f51af59e8a8
 	github.com/submariner-io/shipyard v0.20.0
 	k8s.io/api v0.32.2
 	k8s.io/apimachinery v0.32.2

--- a/go.sum
+++ b/go.sum
@@ -388,8 +388,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/submariner-io/admiral v0.20.0 h1:o0uF+hNpyABChGQ7ZckTVRD3bLFtjA7Bq43m03nUhqM=
-github.com/submariner-io/admiral v0.20.0/go.mod h1:FBLUUZH8U0MnPDI+q5eFD6vjcefPrOKaXcmsbCnqXEY=
+github.com/submariner-io/admiral v0.20.1-0.20250409042613-8f51af59e8a8 h1:5nuUImmwepEz3M5quSFlxzy0gRn1LhuXbCa9tcwxGL8=
+github.com/submariner-io/admiral v0.20.1-0.20250409042613-8f51af59e8a8/go.mod h1:FBLUUZH8U0MnPDI+q5eFD6vjcefPrOKaXcmsbCnqXEY=
 github.com/submariner-io/shipyard v0.20.0 h1:1wp0XYf8LVuzVe0edN15JHgEX6IRqNGQeovlBIteVEU=
 github.com/submariner-io/shipyard v0.20.0/go.mod h1:focyxe2Ljvc4LHhQVVJU3UITWh1bnAg9k8c2p6nd03w=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/pkg/agent/controller/clusterip_service_test.go
+++ b/pkg/agent/controller/clusterip_service_test.go
@@ -108,7 +108,7 @@ func testClusterIPServiceInOneCluster() {
 			t.cluster1.createService()
 			t.cluster1.createServiceExport()
 			t.awaitNonHeadlessServiceExported(&t.cluster1)
-			t.cluster1.localDynClient.Fake.ClearActions()
+			t.cluster1.localDynClientFake.ClearActions()
 
 			By("Deleting the service")
 			t.cluster1.deleteService()
@@ -442,7 +442,7 @@ func testClusterIPServiceInOneCluster() {
 		}
 
 		BeforeEach(func() {
-			fake.AddVerifyNamespaceReactor(&t.cluster2.localDynClient.Fake, "serviceimports", "endpointslices")
+			fake.AddVerifyNamespaceReactor(t.cluster2.localDynClientFake, "serviceimports", "endpointslices")
 
 			createNamespace(t.cluster2.localDynClient, test.LocalNamespace)
 		})

--- a/pkg/agent/controller/endpoint_slice.go
+++ b/pkg/agent/controller/endpoint_slice.go
@@ -94,7 +94,7 @@ func (c *EndpointSliceController) start(stopCh <-chan struct{}) error {
 		return errors.Wrap(err, "error starting EndpointSlice syncer")
 	}
 
-	c.conflictCheckWorkQueue.Run(stopCh, c.checkForConflicts)
+	c.conflictCheckWorkQueue.Run(c.checkForConflicts)
 
 	go func() {
 		<-stopCh

--- a/pkg/agent/controller/reconciliation_test.go
+++ b/pkg/agent/controller/reconciliation_test.go
@@ -120,7 +120,7 @@ var _ = Describe("Reconciliation", func() {
 			brokerDynClient := t.syncerConfig.BrokerClient.(*fake.FakeDynamicClient)
 
 			// Use the broker client for cluster1 to simulate the broker being on the same cluster.
-			t.cluster1.init(t.syncerConfig, brokerDynClient)
+			t.cluster1.init(t.syncerConfig, brokerDynClient, &brokerDynClient.Fake)
 
 			test.CreateResource(t.cluster1.localServiceImportClient.Namespace(test.LocalNamespace), localServiceImport)
 			test.CreateResource(t.cluster1.localEndpointSliceClient, localEndpointSlice)

--- a/pkg/agent/controller/service_endpoint_slices_test.go
+++ b/pkg/agent/controller/service_endpoint_slices_test.go
@@ -1,0 +1,148 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/fake"
+	"github.com/submariner-io/lighthouse/pkg/agent/controller"
+	"github.com/submariner-io/lighthouse/pkg/constants"
+	discovery "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+var _ = Describe("Service EndpointSlice Controller", func() {
+	var t *testDriver
+
+	BeforeEach(func() {
+		t = newTestDiver()
+	})
+
+	JustBeforeEach(func() {
+		t.justBeforeEach()
+	})
+
+	AfterEach(func() {
+		t.afterEach()
+	})
+
+	When("stopping the previous EPS controller is delayed", func() {
+		var fakeEPSClient *epsDynamicClient
+
+		BeforeEach(func() {
+			dynClient := dynamicfake.NewSimpleDynamicClient(t.syncerConfig.Scheme)
+			fake.AddBasicReactors(&dynClient.Fake)
+
+			fakeEPSClient = &epsDynamicClient{
+				dynClient: dynClient,
+				epsResourceClient: epsResourceClient{
+					ResourceInterface: dynClient.Resource(discovery.SchemeGroupVersion.WithResource(
+						"endpointslices")).Namespace(serviceNamespace),
+					epsCreateContinue: make(chan any),
+					epsCreateStarted:  make(chan any),
+				},
+			}
+
+			fakeEPSClient.firstCreate.Store(true)
+
+			t.cluster1.init(t.syncerConfig, fakeEPSClient, &dynClient.Fake)
+
+			controller.AwaitStoppedTimeout = time.Millisecond * 100
+
+			DeferCleanup(func() {
+				controller.AwaitStoppedTimeout = time.Second * 5
+			})
+		})
+
+		JustBeforeEach(func() {
+			t.cluster1.createService()
+			t.cluster1.createServiceExport()
+			t.cluster1.createServiceEndpointSlices()
+		})
+
+		It("should not create two EndpointSlices after the delay resolves and the new controller is starter", func() {
+			Eventually(fakeEPSClient.epsCreateStarted).Within(3 * time.Second).Should(Receive())
+
+			t.cluster1.service.Spec.Ports = append(t.cluster1.service.Spec.Ports, toServicePort(port3))
+			t.aggregatedServicePorts = append(t.aggregatedServicePorts, port3)
+
+			By("Updating the service")
+
+			t.cluster1.updateService()
+
+			time.Sleep(time.Millisecond * 500)
+			fakeEPSClient.epsCreateContinue <- true
+
+			t.awaitEndpointSlice(&t.cluster1)
+
+			Consistently(func() []*discovery.EndpointSlice {
+				return findEndpointSlices(t.cluster1.localEndpointSliceClient, t.cluster1.service.Namespace,
+					t.cluster1.service.Name, t.cluster1.clusterID)
+			}).Within(time.Millisecond * 500).Should(HaveLen(1))
+		})
+	})
+})
+
+type epsDynamicClient struct {
+	dynClient *dynamicfake.FakeDynamicClient
+	epsResourceClient
+}
+
+func (f *epsDynamicClient) Resource(gvr schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	if gvr.Resource == "endpointslices" {
+		return &f.epsResourceClient
+	}
+
+	return f.dynClient.Resource(gvr)
+}
+
+type epsResourceClient struct {
+	dynamic.ResourceInterface
+	epsCreateContinue chan any
+	epsCreateStarted  chan any
+	firstCreate       atomic.Bool
+}
+
+func (c *epsResourceClient) Namespace(_ string) dynamic.ResourceInterface {
+	return c
+}
+
+//nolint:gocritic // Ignore hugeParam
+func (c *epsResourceClient) Create(ctx context.Context, obj *unstructured.Unstructured, opts metav1.CreateOptions, resources ...string,
+) (*unstructured.Unstructured, error) {
+	if obj.GetGenerateName() == "" || obj.GetLabels()[discovery.LabelManagedBy] != constants.LabelValueManagedBy {
+		return c.ResourceInterface.Create(ctx, obj, opts, resources...)
+	}
+
+	if c.firstCreate.CompareAndSwap(true, false) {
+		c.epsCreateStarted <- true
+		<-c.epsCreateContinue
+	}
+
+	return c.ResourceInterface.Create(ctx, obj, opts, resources...)
+}

--- a/pkg/agent/controller/service_export_failures_test.go
+++ b/pkg/agent/controller/service_export_failures_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Service export failures", func() {
 		JustBeforeEach(func() {
 			t.awaitNonHeadlessServiceExported(&t.cluster1)
 
-			fake.FailOnAction(&t.cluster1.localDynClient.Fake, "endpointslices", "delete-collection", nil, true)
+			fake.FailOnAction(t.cluster1.localDynClientFake, "endpointslices", "delete-collection", nil, true)
 		})
 
 		It("should eventually unexport the service", func() {

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -20,6 +20,7 @@ package controller
 
 import (
 	"sync"
+	"time"
 
 	"github.com/submariner-io/admiral/pkg/federate"
 	"github.com/submariner-io/admiral/pkg/ipam"
@@ -121,6 +122,7 @@ type ServiceEndpointSliceController struct {
 	globalIngressIPCache     *globalIngressIPCache
 	epsSyncer                syncer.Interface
 	federator                federate.Federator
+	awaitStoppedTimeout      time.Duration
 }
 
 // EndpointSliceController encapsulates a syncer that syncs EndpointSlices to and from that broker.


### PR DESCRIPTION
Backport of #1757 on release-0.20.

#1757: Prevent duplicate LH EndpointSlices resources

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

Depends on https://github.com/submariner-io/shipyard/pull/1912