### PR TITLE
Switch to MetricsConfig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/gomega v1.39.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
-	github.com/submariner-io/admiral v0.24.0-m0.0.20260218133429-4ba4e2683354
+	github.com/submariner-io/admiral v0.24.0-m0.0.20260302080856-b49ecd71c85d
 	github.com/submariner-io/shipyard v0.24.0-m0
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/submariner-io/admiral v0.24.0-m0.0.20260218133429-4ba4e2683354 h1:uzTWCnaJasQ2GXH8zFJdt93AhovLWru+/27iKFhKOys=
-github.com/submariner-io/admiral v0.24.0-m0.0.20260218133429-4ba4e2683354/go.mod h1:f5j+OHhbLWazmM8/SLHPchpuQFJvOR76zYDO155UU8E=
+github.com/submariner-io/admiral v0.24.0-m0.0.20260302080856-b49ecd71c85d h1:Fxp3ZZj7hxXtlbfln86wWT0ZB9qsHYmcGIdvKcmrN3w=
+github.com/submariner-io/admiral v0.24.0-m0.0.20260302080856-b49ecd71c85d/go.mod h1:f5j+OHhbLWazmM8/SLHPchpuQFJvOR76zYDO155UU8E=
 github.com/submariner-io/shipyard v0.24.0-m0 h1:3DAMmoYvAo8M8e5XaeYXPg3cKnRnYOfo1tmFkI2FbMM=
 github.com/submariner-io/shipyard v0.24.0-m0/go.mod h1:XrVoePXxTaA2ODETstSdpQ/8YDW9UvLuI29AiaLFJq0=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -91,9 +91,11 @@ func newServiceImportController(spec *AgentSpecification, agentConfig AgentConfi
 		ResourceType:    &mcsv1a1.ServiceImport{},
 		Transform:       controller.onLocalServiceImport,
 		Scheme:          syncerConfig.Scheme,
-		SyncCounterOpts: &prometheus.GaugeOpts{
-			Name: agentConfig.ServiceExportCounterName,
-			Help: "Count of exported services",
+		Metrics: syncer.MetricsConfig{
+			SyncCounterOpts: &prometheus.GaugeOpts{
+				Name: agentConfig.ServiceExportCounterName,
+				Help: "Count of exported services",
+			},
 		},
 		WorkQueueConfig: workqueue.ConfigFromGlobal("local-service-import", nil),
 		MaxLogVerbosity: global.Get("local-service-import.syncer.max-verbosity", 0),
@@ -117,9 +119,11 @@ func newServiceImportController(spec *AgentSpecification, agentConfig AgentConfi
 		OnSuccessfulSync:  controller.onSuccessfulSyncFromBroker,
 		Scheme:            syncerConfig.Scheme,
 		NamespaceInformer: syncerConfig.NamespaceInformer,
-		SyncCounterOpts: &prometheus.GaugeOpts{
-			Name: agentConfig.ServiceImportCounterName,
-			Help: "Count of imported services",
+		Metrics: syncer.MetricsConfig{
+			SyncCounterOpts: &prometheus.GaugeOpts{
+				Name: agentConfig.ServiceImportCounterName,
+				Help: "Count of imported services",
+			},
 		},
 		WorkQueueConfig: workqueue.ConfigFromGlobal("remote-service-import", nil),
 		MaxLogVerbosity: global.Get("remote-service-import.syncer.max-verbosity", 0),


### PR DESCRIPTION
https://github.com/submariner-io/admiral/pull/1295 moved SyncCounterOpts into a MetricsConfig struct; this adjusts accordingly.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to the latest versions.

* **Refactor**
  * Restructured internal metrics configuration for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->