### PR TITLE
Remove await all EndpointSlices deleted on E2E cleanup

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -83,11 +83,7 @@ func NewFramework(baseName string) *Framework {
 	BeforeEach(f.BeforeEach)
 
 	AfterEach(func() {
-		namespace := f.Namespace
 		f.AfterEach()
-
-		f.AwaitEndpointSlices(framework.ClusterB, "", namespace, 0, 0)
-		f.AwaitEndpointSlices(framework.ClusterA, "", namespace, 0, 0)
 	})
 
 	return f


### PR DESCRIPTION
This was added by https://github.com/submariner-io/lighthouse/pull/394 but the original motivating issue no longer exists. It can also take significant time (40+ sec) for the EndpointSlices to be deleted via K8s namespace garbage collection.
