### PR TITLE
Use named Kubernetes versions in GHAs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,14 +47,14 @@ jobs:
         ip_family: ['', 'dual-stack', 'ipv6-stack']
         globalnet: ['', 'globalnet']
         # Run most tests against the latest K8s version
-        k8s_version: ['1.32']
+        k8s_version: ['k8s-latest']
         include:
           # Oldest Kubernetes version thought to work with SubM's Service Discovery.
           # If this breaks, we may advance the oldest-working K8s version instead of fixing it. See:
           # https://submariner.io/development/building-testing/ci-maintenance/
           - k8s_version: '1.21'
           # Bottom of supported K8s version range
-          - k8s_version: '1.29'
+          - k8s_version: 'k8s-oldest-supported'
     steps:
       - name: Check out the repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -19,10 +19,10 @@ jobs:
         globalnet: ['', 'globalnet']
         deploytool: ['operator']
         # Run most tests against the latest K8s version
-        k8s_version: ['1.32']
+        k8s_version: ['k8s-latest']
         include:
           # Bottom of supported K8s version range
-          - k8s_version: '1.29'
+          - k8s_version: 'k8s-oldest-supported'
     steps:
       - name: Check out the repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
This ensures consistent job names that don't change when Kubernetes versions change.

The oldest version with support for service discovery is specific to Lighthouse and is maintained here.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
