### PR TITLE
Address potential integer overflow in timestamp comparison

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Check out the mcs-api repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
-          ref: 20de0ebd811cde518944ff211372d6bd8b6b8152
+          ref: a519a188f757d97e36e25dba9d84638ad10acefc
           repository: kubernetes-sigs/mcs-api
           path: mcs-api
 

--- a/pkg/agent/controller/service_import_conflict.go
+++ b/pkg/agent/controller/service_import_conflict.go
@@ -218,10 +218,12 @@ func sortServiceImportsByTimestamp(siList []runtime.Object, aggregatedType mcsv1
 		tsA := parseTimestamp(siA)
 		tsB := parseTimestamp(siB)
 
-		if tsA == tsB {
-			return strings.Compare(siA.Labels[mcsv1a1.LabelSourceCluster], siB.Labels[mcsv1a1.LabelSourceCluster])
+		if tsA < tsB {
+			return -1
+		} else if tsA > tsB {
+			return 1
 		}
 
-		return int(tsA - tsB)
+		return strings.Compare(siA.Labels[mcsv1a1.LabelSourceCluster], siB.Labels[mcsv1a1.LabelSourceCluster])
 	})
 }


### PR DESCRIPTION
Converting int64 subtraction to int could overflow on 32-bit systems. Though unlikely in practice, use comparison instead of subtraction.

This was identified by the Cursor AI tool.
