### PR TITLE
Use strings.Builder instead of concatenation in loop

### DIFF
--- a/pkg/agent/controller/controller_suite_test.go
+++ b/pkg/agent/controller/controller_suite_test.go
@@ -1063,18 +1063,18 @@ func newServiceExportReadyCondition(status metav1.ConditionStatus, reason mcsv1a
 }
 
 func newServiceExportConflictCondition(reason ...mcsv1a1.ServiceExportConditionReason) metav1.Condition {
-	joinedReason := ""
+	var joined strings.Builder
 
 	for i := range reason {
 		if i > 0 {
-			joinedReason += ","
+			joined.WriteString(",")
 		}
 
-		joinedReason += string(reason[i])
+		joined.WriteString(string(reason[i]))
 	}
 
 	return mcsv1a1.NewServiceExportCondition(mcsv1a1.ServiceExportConditionConflict, metav1.ConditionTrue,
-		mcsv1a1.ServiceExportConditionReason(joinedReason), "")
+		mcsv1a1.ServiceExportConditionReason(joined.String()), "")
 }
 
 func setIngressIPConditions(ingressIP *unstructured.Unstructured, conditions ...metav1.Condition) {


### PR DESCRIPTION
This was flagged by the perfsprint linter.

See https://github.com/submariner-io/shipyard/pull/2187 and the comment there — this can wait until after v0.22 rc0.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
