### PR TITLE
Adjust to golangci-lint v2.7.2

### DIFF
--- a/coredns/plugin/record.go
+++ b/coredns/plugin/record.go
@@ -112,7 +112,7 @@ func (lh *Lighthouse) createSRVRecords(dnsrecords []resolver.DNSRecord, state *r
 				Hdr:      dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeSRV, Class: state.QClass(), Ttl: lh.TTL},
 				Priority: 0,
 				Weight:   50,
-				Port:     uint16(port.Port),
+				Port:     uint16(port.Port), //nolint:gosec // Need to ignore integer conversion error
 				Target:   target,
 			}
 


### PR DESCRIPTION
Revert the prior `nolint:gosec` removals due to v2.7.1.

Depends on https://github.com/submariner-io/shipyard/pull/2231
