### PR TITLE
Always populate the Reason field in ServiceExport conditions

### DIFF
--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -305,7 +305,7 @@ func (a *Controller) serviceExportToServiceImport(obj runtime.Object, _ int, op 
 	}
 
 	a.serviceExportClient.UpdateStatusConditions(ctx, svcExport.Name, svcExport.Namespace,
-		newServiceExportCondition(mcsv1a1.ServiceExportValid, metav1.ConditionTrue, "", ""))
+		newServiceExportCondition(mcsv1a1.ServiceExportValid, metav1.ConditionTrue, ExportValidReason, ""))
 
 	logger.V(log.DEBUG).Infof("Returning ServiceImport %s/%s: %s", svcExport.Namespace, svcExport.Name,
 		serviceImportStringer{serviceImport})

--- a/pkg/agent/controller/clusterip_service_test.go
+++ b/pkg/agent/controller/clusterip_service_test.go
@@ -70,8 +70,8 @@ func testClusterIPServiceInOneCluster() {
 				t.cluster1.createService()
 				t.cluster1.createServiceExport()
 				t.awaitNonHeadlessServiceExported(&t.cluster1)
-				t.cluster1.awaitServiceExportCondition(newServiceExportReadyCondition(metav1.ConditionFalse, "AwaitingExport"),
-					newServiceExportReadyCondition(metav1.ConditionTrue, ""))
+				t.cluster1.awaitServiceExportCondition(newServiceExportReadyCondition(metav1.ConditionFalse, controller.AwaitingExportReason),
+					newServiceExportReadyCondition(metav1.ConditionTrue, controller.ServiceExportedReason))
 				t.cluster1.ensureNoServiceExportCondition(mcsv1a1.ServiceExportConflict)
 
 				By(fmt.Sprintf("Ensure cluster %q does not try to update the status for a non-existent ServiceExport",
@@ -113,7 +113,7 @@ func testClusterIPServiceInOneCluster() {
 			By("Deleting the service")
 			t.cluster1.deleteService()
 			t.cluster1.awaitServiceUnavailableStatus()
-			t.cluster1.awaitServiceExportCondition(newServiceExportReadyCondition(metav1.ConditionFalse, "NoServiceImport"))
+			t.cluster1.awaitServiceExportCondition(newServiceExportReadyCondition(metav1.ConditionFalse, controller.NoServiceImportReason))
 			t.awaitServiceUnexported(&t.cluster1)
 
 			By("Re-creating the service")
@@ -132,7 +132,7 @@ func testClusterIPServiceInOneCluster() {
 			t.cluster1.updateService()
 
 			t.cluster1.awaitServiceExportCondition(newServiceExportValidCondition(metav1.ConditionFalse, "UnsupportedServiceType"))
-			t.cluster1.awaitServiceExportCondition(newServiceExportReadyCondition(metav1.ConditionFalse, "NoServiceImport"))
+			t.cluster1.awaitServiceExportCondition(newServiceExportReadyCondition(metav1.ConditionFalse, controller.NoServiceImportReason))
 			t.awaitServiceUnexported(&t.cluster1)
 		})
 	})
@@ -507,6 +507,7 @@ func testClusterIPServiceInTwoClusters() {
 	noConflictCondition := &metav1.Condition{
 		Type:   mcsv1a1.ServiceExportConflict,
 		Status: metav1.ConditionFalse,
+		Reason: controller.NoConflictsReason,
 	}
 
 	var t *testDriver
@@ -553,8 +554,9 @@ func testClusterIPServiceInTwoClusters() {
 
 		It("should export the service in both clusters", func() {
 			t.awaitNonHeadlessServiceExported(&t.cluster1, &t.cluster2)
-			t.cluster1.ensureLastServiceExportCondition(newServiceExportReadyCondition(metav1.ConditionTrue, ""))
-			t.cluster1.ensureLastServiceExportCondition(newServiceExportValidCondition(metav1.ConditionTrue, ""))
+			t.cluster1.ensureLastServiceExportCondition(newServiceExportReadyCondition(metav1.ConditionTrue,
+				controller.ServiceExportedReason))
+			t.cluster1.ensureLastServiceExportCondition(newServiceExportValidCondition(metav1.ConditionTrue, controller.ExportValidReason))
 			t.cluster1.ensureNoServiceExportCondition(mcsv1a1.ServiceExportConflict)
 			t.cluster2.ensureNoServiceExportCondition(mcsv1a1.ServiceExportConflict)
 

--- a/pkg/agent/controller/endpoint_slice.go
+++ b/pkg/agent/controller/endpoint_slice.go
@@ -191,7 +191,7 @@ func (c *EndpointSliceController) onLocalEndpointSliceSynced(obj runtime.Object,
 					fmt.Sprintf("Unable to export: %v", err)))
 		} else {
 			c.serviceExportClient.UpdateStatusConditions(ctx, serviceName, serviceNamespace,
-				newServiceExportCondition(constants.ServiceExportReady, metav1.ConditionTrue, "",
+				newServiceExportCondition(constants.ServiceExportReady, metav1.ConditionTrue, ServiceExportedReason,
 					"Service was successfully exported to the broker"))
 
 			c.enqueueForConflictCheck(ctx, endpointSlice, op)

--- a/pkg/agent/controller/reconciliation_test.go
+++ b/pkg/agent/controller/reconciliation_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/federate"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
 	testutil "github.com/submariner-io/admiral/pkg/test"
+	"github.com/submariner-io/lighthouse/pkg/agent/controller"
 	"github.com/submariner-io/lighthouse/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
@@ -189,7 +190,7 @@ var _ = Describe("Reconciliation", func() {
 			t.cluster1.createServiceExport()
 			t.cluster1.start(t, *t.syncerConfig)
 
-			t.cluster1.awaitServiceExportCondition(newServiceExportReadyCondition(metav1.ConditionFalse, "NoServiceImport"))
+			t.cluster1.awaitServiceExportCondition(newServiceExportReadyCondition(metav1.ConditionFalse, controller.NoServiceImportReason))
 			t.awaitServiceUnexported(&t.cluster1)
 		})
 	})

--- a/pkg/agent/controller/service_export_client.go
+++ b/pkg/agent/controller/service_export_client.go
@@ -121,6 +121,9 @@ func (c *ServiceExportClient) mergeConflictCondition(to, from *metav1.Condition)
 
 	if to.Reason != "" {
 		reasons = strings.Split(to.Reason, ",")
+		reasons = goslices.DeleteFunc(reasons, func(s string) bool {
+			return s == NoConflictsReason
+		})
 	}
 
 	if to.Message != "" {
@@ -155,6 +158,7 @@ func (c *ServiceExportClient) mergeConflictCondition(to, from *metav1.Condition)
 	if to.Reason != "" {
 		to.Status = metav1.ConditionTrue
 	} else {
+		to.Reason = NoConflictsReason
 		to.Status = metav1.ConditionFalse
 	}
 

--- a/pkg/agent/controller/service_export_client_test.go
+++ b/pkg/agent/controller/service_export_client_test.go
@@ -173,7 +173,7 @@ var _ = Describe("ServiceExportClient", func() {
 
 				actual = meta.FindStatusCondition(getServiceExport().Status.Conditions, cond.Type)
 				Expect(actual.Status).To(Equal(metav1.ConditionFalse))
-				Expect(actual.Reason).To(BeEmpty())
+				Expect(actual.Reason).To(Equal(controller.NoConflictsReason))
 				Expect(actual.Message).To(BeEmpty())
 			}
 

--- a/pkg/agent/controller/service_export_failures_test.go
+++ b/pkg/agent/controller/service_export_failures_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Service export failures", func() {
 		})
 
 		It("should eventually export the service", func() {
-			t.cluster1.awaitServiceExportCondition(newServiceExportValidCondition(metav1.ConditionTrue, ""))
+			t.cluster1.awaitServiceExportCondition(newServiceExportValidCondition(metav1.ConditionTrue, controller.ExportValidReason))
 			t.cluster1.ensureNoServiceExportCondition(constants.ServiceExportReady)
 
 			t.cluster1.localServiceImportReactor.SetFailOnCreate(nil)

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -333,13 +333,13 @@ func (c *ServiceImportController) onLocalServiceImport(obj runtime.Object, _ int
 	if op == syncer.Delete {
 		c.serviceExportClient.UpdateStatusConditions(ctx, serviceName, serviceImport.Labels[constants.LabelSourceNamespace],
 			newServiceExportCondition(constants.ServiceExportReady,
-				metav1.ConditionFalse, "NoServiceImport", "ServiceImport was deleted"))
+				metav1.ConditionFalse, NoServiceImportReason, "ServiceImport was deleted"))
 
 		return obj, false
 	} else if op == syncer.Create {
 		c.serviceExportClient.tryUpdateStatusConditions(ctx, serviceName, serviceImport.Labels[constants.LabelSourceNamespace],
 			false, newServiceExportCondition(constants.ServiceExportReady,
-				metav1.ConditionFalse, "AwaitingExport", fmt.Sprintf("ServiceImport %sd - awaiting aggregation on the broker", op)))
+				metav1.ConditionFalse, AwaitingExportReason, fmt.Sprintf("ServiceImport %sd - awaiting aggregation on the broker", op)))
 	}
 
 	return obj, false

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -38,12 +38,17 @@ import (
 )
 
 const (
+	ExportValidReason                    = "ServiceExportValid"
 	ExportFailedReason                   = "ExportFailed"
+	ServiceExportedReason                = "ServiceExported"
+	NoServiceImportReason                = "NoServiceImport"
+	AwaitingExportReason                 = "AwaitingExport"
 	TypeConflictReason                   = "ConflictingType"
 	PortConflictReason                   = "ConflictingPorts"
 	SessionAffinityConflictReason        = "ConflictingSessionAffinity"
 	SessionAffinityConfigConflictReason  = "ConflictingSessionAffinityConfig"
 	ClusterSetIPEnablementConflictReason = "ConflictingClusterSetIPEnablement"
+	NoConflictsReason                    = "NoConflicts"
 )
 
 type EndpointSliceListerFn func(selector k8slabels.Selector) []runtime.Object


### PR DESCRIPTION
This is field is now required to be non-empty after the switch to `metav1.Condition`.
