### PR TITLE
Consider preallocating slices with capacity

### DIFF
--- a/coredns/plugin/record.go
+++ b/coredns/plugin/record.go
@@ -31,7 +31,7 @@ import (
 )
 
 func (lh *Lighthouse) createARecords(dnsrecords []resolver.DNSRecord, state *request.Request) []dns.RR {
-	records := make([]dns.RR, 0)
+	records := make([]dns.RR, 0, len(dnsrecords))
 
 	for _, record := range dnsrecords {
 		dnsRecord := &dns.A{Hdr: dns.RR_Header{
@@ -45,7 +45,7 @@ func (lh *Lighthouse) createARecords(dnsrecords []resolver.DNSRecord, state *req
 }
 
 func (lh *Lighthouse) createAAAARecords(dnsrecords []resolver.DNSRecord, state *request.Request) []dns.RR {
-	records := make([]dns.RR, 0)
+	records := make([]dns.RR, 0, len(dnsrecords))
 
 	for _, record := range dnsrecords {
 		dnsRecord := &dns.AAAA{Hdr: dns.RR_Header{

--- a/coredns/resolver/resolver_suite_test.go
+++ b/coredns/resolver/resolver_suite_test.go
@@ -255,7 +255,7 @@ func (t *testDriver) awaitDNSRecords(ns, name, cluster, hostname string, expFoun
 
 func (t *testDriver) testRoundRobin(ns, service string, serviceIPs ...string) {
 	ipsCount := len(serviceIPs)
-	rrIPs := make([]string, 0)
+	rrIPs := make([]string, 0, ipsCount)
 
 	for i := range ipsCount {
 		r := t.getNonHeadlessDNSRecord(ns, service, "")

--- a/test/e2e/discovery/headless_services.go
+++ b/test/e2e/discovery/headless_services.go
@@ -139,7 +139,7 @@ func RunHeadlessDiscoveryLocalAndRemoteTest(f *lhframework.Framework) {
 	ipListB, hostNameListB := f.GetPodIPs(framework.ClusterB, nginxHeadlessClusterB, false)
 	ipListA, hostNameListA := f.GetPodIPs(framework.ClusterA, nginxHeadlessClusterA, true)
 
-	var ipList []string
+	ipList := make([]string, 0, len(ipListB)+len(ipListA))
 	ipList = append(ipList, ipListB...)
 	ipList = append(ipList, ipListA...)
 

--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -497,17 +497,11 @@ func RunServiceDiscoveryRoundRobinTest(f *lhframework.Framework) {
 	f.AwaitAggregatedServiceImport(framework.ClusterB, nginxServiceClusterB, 2)
 	f.AwaitEndpointSlices(framework.ClusterB, nginxServiceClusterB.Name, nginxServiceClusterB.Namespace, 2, 2)
 
-	var serviceIPList []string
-
 	serviceIPClusterB := f.GetServiceIP(framework.ClusterB, nginxServiceClusterB, corev1.IPFamilyUnknown)
-
-	serviceIPList = append(serviceIPList, serviceIPClusterB)
-
 	serviceIPClusterC := f.GetServiceIP(framework.ClusterC, nginxServiceClusterB, corev1.IPFamilyUnknown)
 
-	serviceIPList = append(serviceIPList, serviceIPClusterC)
-
-	verifyRoundRobinWithDig(f.Framework, framework.ClusterA, nginxServiceClusterB.Name, serviceIPList, netshootPodList, checkedDomains)
+	verifyRoundRobinWithDig(f.Framework, framework.ClusterA, nginxServiceClusterB.Name, []string{serviceIPClusterB, serviceIPClusterC},
+		netshootPodList, checkedDomains)
 }
 
 func RunServicesClusterAvailabilityMultiClusterTest(f *lhframework.Framework) {
@@ -565,7 +559,8 @@ func verifySRVWithDig(f *framework.Framework, srcCluster framework.ClusterIndex,
 	ports := service.Spec.Ports
 	for i := range domains {
 		for _, port := range ports {
-			cmd := []string{"dig", "+short", "SRV"}
+			cmd := make([]string, 0, 4)
+			cmd = append(cmd, "dig", "+short", "SRV")
 
 			clusterDNSName := lhframework.BuildServiceDNSName(clusterName, service.Name, f.Namespace, domains[i])
 
@@ -628,7 +623,8 @@ func verifySRVWithDig(f *framework.Framework, srcCluster framework.ClusterIndex,
 func verifyRoundRobinWithDig(f *framework.Framework, srcCluster framework.ClusterIndex, serviceName string, serviceIPList []string,
 	targetPod *corev1.PodList, domains []string,
 ) {
-	cmd := []string{"dig", "+short"}
+	cmd := make([]string, 0, 2+len(domains))
+	cmd = append(cmd, "dig", "+short")
 
 	for i := range domains {
 		cmd = append(cmd, lhframework.BuildServiceDNSName("", serviceName, f.Namespace, domains[i]))

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -388,8 +388,8 @@ func (f *Framework) AwaitPodIngressIPs(targetCluster framework.ClusterIndex, svc
 	isLocal bool,
 ) ([]string, []string) {
 	podList := f.Framework.AwaitPodsByAppLabel(targetCluster, svc.Labels["app"], svc.Namespace, count)
-	hostNameList := make([]string, 0)
-	ipList := make([]string, 0)
+	hostNameList := make([]string, 0, len(podList.Items))
+	ipList := make([]string, 0, len(podList.Items))
 
 	for i := range len(podList.Items) {
 		ingressIPName := "pod-" + podList.Items[i].Name
@@ -433,12 +433,17 @@ func (f *Framework) GetPodIPs(targetCluster framework.ClusterIndex, service *v1.
 }
 
 func (f *Framework) AwaitEndpointIngressIPs(targetCluster framework.ClusterIndex, svc *v1.Service) ([]string, []string) {
-	hostNameList := make([]string, 0)
-	ipList := make([]string, 0)
-
 	endpoint := framework.AwaitUntil("retrieve Endpoints", func() (*v1.Endpoints, error) {
 		return framework.KubeClients[targetCluster].CoreV1().Endpoints(svc.Namespace).Get(context.TODO(), svc.Name, metav1.GetOptions{})
 	}, framework.NoopCheckResult)
+
+	capacity := 0
+	for _, subset := range endpoint.Subsets {
+		capacity += len(subset.Addresses)
+	}
+
+	hostNameList := make([]string, 0)
+	ipList := make([]string, 0, capacity)
 
 	for _, subset := range endpoint.Subsets {
 		for _, address := range subset.Addresses {


### PR DESCRIPTION
...flagged by the 'prealloc' linter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized internal memory allocations across DNS handling, service discovery, and test flows to reduce transient reallocations and improve efficiency during high-frequency operations, yielding lower runtime overhead and slightly faster response in discovery and DNS-related scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->