### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for lighthouse-coredns-0-21

### DIFF
--- a/package/Dockerfile.lighthouse-coredns.konflux
+++ b/package/Dockerfile.lighthouse-coredns.konflux
@@ -54,6 +54,7 @@ ENTRYPOINT ["/usr/local/bin/lighthouse-coredns"]
 LABEL com.redhat.component="lighthouse-coredns-container" \
       name="rhacm2/lighthouse-coredns-rhel9" \
       version="${BASE_BRANCH}" \
+      cpe="cpe:/a:redhat:acm:2.14::el9" \
       summary="Lighthouse CoreDNS" \
       description="The Lighthouse CoreDNS provides DNS resolution for cross-cluster services." \
       io.k8s.display-name="Lighthouse CoreDNS" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
