### PR TITLE
Add Konflux/Renovate config to only update Tekton

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+  "enabledManagers": ["tekton"]
+}


### PR DESCRIPTION
This prepares the way for adding Konflux-bot, which runs Renovate under the hood. This was a blocking issue last time we tried to add Konflux-based builds.

We already have Dependabot with advanced custom configuration to handle our golang and GitHub Actions updates. We don't want Konflux/Renovate to duplicate that, adding useless verbosity. We only want Konflux to update the new .tekton/ configuration it will add and be defined by.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
