### PR TITLE
Implement dual-stack support in the LH agent

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        deploytool: ['operator']
+        ip_family: ['', 'dual-stack']
         globalnet: ['', 'globalnet']
         # Run most tests against the latest K8s version
         k8s_version: ['1.32']
@@ -63,7 +63,7 @@ jobs:
         uses: submariner-io/shipyard/gh-actions/e2e@devel
         with:
           k8s_version: ${{ matrix.k8s_version }}
-          using: ${{ matrix.deploytool }} ${{ matrix.globalnet }}
+          using: ${{ matrix.ip_family }} ${{ matrix.globalnet }}
 
       - name: Post mortem
         if: failure()

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.22.0
 	github.com/submariner-io/admiral v0.21.0-m1.0.20250424144538-5dbf909f057c
-	github.com/submariner-io/shipyard v0.21.0-m1
+	github.com/submariner-io/shipyard v0.21.0-m1.0.20250426051228-3c3d765a1306
 	k8s.io/api v0.32.1
 	k8s.io/apimachinery v0.32.1
 	k8s.io/client-go v0.32.1

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/client_golang v1.21.1
-	github.com/submariner-io/admiral v0.21.0-m1
+	github.com/prometheus/client_golang v1.22.0
+	github.com/submariner-io/admiral v0.21.0-m1.0.20250424144538-5dbf909f057c
 	github.com/submariner-io/shipyard v0.21.0-m1
 	k8s.io/api v0.32.1
 	k8s.io/apimachinery v0.32.1
@@ -42,7 +42,6 @@ require (
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect

--- a/go.sum
+++ b/go.sum
@@ -242,8 +242,8 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
-github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
+github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
+github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -329,8 +329,8 @@ github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
-github.com/prometheus/client_golang v1.21.1 h1:DOvXXTqVzvkIewV/CDPFdejpMCGeMcbGCQ8YOmu+Ibk=
-github.com/prometheus/client_golang v1.21.1/go.mod h1:U9NM32ykUErtVBxdvD3zfi+EuFkkaBvMb09mIfe0Zgg=
+github.com/prometheus/client_golang v1.22.0 h1:rb93p9lokFEsctTys46VnV1kLCDpVZ0a/Y92Vm0Zc6Q=
+github.com/prometheus/client_golang v1.22.0/go.mod h1:R7ljNsLXhuQXYZYtw6GAE9AZg8Y7vEW5scdCXrWRXC0=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -390,8 +390,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/submariner-io/admiral v0.21.0-m1 h1:uGPUGcym/gCrntAAjRzACzQMsmQjEwfGPgJ2EJddKgU=
-github.com/submariner-io/admiral v0.21.0-m1/go.mod h1:rNG729+maPgD7qTNcyeBdJlOd9adB5rGKSq5JQhE8X0=
+github.com/submariner-io/admiral v0.21.0-m1.0.20250424144538-5dbf909f057c h1:De8Xx/L3MwadLmzLeR2k2NIGteTbRDUwM0km6YjygVY=
+github.com/submariner-io/admiral v0.21.0-m1.0.20250424144538-5dbf909f057c/go.mod h1:UXeSaU9P6bOj3cNiRoUGYHyFFtD1sLjGA2JQUUurmFk=
 github.com/submariner-io/shipyard v0.21.0-m1 h1:C3wDuAf/VleTe5C9FFldwgmUFN3sNmPaoGwuGAH8tng=
 github.com/submariner-io/shipyard v0.21.0-m1/go.mod h1:4Jb5M7Caxz8n+dRYd/aQWWph9LRaD9jVDOScd/aS4wI=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/go.sum
+++ b/go.sum
@@ -392,8 +392,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/submariner-io/admiral v0.21.0-m1.0.20250424144538-5dbf909f057c h1:De8Xx/L3MwadLmzLeR2k2NIGteTbRDUwM0km6YjygVY=
 github.com/submariner-io/admiral v0.21.0-m1.0.20250424144538-5dbf909f057c/go.mod h1:UXeSaU9P6bOj3cNiRoUGYHyFFtD1sLjGA2JQUUurmFk=
-github.com/submariner-io/shipyard v0.21.0-m1 h1:C3wDuAf/VleTe5C9FFldwgmUFN3sNmPaoGwuGAH8tng=
-github.com/submariner-io/shipyard v0.21.0-m1/go.mod h1:4Jb5M7Caxz8n+dRYd/aQWWph9LRaD9jVDOScd/aS4wI=
+github.com/submariner-io/shipyard v0.21.0-m1.0.20250426051228-3c3d765a1306 h1:o/jiE/EK1M538CpzAEuc+lNH1LFBqPr4ospRLYxqBd8=
+github.com/submariner-io/shipyard v0.21.0-m1.0.20250426051228-3c3d765a1306/go.mod h1:J8Qk9Mf40Uj+9g44TkVJtf0fif/62IQ/MqS7feyjp5E=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/agent/controller/dual_stack_test.go
+++ b/pkg/agent/controller/dual_stack_test.go
@@ -1,0 +1,190 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	corev1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+var _ = Describe("Dual-stack", func() {
+	const ipv6ServiceIP = "fc00:2001::6757"
+
+	var t *testDriver
+
+	BeforeEach(func() {
+		t = newTestDiver()
+	})
+
+	JustBeforeEach(func() {
+		t.justBeforeEach()
+
+		t.cluster1.createServiceEndpointSlices()
+		t.cluster1.createService()
+		t.cluster1.createServiceExport()
+	})
+
+	AfterEach(func() {
+		t.afterEach()
+	})
+
+	When("a dual-stack ClusterIP service is exported", func() {
+		BeforeEach(func() {
+			t.cluster1.service.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
+			t.cluster1.service.Spec.ClusterIPs = append(t.cluster1.service.Spec.ClusterIPs, ipv6ServiceIP)
+
+			t.cluster1.serviceEndpointSlices = append(t.cluster1.serviceEndpointSlices, newIPv6ServiceEndpointSlice())
+			t.cluster1.serviceEndpointSlices[1].Endpoints[0].Conditions = discovery.EndpointConditions{Ready: ptr.To(false)}
+		})
+
+		JustBeforeEach(func() {
+			t.cluster1.expectedClusterIPEndpoints[1].Conditions = t.cluster1.serviceEndpointSlices[1].Endpoints[0].Conditions
+		})
+
+		Context("then unexported", func() {
+			It("should create/delete separate EndpointSlices for IPv4 and IPv6", func() {
+				t.awaitNonHeadlessServiceExported(&t.cluster1)
+
+				By("Updating the IPv6 EndpointSlice")
+
+				t.cluster1.serviceEndpointSlices[1].Endpoints[0].Conditions = discovery.EndpointConditions{Ready: ptr.To(true)}
+				t.cluster1.expectedClusterIPEndpoints[1].Conditions = t.cluster1.serviceEndpointSlices[1].Endpoints[0].Conditions
+
+				t.cluster1.updateServiceEndpointSlices()
+				t.ensureEndpointSlice(&t.cluster1)
+
+				By("Deleting the ServiceExport")
+
+				t.cluster1.deleteServiceExport()
+				t.awaitServiceUnexported(&t.cluster1)
+			})
+		})
+
+		Context("with Globalnet enabled and an IPv4 global IP", func() {
+			BeforeEach(func() {
+				t.cluster1.agentSpec.GlobalnetEnabled = true
+				t.cluster1.createGlobalIngressIP(t.cluster1.newGlobalIngressIP(t.cluster1.service.Name, globalIP1))
+			})
+
+			JustBeforeEach(func() {
+				t.cluster1.expectedClusterIPEndpoints[0].Addresses[0] = globalIP1
+			})
+
+			It("should only retrieve the global IP for the IPv4 EndpointSlice", func() {
+				t.awaitNonHeadlessServiceExported(&t.cluster1)
+			})
+		})
+	})
+
+	When("an IPv6 ClusterIP service is exported", func() {
+		BeforeEach(func() {
+			t.cluster1.service.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv6Protocol}
+			t.cluster1.service.Spec.ClusterIPs = []string{ipv6ServiceIP}
+			t.cluster1.serviceEndpointSlices = []discovery.EndpointSlice{newIPv6ServiceEndpointSlice()}
+		})
+
+		It("should only create an IPv6 EndpointSlice", func() {
+			t.awaitNonHeadlessServiceExported(&t.cluster1)
+		})
+
+		Context("with Globalnet enabled", func() {
+			BeforeEach(func() {
+				t.cluster1.agentSpec.GlobalnetEnabled = true
+			})
+
+			It("should not try to retrieve a global IP for the IPv6 EndpointSlice", func() {
+				t.awaitNonHeadlessServiceExported(&t.cluster1)
+			})
+		})
+	})
+
+	When("a dual-stack headless service is exported", func() {
+		BeforeEach(func() {
+			t.cluster1.service.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
+			t.cluster1.service.Spec.ClusterIP = corev1.ClusterIPNone
+
+			t.cluster1.serviceEndpointSlices[0].Endpoints = []discovery.Endpoint{t.cluster1.serviceEndpointSlices[0].Endpoints[0]}
+			t.cluster1.serviceEndpointSlices = append(t.cluster1.serviceEndpointSlices, newIPv6ServiceEndpointSlice())
+
+			t.cluster1.headlessEndpointAddresses = [][]discovery.Endpoint{
+				t.cluster1.serviceEndpointSlices[0].Endpoints,
+				t.cluster1.serviceEndpointSlices[1].Endpoints,
+			}
+		})
+
+		Context("then unexported", func() {
+			It("should create/delete separate EndpointSlices for IPv4 and IPv6", func() {
+				t.awaitHeadlessServiceExported(&t.cluster1)
+
+				By("Deleting the ServiceExport")
+
+				t.cluster1.deleteServiceExport()
+				t.awaitServiceUnexported(&t.cluster1)
+			})
+		})
+
+		Context("with Globalnet enabled and an IPv4 global IP", func() {
+			BeforeEach(func() {
+				t.cluster1.agentSpec.GlobalnetEnabled = true
+				t.cluster1.headlessEndpointAddresses[0][0].Addresses = []string{globalIP1}
+
+				t.cluster1.createGlobalIngressIP(t.cluster1.newHeadlessGlobalIngressIPForPod("one", globalIP1))
+			})
+
+			It("should only retrieve the global IP for the IPv4 EndpointSlice", func() {
+				t.awaitHeadlessServiceExported(&t.cluster1)
+			})
+		})
+	})
+
+	When("a IPv6 headless service is exported", func() {
+		BeforeEach(func() {
+			t.cluster1.service.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv6Protocol}
+			t.cluster1.service.Spec.ClusterIP = corev1.ClusterIPNone
+
+			t.cluster1.serviceEndpointSlices = []discovery.EndpointSlice{newIPv6ServiceEndpointSlice()}
+			t.cluster1.headlessEndpointAddresses = [][]discovery.Endpoint{t.cluster1.serviceEndpointSlices[0].Endpoints}
+		})
+
+		It("should only create an IPv6 EndpointSlice", func() {
+			t.awaitHeadlessServiceExported(&t.cluster1)
+		})
+	})
+})
+
+func newIPv6ServiceEndpointSlice() discovery.EndpointSlice {
+	return discovery.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: serviceName + "-ipv6",
+			Labels: map[string]string{
+				discovery.LabelServiceName: serviceName,
+			},
+		},
+		AddressType: discovery.AddressTypeIPv6,
+		Endpoints: []discovery.Endpoint{
+			{
+				Addresses:  []string{"fd00:2001::1234"},
+				Conditions: discovery.EndpointConditions{Ready: ptr.To(true)},
+			},
+		},
+	}
+}

--- a/pkg/agent/controller/globalnet_test.go
+++ b/pkg/agent/controller/globalnet_test.go
@@ -53,7 +53,10 @@ var _ = Describe("Globalnet enabled", func() {
 
 		BeforeEach(func() {
 			ingressIP = t.cluster1.newGlobalIngressIP(t.cluster1.service.Name, globalIP1)
-			t.cluster1.serviceIP = globalIP1
+		})
+
+		JustBeforeEach(func() {
+			t.cluster1.expectedClusterIPEndpoints[0].Addresses[0] = globalIP1
 		})
 
 		Context("and it has a global IP", func() {

--- a/pkg/agent/controller/reconciliation_test.go
+++ b/pkg/agent/controller/reconciliation_test.go
@@ -132,11 +132,12 @@ var _ = Describe("Reconciliation", func() {
 
 			restoreBrokerResources()
 
-			t.cluster1.createServiceEndpointSlices()
 			t.cluster1.createService()
 
 			t.cluster1.start(t, *t.syncerConfig)
 			t.cluster2.start(t, *t.syncerConfig)
+
+			t.cluster1.createServiceEndpointSlices()
 
 			testutil.EnsureNoActionsForResource(&brokerDynClient.Fake, "endpointslices", "delete")
 
@@ -163,11 +164,15 @@ var _ = Describe("Reconciliation", func() {
 			t = newTestDiver()
 
 			restoreBrokerResources()
+
 			test.CreateResource(t.cluster1.localServiceImportClient.Namespace(test.LocalNamespace), localServiceImport)
 			test.CreateResource(t.cluster1.localEndpointSliceClient, localEndpointSlice)
+
 			t.cluster1.createService()
-			t.cluster1.createServiceEndpointSlices()
+
 			t.cluster1.start(t, *t.syncerConfig)
+
+			t.cluster1.createServiceEndpointSlices()
 
 			t.awaitServiceUnexported(&t.cluster1)
 		})

--- a/pkg/agent/controller/service_import_migration_test.go
+++ b/pkg/agent/controller/service_import_migration_test.go
@@ -70,11 +70,12 @@ var _ = Describe("Pre-clusterset IP ServiceImport migration", func() {
 		t.aggregatedSessionAffinity = t.cluster1.service.Spec.SessionAffinity
 		t.aggregatedSessionAffinityConfig = t.cluster1.service.Spec.SessionAffinityConfig
 
-		t.cluster1.createServiceEndpointSlices()
 		t.cluster1.createService()
 		t.cluster1.createServiceExport()
 
 		t.justBeforeEach()
+
+		t.cluster1.createServiceEndpointSlices()
 	})
 
 	AfterEach(func() {
@@ -97,7 +98,6 @@ func testLegacyServiceImportMigration() {
 	BeforeEach(func() {
 		t = newTestDiver()
 
-		t.cluster1.createServiceEndpointSlices()
 		t.cluster1.createService()
 
 		legacyServiceImport = t.newLegacyServiceImport(t.cluster1.clusterID)
@@ -143,6 +143,8 @@ func testLegacyServiceImportMigration() {
 
 	JustBeforeEach(func() {
 		t.justBeforeEach()
+
+		t.cluster1.createServiceEndpointSlices()
 	})
 
 	AfterEach(func() {

--- a/test/e2e/discovery/dual_stack.go
+++ b/test/e2e/discovery/dual_stack.go
@@ -1,0 +1,77 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"fmt"
+	"slices"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	lhframework "github.com/submariner-io/lighthouse/test/e2e/framework"
+	"github.com/submariner-io/shipyard/test/e2e/framework"
+	corev1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
+	"k8s.io/utils/ptr"
+)
+
+var _ = Describe("Dual-stack Service Discovery Across Clusters", Label(TestLabel), func() {
+	f := lhframework.NewFramework("discovery")
+
+	BeforeEach(func() {
+		if lhframework.IsClusterSetIPEnabled() {
+			Skip("The clusterset IP feature is enabled globally - skipping the test")
+		}
+
+		if f.DetermineIPFamilyType(framework.ClusterB) != framework.DualStack {
+			Skip("Dual-stack is not supported - skipping the test")
+		}
+	})
+
+	When("a pod tries to resolve a dual-stack service in a remote cluster", func() {
+		It("should be able to discover the remote service via either IPv4 or IPv6", func() {
+			RunDualStackServiceDiscoveryTest(f)
+		})
+	})
+})
+
+func RunDualStackServiceDiscoveryTest(f *lhframework.Framework) {
+	clusterBName := framework.TestContext.ClusterIDs[framework.ClusterB]
+
+	framework.By(fmt.Sprintf("Creating an Nginx Deployment on %q", clusterBName))
+	f.NewNginxDeployment(framework.ClusterB)
+
+	framework.By(fmt.Sprintf("Creating a dual-stack Nginx Service on %q", clusterBName))
+
+	nginxServiceClusterB := f.NewNginxServiceWithIPFamilyPolicy(framework.ClusterB, ptr.To(corev1.IPFamilyPolicyRequireDualStack))
+
+	f.NewServiceExport(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+
+	f.AwaitServiceExportedStatusCondition(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace)
+
+	epsList := f.AwaitEndpointSlices(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 2, 2)
+
+	Expect(slices.IndexFunc(epsList.Items, func(eps discovery.EndpointSlice) bool {
+		return eps.AddressType == discovery.AddressTypeIPv4
+	})).To(BeNumerically(">=", 0), "IPv4 EndpointSlice not found")
+
+	Expect(slices.IndexFunc(epsList.Items, func(eps discovery.EndpointSlice) bool {
+		return eps.AddressType == discovery.AddressTypeIPv6
+	})).To(BeNumerically(">=", 0), "IPv6 EndpointSlice not found")
+}


### PR DESCRIPTION
Highlights:
    
- Copy all Service ClusterIPs to the ServiceImport IPs
- If Globalnet is enabled, only retrieve global IPs for IPv4 addresses
- For a ClusterIP service, create a single EndpointSlice for IPv6 same as is done for IPv4.
- Added initial E2E test for dual stack

See commits for details.
