### PR TITLE
Pin Konflux Dockerfile version labels to v0.22.1

### DIFF
--- a/package/Dockerfile.lighthouse-agent.konflux
+++ b/package/Dockerfile.lighthouse-agent.konflux
@@ -50,7 +50,7 @@ ENTRYPOINT ["/usr/local/bin/lighthouse-agent", "-alsologtostderr"]
 
 LABEL com.redhat.component="lighthouse-agent-container" \
       name="rhacm2/lighthouse-agent-rhel9" \
-      version="v0.22.0" \
+      version="v0.22.1" \
       summary="Lighthouse Agent" \
       description="The Lighthouse Agent provides service discovery for Submariner." \
       io.k8s.display-name="Lighthouse Agent" \

--- a/package/Dockerfile.lighthouse-coredns.konflux
+++ b/package/Dockerfile.lighthouse-coredns.konflux
@@ -53,7 +53,7 @@ ENTRYPOINT ["/usr/local/bin/lighthouse-coredns"]
 
 LABEL com.redhat.component="lighthouse-coredns-container" \
       name="rhacm2/lighthouse-coredns-rhel9" \
-      version="v0.22.0" \
+      version="v0.22.1" \
       summary="Lighthouse CoreDNS" \
       description="The Lighthouse CoreDNS provides DNS resolution for cross-cluster services." \
       io.k8s.display-name="Lighthouse CoreDNS" \


### PR DESCRIPTION
Enables dynamic tagging in Konflux releases for 0.22.1 Z-stream.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image versions to v0.22.1 for lighthouse-agent and lighthouse-coredns components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->