### PR TITLE
fix(coredns): implement Readiness interface for ready plugin

### DIFF
--- a/coredns/plugin/lighthouse.go
+++ b/coredns/plugin/lighthouse.go
@@ -20,6 +20,7 @@ package lighthouse
 
 import (
 	"errors"
+	"sync/atomic"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/plugin"
@@ -44,12 +45,17 @@ var logger = log.Logger{Logger: logf.Log.WithName("Handler")}
 
 type Lighthouse struct {
 	Next                plugin.Handler
-	Fall                fall.F
-	Zones               []string
-	TTL                 uint32
-	ClusterStatus       resolver.ClusterStatus
 	Resolver            *resolver.Interface
+	Zones               []string
 	SupportedIPFamilies []k8snet.IPFamily
+	ClusterStatus       resolver.ClusterStatus
+	Fall                fall.F
+	TTL                 uint32
+	ready               atomic.Bool
+}
+
+func (lh *Lighthouse) Ready() bool {
+	return lh.ready.Load()
 }
 
 var _ plugin.Handler = &Lighthouse{}

--- a/coredns/plugin/setup.go
+++ b/coredns/plugin/setup.go
@@ -120,17 +120,8 @@ func lighthouseParse(c *caddy.Controller) (*Lighthouse, error) {
 		SupportedIPFamilies: determineSupportedAddressTypes(),
 	}
 
-	resolverController := resolver.NewController(lh.Resolver)
-
 	stopCh := make(chan struct{})
 	ctx := wait.ContextForChannel(stopCh)
-
-	c.OnShutdown(func() error {
-		close(stopCh)
-		resolverController.Stop()
-
-		return nil
-	})
 
 	submNamespace := os.Getenv("SUBMARINER_NAMESPACE")
 
@@ -142,6 +133,13 @@ func lighthouseParse(c *caddy.Controller) (*Lighthouse, error) {
 	global.Init(configMap)
 
 	configmap.WatchAndSignalOnChange(ctx, k8sClient, submNamespace, syscall.SIGINT, names.ServiceDiscoveryComponent)
+
+	err = lh.configure(c)
+	if err != nil {
+		return nil, err
+	}
+
+	resolverController := resolver.NewController(lh.Resolver)
 
 	err = gwController.Start(ctx, localClient)
 	if err != nil {
@@ -157,9 +155,16 @@ func lighthouseParse(c *caddy.Controller) (*Lighthouse, error) {
 		return nil, errors.Wrap(err, "error starting the resolver controller")
 	}
 
-	err = lh.configure(c)
+	c.OnShutdown(func() error {
+		close(stopCh)
+		resolverController.Stop()
 
-	return lh, err
+		return nil
+	})
+
+	lh.ready.Store(true)
+
+	return lh, nil
 }
 
 func determineSupportedAddressTypes() []k8snet.IPFamily {


### PR DESCRIPTION
## Problem
The Lighthouse CoreDNS plugin becomes "ready" prematurely before all EndpointSlices have been processed, causing NXDOMAIN errors for DNS queries during initial startup or after restarts. This happens because the Lighthouse plugin does not implement the CoreDNS `ready.Readiness` interface.

## Solution  
Implemented the CoreDNS `ready.Readiness` interface by adding a `Ready() bool` method to the Lighthouse plugin using an `atomic.Bool`. The ready flag is set to `true` after the gateway and resolver controllers have started, which synchronously wait for the cache to sync.

## Testing
Ran `go test ./coredns/...` and `go vet ./coredns/...` to ensure no existing tests are broken and code compiles cleanly.

Closes #1745

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin now exposes a readiness status so other components can verify it is fully initialized and operational.

* **Bug Fixes**
  * Startup sequence updated so readiness is only advertised after successful configuration and controller startup, preventing premature ready signals when setup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->