### PR TITLE
Fix wsl_v5 linter warnings reported in golangci-lint 2.9.0

### DIFF
--- a/coredns/loadbalancer/smooth_weighted_round_robin_test.go
+++ b/coredns/loadbalancer/smooth_weighted_round_robin_test.go
@@ -54,6 +54,7 @@ var _ = Describe("Smooth Weighted RR", func() {
 		for _, v := range servers {
 			weight += v.weight
 		}
+
 		return weight
 	}
 
@@ -75,6 +76,7 @@ var _ = Describe("Smooth Weighted RR", func() {
 
 	validateEmptyLBState := func() {
 		Expect(lb.ItemCount()).To(Equal(0))
+
 		for range 100 {
 			Expect(lb.Next()).To(BeNil())
 		}
@@ -83,10 +85,12 @@ var _ = Describe("Smooth Weighted RR", func() {
 	validateLoadBalancingByCount := func(rounds int, servers []server) {
 		totalServersWeight := getTotalServesWeight(servers)
 		results := make(map[string]int64)
+
 		for range rounds {
 			s := lb.Next().(string)
 			results[s]++
 		}
+
 		for _, s := range servers {
 			expectedWeight := int64(rounds) * s.weight / totalServersWeight
 			// Expected weight should be +-1 from the weight counted
@@ -170,6 +174,7 @@ var _ = Describe("Smooth Weighted RR", func() {
 		It("Next() should return it all the time", func() {
 			s := servers[0]
 			addServer(s)
+
 			for range 10 {
 				Expect(lb.Next()).To(Equal(s.name))
 			}
@@ -192,6 +197,7 @@ var _ = Describe("Smooth Weighted RR", func() {
 				err := lb.Add(s.name, s.weight)
 				Expect(err).ToNot(HaveOccurred())
 			}
+
 			for range 100 {
 				for _, s := range roundRobinServers {
 					Expect(lb.Next().(string)).To(Equal(s.name))

--- a/pkg/agent/controller/reconciliation_test.go
+++ b/pkg/agent/controller/reconciliation_test.go
@@ -88,6 +88,7 @@ var _ = Describe("Reconciliation", func() {
 
 		obj, err := t.cluster1.localServiceExportClient.Get(context.Background(), t.cluster1.serviceExport.Name, metav1.GetOptions{})
 		Expect(err).To(Succeed())
+
 		serviceExport = toServiceExport(obj)
 	})
 

--- a/pkg/agent/controller/service_endpoint_slices_test.go
+++ b/pkg/agent/controller/service_endpoint_slices_test.go
@@ -96,6 +96,7 @@ var _ = Describe("Service EndpointSlice Controller", func() {
 			t.cluster1.updateService()
 
 			time.Sleep(time.Millisecond * 500)
+
 			fakeEPSClient.epsCreateContinue <- true
 
 			t.awaitEndpointSlice(&t.cluster1)

--- a/pkg/agent/controller/service_export_client_test.go
+++ b/pkg/agent/controller/service_export_client_test.go
@@ -101,7 +101,6 @@ var _ = Describe("ServiceExportClient", func() {
 	Context("with Conflict condition type", func() {
 		It("should aggregate the different reasons and messages", func() {
 			// The condition shouldn't be added with Status False.
-
 			serviceExportClient.UpdateStatusConditions(context.TODO(), serviceName, serviceNamespace, metav1.Condition{
 				Type:   string(mcsv1a1.ServiceExportConditionConflict),
 				Status: metav1.ConditionFalse,

--- a/test/e2e/discovery/service_discovery.go
+++ b/test/e2e/discovery/service_discovery.go
@@ -96,6 +96,7 @@ var _ = Describe("Test Service Discovery Across Clusters", Label(labels.ServiceD
 			}
 
 			randomIP := "192.168.1.5"
+
 			healthCheckEnabled := f.GetHealthCheckEnabledInfo(framework.ClusterC)
 			if !healthCheckEnabled {
 				Skip("Healthcheck is not enabled hence skipping the test")


### PR DESCRIPTION
Add blank lines before return and go statements to satisfy wsl_v5 whitespace requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved formatting and whitespace consistency across test files.

---

**Note:** This release contains internal test code formatting updates only. No changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->