### PR TITLE
Apply ServiceExport Conflict condition on all exporting clusters

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Check out the mcs-api repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          ref: efcb2f8996f0a58f21f8b0c855bfdd3cf04d214b
+          ref: 20de0ebd811cde518944ff211372d6bd8b6b8152
           repository: kubernetes-sigs/mcs-api
           path: mcs-api
 

--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -44,7 +44,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	validations "k8s.io/apimachinery/pkg/util/validation"
 	k8snet "k8s.io/utils/net"
-	"k8s.io/utils/ptr"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
@@ -125,16 +124,7 @@ func New(spec *AgentSpecification, syncerConf broker.SyncerConfig, agentConfig A
 	agentController.serviceExportClient.localSyncer = agentController.serviceExportSyncer
 
 	agentController.endpointSliceController, err = newEndpointSliceController(spec, syncerConf, agentController.serviceExportClient,
-		agentController.serviceSyncer, func(serviceName string, serviceNamespace string) *mcsv1a1.ServiceImport {
-			obj, found, _ := agentController.serviceImportController.remoteSyncer.GetResource(
-				brokerAggregatedServiceImportName(serviceName, serviceNamespace),
-				agentController.endpointSliceController.syncer.GetBrokerNamespace())
-			if !found {
-				return nil
-			}
-
-			return obj.(*mcsv1a1.ServiceImport)
-		})
+		agentController.serviceSyncer)
 	if err != nil {
 		return nil, err
 	}
@@ -258,6 +248,7 @@ func (a *Controller) serviceExportToServiceImport(obj runtime.Object, _ int, op 
 
 	serviceImport := a.newServiceImport(svcExport.Name, svcExport.Namespace)
 	serviceImport.Annotations[constants.PublishNotReadyAddresses] = strconv.FormatBool(svc.Spec.PublishNotReadyAddresses)
+	serviceImport.Annotations[constants.ServiceExportTimestamp] = strconv.FormatInt(svcExport.CreationTimestamp.UTC().UnixNano(), 10)
 
 	if svcExport.Annotations[constants.UseClustersetIP] != "" {
 		serviceImport.Annotations[constants.UseClustersetIP] = svcExport.Annotations[constants.UseClustersetIP]
@@ -467,27 +458,6 @@ func (c converter) toUnstructured(obj runtime.Object) *unstructured.Unstructured
 func (c converter) toServiceExport(obj runtime.Object) *mcsv1a1.ServiceExport {
 	to := &mcsv1a1.ServiceExport{}
 	utilruntime.Must(c.scheme.Convert(obj, to, nil))
-
-	return to
-}
-
-func (c converter) toEndpointSlice(obj runtime.Object) *discovery.EndpointSlice {
-	to := &discovery.EndpointSlice{}
-	utilruntime.Must(c.scheme.Convert(obj, to, nil))
-
-	return to
-}
-
-func (c converter) toServicePorts(from []discovery.EndpointPort) []mcsv1a1.ServicePort {
-	to := make([]mcsv1a1.ServicePort, len(from))
-	for i := range from {
-		to[i] = mcsv1a1.ServicePort{
-			Name:        ptr.Deref(from[i].Name, ""),
-			Protocol:    ptr.Deref(from[i].Protocol, ""),
-			Port:        ptr.Deref(from[i].Port, 0),
-			AppProtocol: from[i].AppProtocol,
-		}
-	}
 
 	return to
 }

--- a/pkg/agent/controller/cleanup_test.go
+++ b/pkg/agent/controller/cleanup_test.go
@@ -40,6 +40,7 @@ var _ = Describe("Cleanup", func() {
 	var (
 		t                                          *testDriver
 		localServiceImport1                        *mcsv1a1.ServiceImport
+		localServiceImport1OnBroker                *mcsv1a1.ServiceImport
 		localAggregatedServiceImport1              *mcsv1a1.ServiceImport
 		aggregatedServiceImportOnRemoteBroker1     *mcsv1a1.ServiceImport
 		localServiceImport2                        *mcsv1a1.ServiceImport
@@ -76,6 +77,15 @@ var _ = Describe("Cleanup", func() {
 		}
 
 		test.CreateResource(t.cluster1.localServiceImportClient.Namespace(test.LocalNamespace), localServiceImport1)
+
+		localServiceImport1OnBroker = &mcsv1a1.ServiceImport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "localServiceImport1OnBroker",
+				Labels: localServiceImport1.Labels,
+			},
+		}
+
+		test.CreateResource(t.brokerServiceImportClient.Namespace(test.RemoteNamespace), localServiceImport1OnBroker)
 
 		localAggregatedServiceImport1 = &mcsv1a1.ServiceImport{
 			ObjectMeta: metav1.ObjectMeta{
@@ -233,6 +243,7 @@ var _ = Describe("Cleanup", func() {
 		test.AwaitNoResource(t.cluster1.localServiceImportClient.Namespace(test.LocalNamespace), localServiceImport1.Name)
 		test.AwaitNoResource(t.cluster1.localServiceImportClient.Namespace(serviceNamespace), localAggregatedServiceImport1.Name)
 		test.AwaitNoResource(t.brokerServiceImportClient.Namespace(test.RemoteNamespace), aggregatedServiceImportOnRemoteBroker1.Name)
+		test.AwaitNoResource(t.brokerServiceImportClient.Namespace(test.RemoteNamespace), localServiceImport1OnBroker.Name)
 
 		test.AwaitNoResource(t.cluster1.localServiceImportClient.Namespace(test.LocalNamespace), localServiceImport2.Name)
 		test.AwaitNoResource(t.cluster1.localServiceImportClient.Namespace(serviceNamespace), localAggregatedServiceImport2.Name)

--- a/pkg/agent/controller/clusterip_service_test.go
+++ b/pkg/agent/controller/clusterip_service_test.go
@@ -523,10 +523,6 @@ func testClusterIPServiceInTwoClusters() {
 		t.cluster1.createService()
 		t.cluster1.createServiceExport()
 
-		// Sleep a little before starting the second cluster to ensure its resource CreationTimestamps will be
-		// later than the first cluster to ensure conflict checking is deterministic.
-		time.Sleep(100 * time.Millisecond)
-
 		t.cluster2.start(t, *t.syncerConfig)
 
 		t.cluster2.createServiceEndpointSlices()
@@ -572,7 +568,8 @@ func testClusterIPServiceInTwoClusters() {
 			t.aggregatedServicePorts = []mcsv1a1.ServicePort{port1, port2, port3}
 		})
 
-		It("should correctly set the ports in the aggregated ServiceImport and set the Conflict status condition", func() {
+		It("should correctly set the ports in the aggregated ServiceImport and "+
+			"set the Conflict status condition on all exporting clusters", func() {
 			t.awaitNonHeadlessServiceExported(&t.cluster1, &t.cluster2)
 
 			condition := newServiceExportConflictCondition(controller.PortConflictReason)
@@ -616,7 +613,8 @@ func testClusterIPServiceInTwoClusters() {
 			t.aggregatedServicePorts = []mcsv1a1.ServicePort{port1, port2, port3}
 		})
 
-		It("should correctly set the ports in the aggregated ServiceImport and set the Conflict status condition", func() {
+		It("should correctly set the ports in the aggregated ServiceImport and "+
+			"set the Conflict status condition on all exporting clusters", func() {
 			t.awaitNonHeadlessServiceExported(&t.cluster1, &t.cluster2)
 
 			condition := newServiceExportConflictCondition(controller.PortConflictReason)
@@ -628,6 +626,7 @@ func testClusterIPServiceInTwoClusters() {
 	Context("with differing service types", func() {
 		BeforeEach(func() {
 			t.cluster2.service.Spec.ClusterIP = corev1.ClusterIPNone
+			t.cluster2.serviceExport.CreationTimestamp = metav1.NewTime(time.Now().Add(-time.Second * 5))
 		})
 
 		It("should set the Conflict status condition on the second cluster and not export it", func() {
@@ -636,7 +635,7 @@ func testClusterIPServiceInTwoClusters() {
 
 			t.cluster2.awaitServiceExportCondition(newServiceExportConflictCondition(controller.TypeConflictReason))
 			t.cluster2.awaitServiceExportCondition(newServiceExportReadyCondition(metav1.ConditionFalse, controller.ExportFailedReason))
-			t.cluster1.ensureNoServiceExportCondition(mcsv1a1.ServiceExportConflict)
+			t.cluster1.awaitServiceExportCondition(newServiceExportConflictCondition(controller.TypeConflictReason))
 		})
 
 		Context("initially and after updating the service types to match", func() {
@@ -658,33 +657,31 @@ func testClusterIPServiceInTwoClusters() {
 			t.aggregatedSessionAffinity = t.cluster1.service.Spec.SessionAffinity
 		})
 
-		It("should resolve the conflict and set the Conflict status condition on the conflicting cluster", func() {
+		It("should resolve the conflict and set the Conflict status condition on all exporting clusters", func() {
 			t.awaitAggregatedServiceImport(mcsv1a1.ClusterSetIP, t.cluster1.service.Name, t.cluster1.service.Namespace,
 				&t.cluster1, &t.cluster2)
 
-			t.cluster2.awaitServiceExportCondition(newServiceExportConflictCondition(
-				controller.SessionAffinityConflictReason))
-			t.cluster1.ensureNoServiceExportCondition(mcsv1a1.ServiceExportConflict)
+			t.cluster1.awaitServiceExportCondition(newServiceExportConflictCondition(controller.SessionAffinityConflictReason))
+			t.cluster2.awaitServiceExportCondition(newServiceExportConflictCondition(controller.SessionAffinityConflictReason))
 		})
 
 		Context("initially and after updating the SessionAffinity on the conflicting cluster to match", func() {
-			It("should clear the Conflict status condition on the conflicting cluster", func() {
-				t.cluster2.awaitServiceExportCondition(newServiceExportConflictCondition(
-					controller.SessionAffinityConflictReason))
+			It("should clear the Conflict status condition", func() {
+				t.cluster2.awaitServiceExportCondition(newServiceExportConflictCondition(controller.SessionAffinityConflictReason))
 
 				By("Updating the SessionAffinity on the service")
 
 				t.cluster2.service.Spec.SessionAffinity = t.cluster1.service.Spec.SessionAffinity
 				t.cluster2.updateService()
 
+				t.cluster1.awaitServiceExportCondition(noConflictCondition)
 				t.cluster2.awaitServiceExportCondition(noConflictCondition)
 			})
 		})
 
 		Context("initially and after updating the SessionAffinity on the oldest exporting cluster to match", func() {
-			It("should clear the Conflict status condition on the conflicting cluster", func() {
-				t.cluster2.awaitServiceExportCondition(newServiceExportConflictCondition(
-					controller.SessionAffinityConflictReason))
+			It("should clear the Conflict status condition", func() {
+				t.cluster2.awaitServiceExportCondition(newServiceExportConflictCondition(controller.SessionAffinityConflictReason))
 
 				By("Updating the SessionAffinity on the service")
 
@@ -695,22 +692,22 @@ func testClusterIPServiceInTwoClusters() {
 				t.awaitAggregatedServiceImport(mcsv1a1.ClusterSetIP, t.cluster1.service.Name, t.cluster1.service.Namespace,
 					&t.cluster1, &t.cluster2)
 
+				t.cluster1.awaitServiceExportCondition(noConflictCondition)
 				t.cluster2.awaitServiceExportCondition(noConflictCondition)
 			})
 		})
 
 		Context("initially and after the service on the oldest exporting cluster is unexported", func() {
 			It("should update the SessionAffinity on the aggregated ServiceImport and clear the Conflict status condition", func() {
-				t.cluster2.awaitServiceExportCondition(newServiceExportConflictCondition(
-					controller.SessionAffinityConflictReason))
+				t.cluster2.awaitServiceExportCondition(newServiceExportConflictCondition(controller.SessionAffinityConflictReason))
 
 				By("Unexporting the service")
 
 				t.cluster1.deleteServiceExport()
 
+				t.cluster2.awaitServiceExportCondition(noConflictCondition)
 				t.aggregatedSessionAffinity = t.cluster2.service.Spec.SessionAffinity
 				t.awaitAggregatedServiceImport(mcsv1a1.ClusterSetIP, t.cluster1.service.Name, t.cluster1.service.Namespace, &t.cluster2)
-				t.cluster2.awaitServiceExportCondition(noConflictCondition)
 			})
 		})
 	})
@@ -727,33 +724,31 @@ func testClusterIPServiceInTwoClusters() {
 			t.aggregatedSessionAffinityConfig = t.cluster1.service.Spec.SessionAffinityConfig
 		})
 
-		It("should resolve the conflict and set the Conflict status condition on the conflicting cluster", func() {
+		It("should resolve the conflict and set the Conflict status condition on all exporting clusters", func() {
 			t.awaitAggregatedServiceImport(mcsv1a1.ClusterSetIP, t.cluster1.service.Name, t.cluster1.service.Namespace,
 				&t.cluster1, &t.cluster2)
 
-			t.cluster2.awaitServiceExportCondition(newServiceExportConflictCondition(
-				controller.SessionAffinityConfigConflictReason))
-			t.cluster1.ensureNoServiceExportCondition(mcsv1a1.ServiceExportConflict)
+			t.cluster1.awaitServiceExportCondition(newServiceExportConflictCondition(controller.SessionAffinityConfigConflictReason))
+			t.cluster2.awaitServiceExportCondition(newServiceExportConflictCondition(controller.SessionAffinityConfigConflictReason))
 		})
 
 		Context("initially and after updating the SessionAffinityConfig on the conflicting cluster to match", func() {
-			It("should clear the Conflict status condition on the conflicting cluster", func() {
-				t.cluster2.awaitServiceExportCondition(newServiceExportConflictCondition(
-					controller.SessionAffinityConfigConflictReason))
+			It("should clear the Conflict status condition", func() {
+				t.cluster2.awaitServiceExportCondition(newServiceExportConflictCondition(controller.SessionAffinityConfigConflictReason))
 
 				By("Updating the SessionAffinityConfig on the service")
 
 				t.cluster2.service.Spec.SessionAffinityConfig = t.cluster1.service.Spec.SessionAffinityConfig
 				t.cluster2.updateService()
 
+				t.cluster1.awaitServiceExportCondition(noConflictCondition)
 				t.cluster2.awaitServiceExportCondition(noConflictCondition)
 			})
 		})
 
 		Context("initially and after updating the SessionAffinityConfig on the oldest exporting cluster to match", func() {
-			It("should clear the Conflict status condition on the conflicting cluster", func() {
-				t.cluster2.awaitServiceExportCondition(newServiceExportConflictCondition(
-					controller.SessionAffinityConfigConflictReason))
+			It("should clear the Conflict status condition", func() {
+				t.cluster2.awaitServiceExportCondition(newServiceExportConflictCondition(controller.SessionAffinityConfigConflictReason))
 
 				By("Updating the SessionAffinityConfig on the service")
 
@@ -764,6 +759,7 @@ func testClusterIPServiceInTwoClusters() {
 				t.awaitAggregatedServiceImport(mcsv1a1.ClusterSetIP, t.cluster1.service.Name, t.cluster1.service.Namespace,
 					&t.cluster1, &t.cluster2)
 
+				t.cluster1.awaitServiceExportCondition(noConflictCondition)
 				t.cluster2.awaitServiceExportCondition(noConflictCondition)
 			})
 		})
@@ -776,16 +772,15 @@ func testClusterIPServiceInTwoClusters() {
 			})
 
 			It("should update the SessionAffinity on the aggregated ServiceImport and clear the Conflict status condition", func() {
-				t.cluster2.awaitServiceExportCondition(newServiceExportConflictCondition(
-					controller.SessionAffinityConfigConflictReason))
+				t.cluster2.awaitServiceExportCondition(newServiceExportConflictCondition(controller.SessionAffinityConfigConflictReason))
 
 				By("Unexporting the service")
 
 				t.cluster1.deleteServiceExport()
 
+				t.cluster2.awaitServiceExportCondition(noConflictCondition)
 				t.aggregatedSessionAffinityConfig = t.cluster2.service.Spec.SessionAffinityConfig
 				t.awaitAggregatedServiceImport(mcsv1a1.ClusterSetIP, t.cluster1.service.Name, t.cluster1.service.Namespace, &t.cluster2)
-				t.cluster2.awaitServiceExportCondition(noConflictCondition)
 			})
 		})
 	})
@@ -801,13 +796,14 @@ func testClusterIPServiceInTwoClusters() {
 			t.aggregatedSessionAffinityConfig = t.cluster1.service.Spec.SessionAffinityConfig
 		})
 
-		It("should resolve the conflicts and set the Conflict status condition on the conflicting cluster", func() {
+		It("should resolve the conflicts and set the Conflict status condition on all exporting clusters", func() {
 			t.awaitAggregatedServiceImport(mcsv1a1.ClusterSetIP, t.cluster1.service.Name, t.cluster1.service.Namespace,
 				&t.cluster1, &t.cluster2)
 
+			t.cluster1.awaitServiceExportCondition(newServiceExportConflictCondition(
+				fmt.Sprintf("%s,%s", controller.SessionAffinityConflictReason, controller.SessionAffinityConfigConflictReason)))
 			t.cluster2.awaitServiceExportCondition(newServiceExportConflictCondition(
 				fmt.Sprintf("%s,%s", controller.SessionAffinityConflictReason, controller.SessionAffinityConfigConflictReason)))
-			t.cluster1.ensureNoServiceExportCondition(mcsv1a1.ServiceExportConflict)
 		})
 	})
 
@@ -821,9 +817,9 @@ func testClusterIPServiceInTwoClusters() {
 			t.awaitNonHeadlessServiceExported(&t.cluster1, &t.cluster2)
 		})
 
-		It("should set the Conflict status condition on the second cluster", func() {
+		It("should set the Conflict status condition on all exporting clusters", func() {
+			t.cluster1.awaitServiceExportCondition(newServiceExportConflictCondition(controller.ClusterSetIPEnablementConflictReason))
 			t.cluster2.awaitServiceExportCondition(newServiceExportConflictCondition(controller.ClusterSetIPEnablementConflictReason))
-			t.cluster1.ensureNoServiceExportCondition(mcsv1a1.ServiceExportConflict)
 
 			By("Updating the ServiceExport on the second cluster")
 
@@ -833,6 +829,7 @@ func testClusterIPServiceInTwoClusters() {
 			se.SetAnnotations(map[string]string{constants.UseClustersetIP: strconv.FormatBool(true)})
 			test.UpdateResource(t.cluster2.localServiceExportClient, se)
 
+			t.cluster1.awaitServiceExportCondition(noConflictCondition)
 			t.cluster2.awaitServiceExportCondition(noConflictCondition)
 		})
 
@@ -867,10 +864,10 @@ func testClusterIPServiceInTwoClusters() {
 			t.cluster2.serviceExport.Annotations = map[string]string{constants.UseClustersetIP: strconv.FormatBool(true)}
 		})
 
-		It("should set the Conflict status condition on the second cluster", func() {
+		It("should set the Conflict status condition on all exporting clusters", func() {
 			t.awaitNonHeadlessServiceExported(&t.cluster1, &t.cluster2)
+			t.cluster1.awaitServiceExportCondition(newServiceExportConflictCondition(controller.ClusterSetIPEnablementConflictReason))
 			t.cluster2.awaitServiceExportCondition(newServiceExportConflictCondition(controller.ClusterSetIPEnablementConflictReason))
-			t.cluster1.ensureNoServiceExportCondition(mcsv1a1.ServiceExportConflict)
 		})
 	})
 

--- a/pkg/agent/controller/controller_suite_test.go
+++ b/pkg/agent/controller/controller_suite_test.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -526,13 +527,17 @@ func (c *cluster) awaitServiceExportCondition(expected ...*metav1.Condition) {
 			actual.Reason == expected.Reason
 	}
 
-	actual := make([]*metav1.Condition, len(expected))
 	lastIndex := -1
 
 	for i := range len(expected) - 1 {
 		j := lastIndex + 1
 
-		Eventually(func() interface{} {
+		Eventually(func(g Gomega) {
+			var (
+				found *metav1.Condition
+				all   []*metav1.Condition
+			)
+
 			actions := c.localDynClientFake.Actions()
 			for j < len(actions) {
 				a := actions[j]
@@ -542,44 +547,37 @@ func (c *cluster) awaitServiceExportCondition(expected ...*metav1.Condition) {
 					continue
 				}
 
-				actual[i] = meta.FindStatusCondition(toServiceExport(a.(k8stesting.UpdateActionImpl).Object).Status.Conditions,
+				found = meta.FindStatusCondition(toServiceExport(a.(k8stesting.UpdateActionImpl).Object).Status.Conditions,
 					expected[i].Type)
 
-				if conditionsEqual(actual[i], expected[i]) {
-					lastIndex = j
+				if found != nil {
+					all = append(all, found)
+				}
 
-					return actual[i]
+				if conditionsEqual(found, expected[i]) {
+					lastIndex = j
+					break
 				}
 			}
 
-			return nil
-		}).ShouldNot(BeNil(), "ServiceExport condition not received. Expected: "+resource.ToJSON(expected[i]))
+			g.Expect(found).NotTo(BeNil(), "ServiceExport condition not received. Expected: %s\nActual: %s",
+				resource.ToJSON(expected[i]), resource.ToJSON(all))
+			assertEquivalentConditions(g, found, expected[i])
+		}).Should(Succeed())
 	}
 
 	last := len(expected) - 1
 
-	Eventually(func() interface{} {
+	Eventually(func(g Gomega) {
 		obj, err := c.localServiceExportClient.Get(context.Background(), c.serviceExport.Name, metav1.GetOptions{})
 		Expect(err).To(Succeed())
 		se := toServiceExport(obj)
 
 		c := meta.FindStatusCondition(se.Status.Conditions, expected[last].Type)
 
-		if c != nil {
-			Expect(c.Reason).NotTo(BeEmpty(), resource.ToJSON(c))
-		}
-
-		if conditionsEqual(c, expected[last]) {
-			actual[last] = c
-			return c
-		}
-
-		return nil
-	}).ShouldNot(BeNil(), "ServiceExport condition not found. Expected: "+resource.ToJSON(expected[last]))
-
-	for i := range expected {
-		assertEquivalentConditions(actual[i], expected[i])
-	}
+		g.Expect(c).NotTo(BeNil(), "ServiceExport condition not found for type %q", expected[last].Type)
+		assertEquivalentConditions(g, c, expected[last])
+	}).Should(Succeed())
 }
 
 func (c *cluster) ensureLastServiceExportCondition(expected *metav1.Condition) {
@@ -594,7 +592,7 @@ func (c *cluster) ensureLastServiceExportCondition(expected *metav1.Condition) {
 				toServiceExport(actions[i].(k8stesting.UpdateActionImpl).Object).Status.Conditions, expected.Type)
 
 			if actual != nil {
-				assertEquivalentConditions(actual, expected)
+				assertEquivalentConditions(Default, actual, expected)
 				return i
 			}
 		}
@@ -965,15 +963,16 @@ func endpointSliceClientFor(client dynamic.Interface, namespace string) dynamic.
 	return client.Resource(discovery.SchemeGroupVersion.WithResource("endpointslices")).Namespace(namespace)
 }
 
-func assertEquivalentConditions(actual, expected *metav1.Condition) {
+func assertEquivalentConditions(g Gomega, actual, expected *metav1.Condition) {
 	out := resource.ToJSON(actual)
 
-	Expect(actual.Status).To(Equal(expected.Status), "Actual: %s", out)
-	Expect(actual.LastTransitionTime).To(Not(BeNil()), "Actual: %s", out)
-	Expect(actual.Reason).To(Equal(expected.Reason), "Actual: %s", out)
+	g.Expect(actual.Status).To(Equal(expected.Status), "Condition Status differs. Actual: %s", out)
+	g.Expect(actual.LastTransitionTime).To(Not(BeNil()), "Condition LastTransitionTime. Actual: %s", out)
+	Expect(actual.Reason).NotTo(BeEmpty(), "Condition Reason cannot be empty. Actual: %s", out)
+	g.Expect(actual.Reason).To(Equal(expected.Reason), "Condition Reason differs. Actual: %s", out)
 
 	if expected.Message != "" {
-		Expect(actual.Message).To(ContainSubstring(expected.Message), "Actual: %s", out)
+		g.Expect(actual.Message).To(ContainSubstring(expected.Message), "Condition Message differs. Actual: %s", out)
 	}
 }
 
@@ -1003,6 +1002,18 @@ func (t *testDriver) awaitServiceExported(sType mcsv1a1.ServiceImportType, clust
 	t.awaitAggregatedServiceImport(sType, t.cluster1.service.Name, t.cluster1.service.Namespace, clusters...)
 
 	for _, c := range clusters {
+		Eventually(func(g Gomega) {
+			list, err := t.brokerServiceImportClient.Namespace(test.RemoteNamespace).List(context.TODO(), metav1.ListOptions{
+				LabelSelector: k8slabels.Set(map[string]string{
+					mcsv1a1.LabelServiceName:       t.cluster1.service.Name,
+					constants.LabelSourceNamespace: t.cluster1.service.Namespace,
+					mcsv1a1.LabelSourceCluster:     c.clusterID,
+				}).String(),
+			})
+			Expect(err).To(Succeed())
+			g.Expect(list.Items).To(HaveLen(1), "Local ServiceImport for %q on the broker", c.clusterID)
+		}).Should(Succeed())
+
 		t.awaitEndpointSlice(c)
 
 		c.awaitServiceExportCondition(newServiceExportValidCondition(metav1.ConditionTrue, controller.ExportValidReason))

--- a/pkg/agent/controller/endpoint_slice.go
+++ b/pkg/agent/controller/endpoint_slice.go
@@ -20,39 +20,29 @@ package controller
 
 import (
 	"context"
-	"fmt"
-	"strconv"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
-	"github.com/submariner-io/admiral/pkg/slices"
 	"github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/syncer/broker"
-	"github.com/submariner-io/admiral/pkg/workqueue"
 	"github.com/submariner-io/lighthouse/pkg/constants"
 	discovery "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/utils/ptr"
-	"k8s.io/utils/set"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
 //nolint:gocritic // (hugeParam) This function modifies syncerConf so we don't want to pass by pointer.
 func newEndpointSliceController(spec *AgentSpecification, syncerConfig broker.SyncerConfig,
-	serviceExportClient *ServiceExportClient, serviceSyncer syncer.Interface, aggregatedServiceImportGetter AggregatedServiceImportGetterFn,
+	serviceExportClient *ServiceExportClient, serviceSyncer syncer.Interface,
 ) (*EndpointSliceController, error) {
 	c := &EndpointSliceController{
-		clusterID:                     spec.ClusterID,
-		serviceExportClient:           serviceExportClient,
-		serviceSyncer:                 serviceSyncer,
-		conflictCheckWorkQueue:        workqueue.New("ConflictChecker"),
-		aggregatedServiceImportGetter: aggregatedServiceImportGetter,
+		clusterID:           spec.ClusterID,
+		serviceExportClient: serviceExportClient,
+		serviceSyncer:       serviceSyncer,
 	}
 
 	syncerConfig.LocalNamespace = metav1.NamespaceAll
@@ -68,10 +58,6 @@ func newEndpointSliceController(spec *AgentSpecification, syncerConfig broker.Sy
 			OnSuccessfulSyncToBroker: c.onLocalEndpointSliceSynced,
 			BrokerResourceType:       &discovery.EndpointSlice{},
 			TransformBrokerToLocal:   c.onRemoteEndpointSlice,
-			OnSuccessfulSyncFromBroker: func(obj runtime.Object, op syncer.Operation) bool {
-				c.enqueueForConflictCheck(context.TODO(), obj.(*discovery.EndpointSlice), op)
-				return false
-			},
 		},
 	}
 
@@ -82,9 +68,6 @@ func newEndpointSliceController(spec *AgentSpecification, syncerConfig broker.Sy
 		return nil, errors.Wrap(err, "error creating EndpointSlice syncer")
 	}
 
-	c.serviceImportAggregator = newServiceImportAggregator(c.syncer.GetBrokerClient(), c.syncer.GetBrokerNamespace(),
-		spec.ClusterID, syncerConfig.Scheme)
-
 	return c, nil
 }
 
@@ -93,11 +76,8 @@ func (c *EndpointSliceController) start(stopCh <-chan struct{}) error {
 		return errors.Wrap(err, "error starting EndpointSlice syncer")
 	}
 
-	c.conflictCheckWorkQueue.Run(c.checkForConflicts)
-
 	go func() {
 		<-stopCh
-		c.conflictCheckWorkQueue.ShutDown()
 	}()
 
 	return nil
@@ -177,157 +157,11 @@ func (c *EndpointSliceController) onLocalEndpointSliceSynced(obj runtime.Object,
 		return false
 	}
 
-	var err error
-
-	if op == syncer.Delete {
-		if c.hasNoRemainingEndpointSlices(endpointSlice) {
-			err = c.serviceImportAggregator.updateOnDelete(ctx, serviceName, serviceNamespace)
-		}
-	} else {
-		err = c.serviceImportAggregator.updateOnCreateOrUpdate(ctx, serviceName, serviceNamespace)
-		if err != nil {
-			c.serviceExportClient.UpdateStatusConditions(ctx, serviceName, serviceNamespace,
-				newServiceExportCondition(constants.ServiceExportReady, metav1.ConditionFalse, ExportFailedReason,
-					fmt.Sprintf("Unable to export: %v", err)))
-		} else {
-			c.serviceExportClient.UpdateStatusConditions(ctx, serviceName, serviceNamespace,
-				newServiceExportCondition(constants.ServiceExportReady, metav1.ConditionTrue, ServiceExportedReason,
-					"Service was successfully exported to the broker"))
-
-			c.enqueueForConflictCheck(ctx, endpointSlice, op)
-		}
+	if op != syncer.Delete {
+		c.serviceExportClient.UpdateStatusConditions(ctx, serviceName, serviceNamespace,
+			newServiceExportCondition(constants.ServiceExportReady, metav1.ConditionTrue, ServiceExportedReason,
+				"Service was successfully exported to the broker"))
 	}
 
-	if err != nil {
-		logger.Errorf(err, "Error processing %sd EndpointSlice for service \"%s/%s\"", op, serviceNamespace, serviceName)
-	}
-
-	return err != nil
-}
-
-func (c *EndpointSliceController) hasNoRemainingEndpointSlices(endpointSlice *discovery.EndpointSlice) bool {
-	if endpointSlice.Labels[constants.LabelIsHeadless] == strconv.FormatBool(true) {
-		serviceNS := endpointSlice.Labels[constants.LabelSourceNamespace]
-
-		list := c.syncer.ListLocalResourcesBySelector(&discovery.EndpointSlice{}, k8slabels.SelectorFromSet(map[string]string{
-			constants.LabelSourceNamespace: serviceNS,
-			mcsv1a1.LabelServiceName:       endpointSlice.Labels[mcsv1a1.LabelServiceName],
-			mcsv1a1.LabelSourceCluster:     endpointSlice.Labels[mcsv1a1.LabelSourceCluster],
-		}))
-
-		count := 0
-
-		for _, eps := range list {
-			// Make sure we don't count ones in the broker namespace is co-located on the same cluster.
-			if eps.(*discovery.EndpointSlice).Namespace == serviceNS {
-				count++
-			}
-		}
-
-		return count == 0
-	}
-
-	return true
-}
-
-func (c *EndpointSliceController) checkForConflicts(_, name, namespace string) (bool, error) {
-	ctx := context.TODO()
-
-	localServiceExport := c.serviceExportClient.getLocalInstance(name, namespace)
-	if localServiceExport == nil {
-		return false, nil
-	}
-
-	epsList := c.syncer.ListLocalResourcesBySelector(&discovery.EndpointSlice{}, k8slabels.SelectorFromSet(map[string]string{
-		constants.LabelSourceNamespace: namespace,
-		mcsv1a1.LabelServiceName:       name,
-	}))
-
-	servicePortKey := func(p mcsv1a1.ServicePort) string {
-		return fmt.Sprintf("%s:%s:%d:%s", p.Name, p.Protocol, p.Port, ptr.Deref(p.AppProtocol, ""))
-	}
-
-	var prevServicePorts []mcsv1a1.ServicePort
-	var intersectedServicePorts []mcsv1a1.ServicePort
-	clusterNames := set.New[string]()
-	conflict := false
-
-	for _, o := range epsList {
-		eps := o.(*discovery.EndpointSlice)
-
-		if clusterNames.Has(eps.Labels[mcsv1a1.LabelSourceCluster]) {
-			continue
-		}
-
-		clusterNames.Insert(eps.Labels[mcsv1a1.LabelSourceCluster])
-
-		servicePorts := c.serviceExportClient.toServicePorts(eps.Ports)
-		if prevServicePorts == nil {
-			prevServicePorts = servicePorts
-			intersectedServicePorts = servicePorts
-		} else if !slices.Equivalent(prevServicePorts, servicePorts, servicePortKey) {
-			conflict = true
-		}
-
-		intersectedServicePorts = slices.Intersect(intersectedServicePorts, servicePorts, servicePortKey)
-	}
-
-	if conflict {
-		aggregatedSI := c.aggregatedServiceImportGetter(name, namespace)
-		if aggregatedSI == nil {
-			return true, nil
-		}
-
-		exposedOp := "intersection"
-		exposedPorts := intersectedServicePorts
-
-		if len(aggregatedSI.Spec.IPs) > 0 {
-			exposedPorts = aggregatedSI.Spec.Ports
-			exposedOp = "union"
-		}
-
-		c.serviceExportClient.UpdateStatusConditions(ctx, name, namespace, newServiceExportCondition(
-			mcsv1a1.ServiceExportConflict, metav1.ConditionTrue, PortConflictReason,
-			fmt.Sprintf("The service ports conflict between the constituent clusters %s. "+
-				"The service will expose the %s of all the ports: %s",
-				fmt.Sprintf("[%s]", strings.Join(clusterNames.UnsortedList(), ", ")), exposedOp,
-				servicePortsToString(exposedPorts))))
-	} else if c.serviceExportClient.hasCondition(name, namespace, mcsv1a1.ServiceExportConflict, PortConflictReason) {
-		c.serviceExportClient.UpdateStatusConditions(ctx, name, namespace, newServiceExportCondition(
-			mcsv1a1.ServiceExportConflict, metav1.ConditionFalse, PortConflictReason, ""))
-	}
-
-	return false, nil
-}
-
-func (c *EndpointSliceController) enqueueForConflictCheck(ctx context.Context, eps *discovery.EndpointSlice, op syncer.Operation) {
-	if eps.Labels[constants.LabelIsHeadless] != "false" {
-		return
-	}
-
-	// Since the conflict checking works off of the local cache for efficiency, wait a little bit here for the local cache to be updated
-	// with the latest state of the EndpointSlice.
-	_ = wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, 100*time.Millisecond, true,
-		func(_ context.Context) (bool, error) {
-			_, found, _ := c.syncer.GetLocalResource(eps.Name, eps.Namespace, eps)
-			return (op == syncer.Delete && !found) || (op != syncer.Delete && found), nil
-		},
-	)
-
-	c.conflictCheckWorkQueue.Enqueue(&discovery.EndpointSlice{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      eps.Labels[mcsv1a1.LabelServiceName],
-			Namespace: eps.Labels[constants.LabelSourceNamespace],
-		},
-	})
-}
-
-func servicePortsToString(p []mcsv1a1.ServicePort) string {
-	s := make([]string, len(p))
-	for i := range p {
-		s[i] = fmt.Sprintf("[name: %s, protocol: %s, port: %v, appProtocol: %q]", p[i].Name, p[i].Protocol, p[i].Port,
-			ptr.Deref(p[i].AppProtocol, ""))
-	}
-
-	return strings.Join(s, ", ")
+	return false
 }

--- a/pkg/agent/controller/reconciliation_test.go
+++ b/pkg/agent/controller/reconciliation_test.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -36,7 +35,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic/fake"
-	"k8s.io/client-go/testing"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
@@ -141,19 +139,7 @@ var _ = Describe("Reconciliation", func() {
 			t.cluster1.createServiceEndpointSlices()
 
 			testutil.EnsureNoActionsForResource(&brokerDynClient.Fake, "endpointslices", "delete")
-
-			// For migration cleanup, it may attempt to delete a local legacy ServiceImport from the broker so ignore it.
-			Consistently(func() bool {
-				siActions := brokerDynClient.Fake.Actions()
-				for i := range siActions {
-					if siActions[i].GetResource().Resource == "serviceimports" && siActions[i].GetVerb() == "delete" &&
-						!strings.Contains(siActions[i].(testing.DeleteAction).GetName(), t.cluster1.clusterID) {
-						return true
-					}
-				}
-
-				return false
-			}).Should(BeFalse())
+			testutil.EnsureNoActionsForResource(&brokerDynClient.Fake, "serviceimports", "delete")
 
 			t.awaitNonHeadlessServiceExported(&t.cluster1)
 		})

--- a/pkg/agent/controller/service_export_client.go
+++ b/pkg/agent/controller/service_export_client.go
@@ -204,7 +204,6 @@ func (c *ServiceExportClient) getLocalInstance(name, namespace string) *mcsv1a1.
 	return obj.(*mcsv1a1.ServiceExport)
 }
 
-//nolint:unparam // Ignore `condType` always receives `mcsv1a1.ServiceExportConflict`
 func (c *ServiceExportClient) hasCondition(name, namespace, condType, reason string) bool {
 	se := c.getLocalInstance(name, namespace)
 	if se == nil {

--- a/pkg/agent/controller/service_export_failures_test.go
+++ b/pkg/agent/controller/service_export_failures_test.go
@@ -125,17 +125,4 @@ var _ = Describe("Service export failures", func() {
 			t.awaitServiceUnexported(&t.cluster1)
 		})
 	})
-
-	When("listing the broker EndpointSlices initially fails", func() {
-		BeforeEach(func() {
-			t.brokerEndpointSliceReactor.SetFailOnList(errors.New("mock list error"))
-		})
-
-		It("should eventually export the service", func() {
-			t.cluster1.awaitServiceExportCondition(newServiceExportReadyCondition(metav1.ConditionFalse, controller.ExportFailedReason))
-
-			t.brokerEndpointSliceReactor.SetFailOnList(nil)
-			t.awaitNonHeadlessServiceExported(&t.cluster1)
-		})
-	})
 })

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -21,9 +21,7 @@ package controller
 import (
 	"context"
 	"fmt"
-	"math"
 	"net"
-	"reflect"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -38,17 +36,15 @@ import (
 	"github.com/submariner-io/admiral/pkg/watcher"
 	"github.com/submariner-io/lighthouse/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/cache"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
-
-const timestampAnnotationPrefix = "timestamp.submariner.io/"
 
 //nolint:gocritic // (hugeParam) This function modifies syncerConf so we don't want to pass by pointer.
 func newServiceImportController(spec *AgentSpecification, agentConfig AgentConfig, syncerConfig broker.SyncerConfig,
@@ -156,6 +152,7 @@ func (c *ServiceImportController) start(stopCh <-chan struct{}) error {
 
 	c.reconcileLocalAggregatedServiceImports()
 	c.reconcileRemoteAggregatedServiceImports()
+	c.reconcileLocalServiceImportsOnBroker()
 
 	return nil
 }
@@ -220,6 +217,30 @@ func (c *ServiceImportController) reconcileRemoteAggregatedServiceImports() {
 				mcsv1a1.LabelServiceName:       serviceName,
 				constants.LabelSourceNamespace: si.Annotations[constants.LabelSourceNamespace],
 			}
+
+			retList = append(retList, si)
+		}
+
+		return retList
+	})
+}
+
+func (c *ServiceImportController) reconcileLocalServiceImportsOnBroker() {
+	c.localSyncer.Reconcile(func() []runtime.Object {
+		siList := c.remoteSyncer.ListResources()
+		retList := make([]runtime.Object, 0, len(siList))
+
+		for i := range siList {
+			si := c.converter.toServiceImport(siList[i])
+
+			if si.Annotations[mcsv1a1.LabelServiceName] != "" ||
+				si.Labels[mcsv1a1.LabelSourceCluster] != c.clusterID {
+				// This is an aggregated ServiceImport or another cluster's local ServiceImport.
+				continue
+			}
+
+			si.Namespace = c.localNamespace
+			si.Name = si.Labels[mcsv1a1.LabelServiceName] + "-" + si.Labels[constants.LabelSourceNamespace] + "-" + c.clusterID
 
 			retList = append(retList, si)
 		}
@@ -343,32 +364,17 @@ func (c *ServiceImportController) Distribute(ctx context.Context, obj runtime.Ob
 	serviceName := serviceImportSourceName(localServiceImport)
 	serviceNamespace := localServiceImport.Labels[constants.LabelSourceNamespace]
 
-	localTimestamp := strconv.FormatInt(int64(math.MaxInt64-1), 10)
-
-	// As per the MCS spec, a conflict will be resolved by assigning precedence based on each ServiceExport's
-	// creationTimestamp, from oldest to newest. We don't have access to other cluster's ServiceExports so
-	// instead add our ServiceExport's creationTimestamp as an annotation on the aggregated ServiceImport.
-	localServiceExport := c.serviceExportClient.getLocalInstance(serviceName, serviceNamespace)
-	if localServiceExport != nil {
-		localTimestamp = strconv.FormatInt(localServiceExport.CreationTimestamp.UTC().UnixNano(), 10)
-	}
-
-	timestampAnnotationKey := makeTimestampAnnotationKey(c.clusterID)
-
 	aggregate := &mcsv1a1.ServiceImport{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: brokerAggregatedServiceImportName(serviceName, serviceNamespace),
 			Annotations: map[string]string{
 				mcsv1a1.LabelServiceName:       serviceName,
 				constants.LabelSourceNamespace: serviceNamespace,
-				timestampAnnotationKey:         localTimestamp,
 			},
 		},
 		Spec: mcsv1a1.ServiceImportSpec{
-			Type:                  localServiceImport.Spec.Type,
-			Ports:                 []mcsv1a1.ServicePort{},
-			SessionAffinity:       localServiceImport.Spec.SessionAffinity,
-			SessionAffinityConfig: localServiceImport.Spec.SessionAffinityConfig,
+			Type:  localServiceImport.Spec.Type,
+			Ports: []mcsv1a1.ServicePort{},
 		},
 		Status: mcsv1a1.ServiceImportStatus{
 			Clusters: []mcsv1a1.ClusterStatus{
@@ -384,12 +390,7 @@ func (c *ServiceImportController) Distribute(ctx context.Context, obj runtime.Ob
 
 	useClusterSetIP := c.determineUseClusterSetIP(localServiceImport)
 
-	// Here we create the aggregated ServiceImport on the broker or update the existing instance with our local service
-	// info, but we don't add/merge our local service ports until we've successfully synced our local EndpointSlice to
-	// the broker. This is mainly done b/c the aggregated port information is determined from the constituent clusters'
-	// EndpointSlices, thus each cluster must have a consistent view of all the EndpointSlices in order for the
-	// aggregated port information to be eventually consistent.
-
+	// Create the aggregated ServiceImport on the broker or update the existing instance with our local service info.
 	result, newAggregate, err := util.CreateOrUpdateWithOptions(ctx, util.CreateOrUpdateOptions[*unstructured.Unstructured]{
 		Client: resource.ForDynamic(c.serviceImportAggregator.brokerServiceImportClient()),
 		Obj:    c.converter.toUnstructured(aggregate),
@@ -398,35 +399,18 @@ func (c *ServiceImportController) Distribute(ctx context.Context, obj runtime.Ob
 
 			if localServiceImport.Spec.Type != existing.Spec.Type {
 				typeConflict = true
-				conflictCondition := newServiceExportCondition(
-					mcsv1a1.ServiceExportConflict, metav1.ConditionTrue, TypeConflictReason,
-					fmt.Sprintf("The local service type (%q) does not match the type (%q) of the existing exported service",
-						localServiceImport.Spec.Type, existing.Spec.Type))
-
-				c.serviceExportClient.UpdateStatusConditions(ctx, serviceName, serviceNamespace, conflictCondition,
+				c.serviceExportClient.UpdateStatusConditions(ctx, serviceName, serviceNamespace,
 					newServiceExportCondition(constants.ServiceExportReady,
 						metav1.ConditionFalse, ExportFailedReason, "Unable to export due to an irresolvable conflict"))
 			} else {
-				if c.serviceExportClient.hasCondition(serviceName, serviceNamespace, mcsv1a1.ServiceExportConflict, TypeConflictReason) {
-					c.serviceExportClient.UpdateStatusConditions(ctx, serviceName, serviceNamespace, newServiceExportCondition(
-						mcsv1a1.ServiceExportConflict, metav1.ConditionFalse, TypeConflictReason, ""))
-				}
-
 				if existing.Annotations == nil {
 					existing.Annotations = map[string]string{}
 				}
-
-				existing.Annotations[timestampAnnotationKey] = localTimestamp
 
 				if _, found := existing.Annotations[constants.UseClustersetIP]; !found {
 					// This will happen on migration from pre-clusterset IP version
 					existing.Annotations[constants.UseClustersetIP] = strconv.FormatBool(false)
 				}
-
-				// Update the appropriate aggregated ServiceImport fields if we're the oldest exporting cluster
-				_ = c.updateAggregatedServiceImport(existing, localServiceImport)
-
-				c.checkConflicts(ctx, existing, localServiceImport, &useClusterSetIP)
 
 				var added bool
 
@@ -480,6 +464,10 @@ func (c *ServiceImportController) Distribute(ctx context.Context, obj runtime.Ob
 		logger.V(log.DEBUG).Infof("Created aggregated ServiceImport %s", resource.ToJSON(newAggregate))
 	}
 
+	if err == nil {
+		err = c.createLocalServiceImportOnBroker(ctx, localServiceImport)
+	}
+
 	return err
 }
 
@@ -493,25 +481,69 @@ func (c *ServiceImportController) Delete(ctx context.Context, obj runtime.Object
 
 	logger.V(log.DEBUG).Infof("Delete for local ServiceImport %q", key)
 
-	// For consistency, we let the EndpointSlice controller handle removing the local service info from the aggregated
-	// ServiceImport on the broker after we delete the local EndpointSlice here. However, if the Endpoints controller
-	// was never started or if there are no local EndpointSlices, which can happen during reconciliation on startup or
-	// during clean up on uninstall, then we handle removal here.
-
-	found, err := c.stopEndpointsController(ctx, key)
+	_, err := c.stopEndpointsController(ctx, key)
 	if err != nil {
 		return err
 	}
 
-	if !found {
-		err = c.serviceImportAggregator.updateOnDelete(ctx, serviceImportSourceName(localServiceImport),
-			localServiceImport.Labels[constants.LabelSourceNamespace])
+	err = c.serviceImportAggregator.updateOnDelete(ctx, serviceImportSourceName(localServiceImport),
+		localServiceImport.Labels[constants.LabelSourceNamespace])
+	if err != nil {
+		return err
 	}
 
-	return err
+	list, err := c.serviceImportAggregator.brokerServiceImportClient().List(ctx, metav1.ListOptions{
+		LabelSelector: k8slabels.Set(map[string]string{
+			mcsv1a1.LabelServiceName:       localServiceImport.Labels[mcsv1a1.LabelServiceName],
+			constants.LabelSourceNamespace: localServiceImport.Labels[constants.LabelSourceNamespace],
+			mcsv1a1.LabelSourceCluster:     localServiceImport.Labels[mcsv1a1.LabelSourceCluster],
+		}).String(),
+	})
+	if err != nil {
+		return errors.Wrap(err, "error listing ServiceImport resources for delete")
+	}
+
+	if len(list.Items) == 0 {
+		return nil
+	}
+
+	return errors.Wrapf(c.serviceImportAggregator.brokerServiceImportClient().Delete(ctx, list.Items[0].GetName(), metav1.DeleteOptions{}),
+		"error deleting ServiceImport %q on the broker", list.Items[0].GetName())
 }
 
-func (c *ServiceImportController) onRemoteServiceImport(obj runtime.Object, _ int, _ syncer.Operation) (runtime.Object, bool) {
+func (c *ServiceImportController) createLocalServiceImportOnBroker(ctx context.Context, localServiceImport *mcsv1a1.ServiceImport) error {
+	useClusterSetIP := c.determineUseClusterSetIP(localServiceImport)
+
+	localServiceImport.ObjectMeta = metav1.ObjectMeta{
+		GenerateName: serviceImportSourceName(localServiceImport) + "-",
+		Labels:       localServiceImport.Labels,
+		Annotations:  localServiceImport.Annotations,
+	}
+
+	localServiceImport.Annotations[constants.UseClustersetIP] = strconv.FormatBool(useClusterSetIP)
+	localServiceImport.Status = mcsv1a1.ServiceImportStatus{}
+
+	result, si, err := util.CreateOrUpdateWithOptions(ctx, util.CreateOrUpdateOptions[*unstructured.Unstructured]{
+		Client: resource.ForDynamic(c.serviceImportAggregator.brokerServiceImportClient()),
+		Obj:    c.converter.toUnstructured(localServiceImport),
+		IdentifyingLabels: map[string]string{
+			mcsv1a1.LabelServiceName:       localServiceImport.Labels[mcsv1a1.LabelServiceName],
+			constants.LabelSourceNamespace: localServiceImport.Labels[constants.LabelSourceNamespace],
+			mcsv1a1.LabelSourceCluster:     localServiceImport.Labels[mcsv1a1.LabelSourceCluster],
+		},
+		MutateOnUpdate: func(existing *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+			return util.CopyImmutableMetadata(existing, c.converter.toUnstructured(localServiceImport)), nil
+		},
+	})
+
+	if result == util.OperationResultCreated {
+		logger.V(log.DEBUG).Infof("Created local ServiceImport %q on the broker", si.GetName())
+	}
+
+	return err //nolint:wrapcheck // No need to wrap
+}
+
+func (c *ServiceImportController) onRemoteServiceImport(obj runtime.Object, _ int, op syncer.Operation) (runtime.Object, bool) {
 	serviceImport := obj.(*mcsv1a1.ServiceImport)
 
 	serviceName, ok := serviceImport.Annotations[mcsv1a1.LabelServiceName]
@@ -526,56 +558,64 @@ func (c *ServiceImportController) onRemoteServiceImport(obj runtime.Object, _ in
 		return serviceImport, false
 	}
 
-	return nil, false
+	ctx := context.TODO()
+	serviceName = serviceImport.Labels[mcsv1a1.LabelServiceName]
+	serviceNamespace := serviceImport.Labels[constants.LabelSourceNamespace]
+
+	localServiceExport := c.serviceExportClient.getLocalInstance(serviceName, serviceNamespace)
+	if localServiceExport == nil {
+		return nil, false
+	}
+
+	aggregatedObj, err := c.serviceImportAggregator.brokerServiceImportClient().Get(ctx,
+		brokerAggregatedServiceImportName(serviceName, serviceNamespace), metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil, false
+	}
+
+	if err != nil {
+		logger.Errorf(err, "Error retrieving aggregated ServiceImport \"%s%s\"", serviceNamespace, serviceName)
+		return nil, true
+	}
+
+	aggregatedServiceImport := c.converter.toServiceImport(aggregatedObj)
+
+	key, _ := cache.MetaNamespaceKeyFunc(serviceImport)
+
+	logger.V(log.DEBUG).Infof("ServiceImport %q from cluster %q %sd on broker",
+		key, serviceImport.Labels[mcsv1a1.LabelSourceCluster], op)
+
+	precedentServiceImport := c.checkForConflicts(ctx, aggregatedServiceImport)
+	if precedentServiceImport == nil {
+		return nil, false
+	}
+
+	isPrecedentCluster := precedentServiceImport.Labels[mcsv1a1.LabelSourceCluster] == c.clusterID
+	if isPrecedentCluster {
+		err = c.serviceImportAggregator.update(ctx, serviceName, serviceNamespace,
+			func(aggregated *mcsv1a1.ServiceImport) error {
+				aggregated.Spec.SessionAffinity = precedentServiceImport.Spec.SessionAffinity
+				aggregated.Spec.SessionAffinityConfig = precedentServiceImport.Spec.SessionAffinityConfig
+				aggregated.Spec.Ports = precedentServiceImport.Spec.Ports
+
+				return nil
+			})
+		if err != nil {
+			logger.Errorf(err, "Error updating aggregated ServiceImport \"%s%s\"", serviceNamespace, serviceName)
+		}
+	}
+
+	return nil, err != nil
 }
 
 func (c *ServiceImportController) onSuccessfulSyncFromBroker(synced runtime.Object, op syncer.Operation) bool {
-	ctx := context.TODO()
-
 	aggregatedServiceImport := synced.(*mcsv1a1.ServiceImport)
 
 	if op == syncer.Delete {
 		if c.isIPInClustersetCIDR(aggregatedServiceImport) {
 			_ = c.clustersetIPPool.Release(aggregatedServiceImport.Spec.IPs[0])
 		}
-
-		return false
 	}
-
-	// Check for conflicts with the local ServiceImport
-
-	siList := c.localSyncer.ListResourcesBySelector(k8slabels.SelectorFromSet(map[string]string{
-		mcsv1a1.LabelServiceName:       aggregatedServiceImport.Name,
-		constants.LabelSourceNamespace: aggregatedServiceImport.Namespace,
-		mcsv1a1.LabelSourceCluster:     c.clusterID,
-	}))
-
-	if len(siList) == 0 {
-		// Service not exported locally.
-		return false
-	}
-
-	localServiceImport := siList[0].(*mcsv1a1.ServiceImport)
-
-	// This handles the case where the previously oldest exporting cluster has unexported its service. If we're now
-	// the oldest exporting cluster, then update the appropriate aggregated ServiceImport fields to match those of
-	// our service's.
-	if c.updateAggregatedServiceImport(aggregatedServiceImport, localServiceImport) {
-		err := c.serviceImportAggregator.update(ctx, aggregatedServiceImport.Name, aggregatedServiceImport.Namespace,
-			func(aggregated *mcsv1a1.ServiceImport) error {
-				aggregated.Spec.SessionAffinity = localServiceImport.Spec.SessionAffinity
-				aggregated.Spec.SessionAffinityConfig = localServiceImport.Spec.SessionAffinityConfig
-
-				return nil
-			})
-		if err != nil {
-			logger.Errorf(err, "error updating aggregated ServiceImport on broker sync")
-
-			return true
-		}
-	}
-
-	c.checkConflicts(ctx, aggregatedServiceImport, localServiceImport, nil)
 
 	return false
 }
@@ -606,75 +646,6 @@ func (c *ServiceImportController) allocateClusterSetIPIfNeeded(existingIP string
 	return existingIP, nil
 }
 
-func (c *ServiceImportController) checkConflicts(ctx context.Context, aggregated, local *mcsv1a1.ServiceImport, useClusterSetIP *bool) {
-	var conditions []metav1.Condition
-
-	serviceName := local.Labels[mcsv1a1.LabelServiceName]
-	serviceNamespace := local.Labels[constants.LabelSourceNamespace]
-
-	precedentCluster := findClusterWithOldestTimestamp(aggregated.Annotations)
-
-	if local.Spec.SessionAffinity != aggregated.Spec.SessionAffinity {
-		conditions = append(conditions, newServiceExportCondition(mcsv1a1.ServiceExportConflict, metav1.ConditionTrue,
-			SessionAffinityConflictReason,
-			fmt.Sprintf("The local service SessionAffinity %q conflicts with other constituent clusters. "+
-				"Using SessionAffinity %q from the oldest exported service in cluster %q.",
-				local.Spec.SessionAffinity, aggregated.Spec.SessionAffinity, precedentCluster)))
-	} else if c.serviceExportClient.hasCondition(serviceName, serviceNamespace, mcsv1a1.ServiceExportConflict,
-		SessionAffinityConflictReason) {
-		conditions = append(conditions, newServiceExportCondition(
-			mcsv1a1.ServiceExportConflict, metav1.ConditionFalse, SessionAffinityConflictReason, ""))
-	}
-
-	if !reflect.DeepEqual(local.Spec.SessionAffinityConfig, aggregated.Spec.SessionAffinityConfig) {
-		conditions = append(conditions, newServiceExportCondition(mcsv1a1.ServiceExportConflict, metav1.ConditionTrue,
-			SessionAffinityConfigConflictReason,
-			fmt.Sprintf("The local service SessionAffinityConfig %q conflicts with other constituent clusters. "+
-				"Using SessionAffinityConfig %q from the oldest exported service in cluster %q.",
-				toSessionAffinityConfigString(local.Spec.SessionAffinityConfig),
-				toSessionAffinityConfigString(aggregated.Spec.SessionAffinityConfig), precedentCluster)))
-	} else if c.serviceExportClient.hasCondition(serviceName, serviceNamespace, mcsv1a1.ServiceExportConflict,
-		SessionAffinityConfigConflictReason) {
-		conditions = append(conditions, newServiceExportCondition(
-			mcsv1a1.ServiceExportConflict, metav1.ConditionFalse, SessionAffinityConfigConflictReason, ""))
-	}
-
-	if aggregated.Spec.Type == mcsv1a1.ClusterSetIP && useClusterSetIP != nil {
-		if aggregated.Annotations[constants.UseClustersetIP] != strconv.FormatBool(*useClusterSetIP) {
-			clusterName := aggregated.Annotations[constants.ClustersetIPAllocatedBy]
-			if clusterName == "" {
-				clusterName = precedentCluster
-			}
-
-			conditions = append(conditions, newServiceExportCondition(mcsv1a1.ServiceExportConflict, metav1.ConditionTrue,
-				ClusterSetIPEnablementConflictReason,
-				fmt.Sprintf("The local service clusterset IP enablement setting %q conflicts with the enablement setting %q"+
-					" determined by the first exporting cluster %q.",
-					strconv.FormatBool(*useClusterSetIP), aggregated.Annotations[constants.UseClustersetIP], clusterName)))
-		} else if c.serviceExportClient.hasCondition(serviceName, serviceNamespace, mcsv1a1.ServiceExportConflict,
-			ClusterSetIPEnablementConflictReason) {
-			conditions = append(conditions, newServiceExportCondition(
-				mcsv1a1.ServiceExportConflict, metav1.ConditionFalse, ClusterSetIPEnablementConflictReason, ""))
-		}
-	}
-
-	c.serviceExportClient.UpdateStatusConditions(ctx, serviceName, serviceNamespace, conditions...)
-}
-
-func (c *ServiceImportController) updateAggregatedServiceImport(aggregated, local *mcsv1a1.ServiceImport) bool {
-	oldestCluster := findClusterWithOldestTimestamp(aggregated.Annotations)
-	if oldestCluster != sanitizeClusterID(c.clusterID) {
-		return false
-	}
-
-	origSpec := aggregated.Spec
-
-	aggregated.Spec.SessionAffinity = local.Spec.SessionAffinity
-	aggregated.Spec.SessionAffinityConfig = local.Spec.SessionAffinityConfig
-
-	return !reflect.DeepEqual(origSpec, aggregated.Spec)
-}
-
 func (c *ServiceImportController) localServiceImportLister(transform func(si *mcsv1a1.ServiceImport) runtime.Object) []runtime.Object {
 	siList := c.localSyncer.ListResources()
 
@@ -691,35 +662,6 @@ func (c *ServiceImportController) localServiceImportLister(transform func(si *mc
 	}
 
 	return retList
-}
-
-func findClusterWithOldestTimestamp(from map[string]string) string {
-	names := getClusterNamesOrderedByTimestamp(from)
-	if len(names) > 0 {
-		return names[0]
-	}
-
-	return ""
-}
-
-func toSessionAffinityConfigString(c *corev1.SessionAffinityConfig) string {
-	if c != nil && c.ClientIP != nil && c.ClientIP.TimeoutSeconds != nil {
-		return fmt.Sprintf("ClientIP TimeoutSeconds: %d", *c.ClientIP.TimeoutSeconds)
-	}
-
-	return "none"
-}
-
-func makeTimestampAnnotationKey(clusterID string) string {
-	return timestampAnnotationPrefix + sanitizeClusterID(clusterID)
-}
-
-func sanitizeClusterID(clusterID string) string {
-	if len(clusterID) > validation.DNS1123LabelMaxLength {
-		clusterID = clusterID[:validation.DNS1123LabelMaxLength]
-	}
-
-	return resource.EnsureValidName(clusterID)
 }
 
 func serviceImportSourceName(serviceImport *mcsv1a1.ServiceImport) string {

--- a/pkg/agent/controller/service_import_aggregator.go
+++ b/pkg/agent/controller/service_import_aggregator.go
@@ -20,21 +20,15 @@ package controller
 
 import (
 	"context"
-	goslices "slices"
-	"strconv"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
 	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/slices"
 	"github.com/submariner-io/admiral/pkg/util"
-	"github.com/submariner-io/lighthouse/pkg/constants"
-	discovery "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/utils/ptr"
@@ -51,56 +45,6 @@ func newServiceImportAggregator(brokerClient dynamic.Interface, brokerNamespace,
 	}
 }
 
-func (a *ServiceImportAggregator) updateOnCreateOrUpdate(ctx context.Context, name, namespace string) error {
-	return a.update(ctx, name, namespace, func(existing *mcsv1a1.ServiceImport) error {
-		return a.setServicePorts(ctx, existing)
-	})
-}
-
-func (a *ServiceImportAggregator) setServicePorts(ctx context.Context, si *mcsv1a1.ServiceImport) error {
-	// We don't set the port info for headless services.
-	if si.Spec.Type != mcsv1a1.ClusterSetIP {
-		return nil
-	}
-
-	serviceName := si.Annotations[mcsv1a1.LabelServiceName]
-	serviceNamespace := si.Annotations[constants.LabelSourceNamespace]
-
-	list, err := a.brokerClient.Resource(endpointSliceGVR).Namespace(a.brokerNamespace).List(ctx, metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(map[string]string{
-			discovery.LabelManagedBy:       constants.LabelValueManagedBy,
-			constants.LabelSourceNamespace: serviceNamespace,
-			mcsv1a1.LabelServiceName:       serviceName,
-		}).String(),
-	})
-	if err != nil {
-		return errors.Wrapf(err, "error listing the EndpointSlices associated with service %s/%s",
-			serviceNamespace, serviceName)
-	}
-
-	portsByCluster := map[string][]mcsv1a1.ServicePort{}
-
-	for i := range list.Items {
-		eps := a.converter.toEndpointSlice(&list.Items[i])
-		portsByCluster[eps.Labels[mcsv1a1.LabelSourceCluster]] = a.converter.toServicePorts(eps.Ports)
-	}
-
-	// Sort the clusters by their ServiceExport timestamps stored in the ServiceImport annotations so conflicting ports are
-	// resolved by taking the oldest as per the MCS spec's conflict resolution policy.
-
-	si.Spec.Ports = make([]mcsv1a1.ServicePort, 0)
-	for _, clusterName := range getClusterNamesOrderedByTimestamp(si.Annotations) {
-		ports := portsByCluster[clusterName]
-		si.Spec.Ports = slices.Union(si.Spec.Ports, ports, func(p mcsv1a1.ServicePort) string {
-			return p.Name
-		})
-	}
-
-	logger.V(log.DEBUG).Infof("Calculated ports for aggregated ServiceImport %q: %s", si.Name, servicePortsToString(si.Spec.Ports))
-
-	return nil
-}
-
 func (a *ServiceImportAggregator) updateOnDelete(ctx context.Context, name, namespace string) error {
 	return a.update(ctx, name, namespace, func(existing *mcsv1a1.ServiceImport) error {
 		var removed bool
@@ -114,9 +58,7 @@ func (a *ServiceImportAggregator) updateOnDelete(ctx context.Context, name, name
 		logger.V(log.DEBUG).Infof("Removed cluster name %q from aggregated ServiceImport %q. New status: %#v",
 			a.clusterID, existing.Name, existing.Status.Clusters)
 
-		delete(existing.Annotations, makeTimestampAnnotationKey(a.clusterID))
-
-		return a.setServicePorts(ctx, existing)
+		return nil
 	})
 }
 
@@ -163,47 +105,4 @@ func (a *ServiceImportAggregator) brokerServiceImportClient() dynamic.ResourceIn
 
 func clusterStatusKey(c mcsv1a1.ClusterStatus) string {
 	return c.Cluster
-}
-
-type clusterSortInfo struct {
-	name      string
-	timestamp int64
-}
-
-func getClusterNamesOrderedByTimestamp(from map[string]string) []string {
-	info := make([]clusterSortInfo, 0, len(from))
-
-	for k, v := range from {
-		cluster, found := strings.CutPrefix(k, timestampAnnotationPrefix)
-		if !found {
-			continue
-		}
-
-		t, err := strconv.ParseInt(v, 10, 64)
-		if err != nil {
-			logger.Warningf("Invalid timestamp annotation value %q for cluster %q", v, cluster)
-			continue
-		}
-
-		info = append(info, clusterSortInfo{name: cluster, timestamp: t})
-	}
-
-	goslices.SortFunc(info, func(a, b clusterSortInfo) int {
-		if a.timestamp == b.timestamp {
-			return strings.Compare(a.name, b.name)
-		}
-
-		if a.timestamp < b.timestamp {
-			return -1
-		}
-
-		return 1
-	})
-
-	sortedNames := make([]string, len(info))
-	for i := range info {
-		sortedNames[i] = info[i].name
-	}
-
-	return sortedNames
 }

--- a/pkg/agent/controller/service_import_conflict.go
+++ b/pkg/agent/controller/service_import_conflict.go
@@ -1,0 +1,227 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"reflect"
+	goslices "slices"
+	"strconv"
+	"strings"
+
+	"github.com/submariner-io/admiral/pkg/slices"
+	"github.com/submariner-io/lighthouse/pkg/constants"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"k8s.io/utils/set"
+	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+)
+
+func (c *ServiceImportController) checkForConflicts(ctx context.Context, aggregatedServiceImport *mcsv1a1.ServiceImport,
+) *mcsv1a1.ServiceImport {
+	serviceName := aggregatedServiceImport.Annotations[mcsv1a1.LabelServiceName]
+	serviceNamespace := aggregatedServiceImport.Annotations[constants.LabelSourceNamespace]
+
+	siList := c.remoteSyncer.ListResourcesBySelector(k8slabels.SelectorFromSet(map[string]string{
+		mcsv1a1.LabelServiceName:       serviceName,
+		constants.LabelSourceNamespace: serviceNamespace,
+	}))
+
+	if len(siList) == 0 {
+		return nil
+	}
+
+	sortServiceImportsByTimestamp(siList, aggregatedServiceImport.Spec.Type)
+
+	servicePortKey := func(p mcsv1a1.ServicePort) string {
+		return fmt.Sprintf("%s:%s:%d:%s", p.Name, p.Protocol, p.Port, ptr.Deref(p.AppProtocol, ""))
+	}
+
+	precedentServiceImport := siList[0].(*mcsv1a1.ServiceImport)
+	intersectionOfServicePorts := precedentServiceImport.Spec.Ports
+	unionOfServicePorts := precedentServiceImport.Spec.Ports
+
+	exportingClusters := set.New[string](precedentServiceImport.Labels[mcsv1a1.LabelSourceCluster])
+	conflictingServiceTypeClusters := set.New[string]()
+	portConflict := false
+	conflictingSessionAffinityClusters := set.New[string]()
+	conflictingSessionAffinityConfigClusters := set.New[string]()
+	conflictingClusterSetIPEnablementClusters := set.New[string]()
+
+	for i := 1; i < len(siList); i++ {
+		serviceImport := siList[i].(*mcsv1a1.ServiceImport)
+
+		exportingClusters.Insert(serviceImport.Labels[mcsv1a1.LabelSourceCluster])
+
+		// If the service type differs then we don't actually export it so skip the rest of the checking.
+		if serviceImport.Spec.Type != precedentServiceImport.Spec.Type {
+			conflictingServiceTypeClusters.Insert(serviceImport.Labels[mcsv1a1.LabelSourceCluster])
+			continue
+		}
+
+		if serviceImport.Spec.SessionAffinity != precedentServiceImport.Spec.SessionAffinity {
+			conflictingSessionAffinityClusters.Insert(serviceImport.Labels[mcsv1a1.LabelSourceCluster])
+		}
+
+		if !reflect.DeepEqual(serviceImport.Spec.SessionAffinityConfig, precedentServiceImport.Spec.SessionAffinityConfig) {
+			conflictingSessionAffinityConfigClusters.Insert(serviceImport.Labels[mcsv1a1.LabelSourceCluster])
+		}
+
+		if serviceImport.Annotations[constants.UseClustersetIP] != precedentServiceImport.Annotations[constants.UseClustersetIP] {
+			conflictingClusterSetIPEnablementClusters.Insert(serviceImport.Labels[mcsv1a1.LabelSourceCluster])
+		}
+
+		unionOfServicePorts = slices.Union(unionOfServicePorts, serviceImport.Spec.Ports, func(p mcsv1a1.ServicePort) string {
+			return p.Name
+		})
+
+		intersectionOfServicePorts = slices.Intersect(intersectionOfServicePorts, serviceImport.Spec.Ports, servicePortKey)
+
+		portConflict = portConflict || !slices.Equivalent(precedentServiceImport.Spec.Ports, serviceImport.Spec.Ports, servicePortKey)
+	}
+
+	var conditions []metav1.Condition
+
+	toStringClusterNames := func(names set.Set[string]) string {
+		return fmt.Sprintf("[%s]", strings.Join(names.UnsortedList(), ", "))
+	}
+
+	addConflictCondition := func(conflict bool, reason string, message func() string) {
+		if conflict {
+			conditions = append(conditions, newServiceExportCondition(mcsv1a1.ServiceExportConflict, metav1.ConditionTrue,
+				reason, message()))
+		} else if c.serviceExportClient.hasCondition(serviceName, serviceNamespace, mcsv1a1.ServiceExportConflict, reason) {
+			conditions = append(conditions, newServiceExportCondition(
+				mcsv1a1.ServiceExportConflict, metav1.ConditionFalse, reason, ""))
+		}
+	}
+
+	addConflictCondition(len(conflictingServiceTypeClusters) > 0, TypeConflictReason, func() string {
+		return fmt.Sprintf("The service type conflicts between the constituent clusters %s. "+
+			"Using the setting %q determined by the first exporting cluster %q (clusters %s disagree).",
+			toStringClusterNames(exportingClusters), aggregatedServiceImport.Spec.Type,
+			aggregatedServiceImport.Status.Clusters[0].Cluster, toStringClusterNames(conflictingServiceTypeClusters))
+	})
+
+	addConflictCondition(portConflict, PortConflictReason, func() string {
+		exposedOp := "intersection"
+		exposedPorts := intersectionOfServicePorts
+
+		if len(aggregatedServiceImport.Spec.IPs) > 0 {
+			exposedPorts = aggregatedServiceImport.Spec.Ports
+			exposedOp = "union"
+		}
+
+		return fmt.Sprintf("The service ports conflict between the constituent clusters %s. "+
+			"The service will expose the %s of all the ports: %s.", toStringClusterNames(exportingClusters), exposedOp,
+			servicePortsToString(exposedPorts))
+	})
+
+	addConflictCondition(len(conflictingSessionAffinityClusters) > 0, SessionAffinityConflictReason, func() string {
+		return fmt.Sprintf("The service SessionAffinity conflicts between the constituent clusters %s. "+
+			"Using SessionAffinity %q from the oldest exporting service in cluster %q (clusters %s disagree).",
+			toStringClusterNames(exportingClusters), precedentServiceImport.Spec.SessionAffinity,
+			precedentServiceImport.Labels[mcsv1a1.LabelSourceCluster], toStringClusterNames(conflictingSessionAffinityClusters))
+	})
+
+	addConflictCondition(len(conflictingSessionAffinityConfigClusters) > 0, SessionAffinityConfigConflictReason, func() string {
+		return fmt.Sprintf("The service SessionAffinityConfig conflicts between the constituent clusters %s. "+
+			"Using SessionAffinityConfig %q from the oldest exporting service in cluster %q (clusters %s disagree).",
+			toStringClusterNames(exportingClusters), toSessionAffinityConfigString(precedentServiceImport.Spec.SessionAffinityConfig),
+			precedentServiceImport.Labels[mcsv1a1.LabelSourceCluster], toStringClusterNames(conflictingSessionAffinityConfigClusters))
+	})
+
+	addConflictCondition(len(conflictingClusterSetIPEnablementClusters) > 0, ClusterSetIPEnablementConflictReason, func() string {
+		clusterName := aggregatedServiceImport.Annotations[constants.ClustersetIPAllocatedBy]
+		if clusterName == "" {
+			clusterName = precedentServiceImport.Labels[mcsv1a1.LabelSourceCluster]
+		}
+
+		return fmt.Sprintf("The service clusterset IP enablement setting conflicts between the constituent clusters %s. "+
+			"Using the setting %q determined by the first exporting cluster %q (clusters %s disagree).",
+			toStringClusterNames(exportingClusters), aggregatedServiceImport.Annotations[constants.UseClustersetIP], clusterName,
+			toStringClusterNames(conflictingClusterSetIPEnablementClusters))
+	})
+
+	c.serviceExportClient.UpdateStatusConditions(ctx, serviceName, serviceNamespace, conditions...)
+
+	precedentServiceImport.Spec.Ports = unionOfServicePorts
+
+	return precedentServiceImport
+}
+
+func servicePortsToString(p []mcsv1a1.ServicePort) string {
+	s := make([]string, len(p))
+	for i := range p {
+		s[i] = fmt.Sprintf("[name: %s, protocol: %s, port: %v, appProtocol: %q]", p[i].Name, p[i].Protocol, p[i].Port,
+			ptr.Deref(p[i].AppProtocol, ""))
+	}
+
+	return strings.Join(s, ", ")
+}
+
+func toSessionAffinityConfigString(c *corev1.SessionAffinityConfig) string {
+	if c != nil && c.ClientIP != nil && c.ClientIP.TimeoutSeconds != nil {
+		return fmt.Sprintf("ClientIP TimeoutSeconds: %d", *c.ClientIP.TimeoutSeconds)
+	}
+
+	return "none"
+}
+
+func parseTimestamp(si *mcsv1a1.ServiceImport) int64 {
+	v := si.Annotations[constants.ServiceExportTimestamp]
+
+	t, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		logger.Warningf("Invalid %q annotation value %q for ServiceImport %q", constants.ServiceExportTimestamp, v, si.Name)
+		return math.MaxInt64
+	}
+
+	return t
+}
+
+func sortServiceImportsByTimestamp(siList []runtime.Object, aggregatedType mcsv1a1.ServiceImportType) {
+	goslices.SortFunc(siList, func(a, b runtime.Object) int {
+		siA := a.(*mcsv1a1.ServiceImport)
+		siB := b.(*mcsv1a1.ServiceImport)
+
+		// Don't allow an unexported cluster's service to become precedent.
+		if siA.Spec.Type != aggregatedType {
+			return 1
+		}
+
+		if siB.Spec.Type != aggregatedType {
+			return -1
+		}
+
+		tsA := parseTimestamp(siA)
+		tsB := parseTimestamp(siB)
+
+		if tsA == tsB {
+			return strings.Compare(siA.Labels[mcsv1a1.LabelSourceCluster], siB.Labels[mcsv1a1.LabelSourceCluster])
+		}
+
+		return int(tsA - tsB)
+	})
+}

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -27,7 +27,6 @@ import (
 	"github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/syncer/broker"
 	"github.com/submariner-io/admiral/pkg/watcher"
-	"github.com/submariner-io/admiral/pkg/workqueue"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
@@ -132,13 +131,10 @@ type ServiceEndpointSliceController struct {
 
 // EndpointSliceController encapsulates a syncer that syncs EndpointSlices to and from that broker.
 type EndpointSliceController struct {
-	clusterID                     string
-	syncer                        *broker.Syncer
-	aggregatedServiceImportGetter AggregatedServiceImportGetterFn
-	serviceImportAggregator       *ServiceImportAggregator
-	serviceExportClient           *ServiceExportClient
-	serviceSyncer                 syncer.Interface
-	conflictCheckWorkQueue        workqueue.Interface
+	clusterID           string
+	syncer              *broker.Syncer
+	serviceExportClient *ServiceExportClient
+	serviceSyncer       syncer.Interface
 }
 
 type ServiceExportClient struct {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -27,6 +27,7 @@ const (
 	GlobalnetEnabled         = "lighthouse.submariner.io/globalnet-enabled"
 	UseClustersetIP          = "lighthouse.submariner.io/use-clusterset-ip"
 	ClustersetIPAllocatedBy  = "lighthouse.submariner.io/clusterset-ip-allocated-by"
+	ServiceExportTimestamp   = "lighthouse.submariner.io/svc-export-timestanp"
 )
 
 const ServiceExportReady = "Ready"


### PR DESCRIPTION
...to be MCS compliant. Currently we only apply it on the cluster that introduces a conflict b/c we don't have the service information from all exporting clusters (except for ports which are also in the `EndpointSlices`).

With this PR, each cluster now syncs its local `ServiceImport` to the broker enabling each cluster to apply a `Conflict` condition if any cluster conflicts. This also simplifies the conflict checking as it only needs to be done in one place, ie when a local `ServiceImport` is created/updated/removed on the broker. The port conflict checking has been removed from the `EndpointSlice` processing.

The `ServiceExport`'s creation timestamp is added to the synced ServiceImport to enable determination of the oldest exporting cluster.

Note that the cluster `ServiceImports` are not synced locally by each cluster - it only needs to observe the `ServiceImports` on the broker.

Fixes https://github.com/submariner-io/lighthouse/issues/1831
