### PR TITLE
Automated backport of #1834: Use named Kubernetes versions in GHAs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,14 +47,14 @@ jobs:
         deploytool: ['operator']
         globalnet: ['', 'globalnet']
         # Run most tests against the latest K8s version
-        k8s_version: ['1.28']
+        k8s_version: ['k8s-latest']
         include:
           # Oldest Kubernetes version thought to work with SubM's Service Discovery.
           # If this breaks, we may advance the oldest-working K8s version instead of fixing it. See:
           # https://submariner.io/development/building-testing/ci-maintenance/
           - k8s_version: '1.21'
           # Bottom of supported K8s version range
-          - k8s_version: '1.26'
+          - k8s_version: 'k8s-oldest-supported'
     steps:
       - name: Check out the repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -19,10 +19,10 @@ jobs:
         globalnet: ['', 'globalnet']
         deploytool: ['operator']
         # Run most tests against the latest K8s version
-        k8s_version: ['1.28']
+        k8s_version: ['k8s-latest']
         include:
           # Bottom of supported K8s version range
-          - k8s_version: '1.26'
+          - k8s_version: 'k8s-oldest-supported'
     steps:
       - name: Check out the repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
Backport of #1834 on release-0.17.

#1834: Use named Kubernetes versions in GHAs

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.