### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for lighthouse-agent-0-21

### DIFF
--- a/package/Dockerfile.lighthouse-agent.konflux
+++ b/package/Dockerfile.lighthouse-agent.konflux
@@ -57,5 +57,6 @@ LABEL com.redhat.component="lighthouse-agent-container" \
       io.k8s.description="The Lighthouse Agent handles cross-cluster service discovery." \
       io.openshift.tags="submariner, lighthouse-agent, rhacm" \
       maintainer="multi-cluster-networking@redhat.com" \
+      cpe="cpe:/a:redhat:acm:2.14::el9" \
       com.github.url="https://github.com/submariner-io/lighthouse" \
       com.github.commit="${BASE_BRANCH}"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
