### PR TITLE
Automated backport of #1839: Remove await all EndpointSlices deleted on E2E cleanup

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -83,11 +83,7 @@ func NewFramework(baseName string) *Framework {
 	BeforeEach(f.BeforeEach)
 
 	AfterEach(func() {
-		namespace := f.Namespace
 		f.AfterEach()
-
-		f.AwaitEndpointSlices(framework.ClusterB, "", namespace, 0, 0)
-		f.AwaitEndpointSlices(framework.ClusterA, "", namespace, 0, 0)
 	})
 
 	return f


### PR DESCRIPTION
Backport of #1839 on release-0.21.

#1839: Remove await all EndpointSlices deleted on E2E cleanup

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.