### PR TITLE
Implement ServiceImport IPFamilies and conflict detection

### DIFF
--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -261,6 +261,7 @@ func (a *Controller) serviceExportToServiceImport(obj runtime.Object, _ int, op 
 	serviceImport.Spec = mcsv1a1.ServiceImportSpec{
 		Ports:                 []mcsv1a1.ServicePort{},
 		Type:                  svcType,
+		IPFamilies:            svc.Spec.IPFamilies,
 		SessionAffinity:       svc.Spec.SessionAffinity,
 		SessionAffinityConfig: svc.Spec.SessionAffinityConfig,
 		TrafficDistribution:   svc.Spec.TrafficDistribution,

--- a/pkg/agent/controller/clusterip_service_test.go
+++ b/pkg/agent/controller/clusterip_service_test.go
@@ -21,6 +21,7 @@ package controller_test
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"time"
 
@@ -489,6 +490,7 @@ func testClusterIPServiceInOneCluster() {
 				Spec: mcsv1a1.ServiceImportSpec{
 					Type:            mcsv1a1.ClusterSetIP,
 					Ports:           t.aggregatedServicePorts,
+					IPFamilies:      t.aggregatedIPFamilies,
 					SessionAffinity: corev1.ServiceAffinityNone,
 				},
 				Status: mcsv1a1.ServiceImportStatus{
@@ -534,6 +536,10 @@ func testClusterIPServiceInTwoClusters() {
 		t.cluster2.createServiceEndpointSlices()
 		t.cluster2.createService()
 		t.cluster2.createServiceExport()
+
+		if t.aggregatedIPFamilies == nil {
+			t.aggregatedIPFamilies = t.cluster1.service.Spec.IPFamilies
+		}
 	})
 
 	AfterEach(func() {
@@ -852,6 +858,24 @@ func testClusterIPServiceInTwoClusters() {
 				mcsv1a1.ServiceExportReasonTrafficDistributionConflict))
 			t.cluster2.awaitServiceExportCondition(newServiceExportConflictCondition(
 				mcsv1a1.ServiceExportReasonTrafficDistributionConflict))
+		})
+	})
+
+	Context("with differing service IP families", func() {
+		BeforeEach(func() {
+			t.cluster1.service.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv4Protocol}
+			t.cluster2.service.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv6Protocol}
+			t.aggregatedIPFamilies = append(slices.Clone(t.cluster1.service.Spec.IPFamilies), t.cluster2.service.Spec.IPFamilies...)
+		})
+
+		It("should resolve the conflict and set the Conflict status condition on all exporting clusters", func() {
+			t.awaitAggregatedServiceImport(mcsv1a1.ClusterSetIP, t.cluster1.service.Name, t.cluster1.service.Namespace,
+				&t.cluster1, &t.cluster2)
+
+			t.cluster1.awaitServiceExportCondition(newServiceExportConflictCondition(
+				mcsv1a1.ServiceExportReasonIPFamilyConflict))
+			t.cluster2.awaitServiceExportCondition(newServiceExportConflictCondition(
+				mcsv1a1.ServiceExportReasonIPFamilyConflict))
 		})
 	})
 

--- a/pkg/agent/controller/controller_suite_test.go
+++ b/pkg/agent/controller/controller_suite_test.go
@@ -152,6 +152,7 @@ type testDriver struct {
 	aggregatedSessionAffinityConfig *corev1.SessionAffinityConfig
 	aggregatedTrafficDistribution   *string
 	aggregatedInternalTrafficPolicy *corev1.ServiceInternalTrafficPolicy
+	aggregatedIPFamilies            []corev1.IPFamily
 }
 
 func newTestDiver() *testDriver {
@@ -172,6 +173,7 @@ func newTestDiver() *testDriver {
 	t := &testDriver{
 		aggregatedServicePorts:    []mcsv1a1.ServicePort{port1, port2},
 		aggregatedSessionAffinity: corev1.ServiceAffinityNone,
+		aggregatedIPFamilies:      nil,
 		cluster1: cluster{
 			clusterID: clusterID1,
 			agentSpec: controller.AgentSpecification{
@@ -338,6 +340,10 @@ func newTestDiver() *testDriver {
 func (t *testDriver) justBeforeEach() {
 	t.cluster1.start(t, *t.syncerConfig)
 	t.cluster2.start(t, *t.syncerConfig)
+
+	if t.aggregatedIPFamilies == nil {
+		t.aggregatedIPFamilies = t.cluster1.service.Spec.IPFamilies
+	}
 }
 
 func (t *testDriver) afterEach() {
@@ -817,6 +823,7 @@ func (t *testDriver) awaitAggregatedServiceImport(sType mcsv1a1.ServiceImportTyp
 		Spec: mcsv1a1.ServiceImportSpec{
 			Type:                  sType,
 			Ports:                 []mcsv1a1.ServicePort{},
+			IPFamilies:            t.aggregatedIPFamilies,
 			SessionAffinity:       t.aggregatedSessionAffinity,
 			SessionAffinityConfig: t.aggregatedSessionAffinityConfig,
 			TrafficDistribution:   t.aggregatedTrafficDistribution,

--- a/pkg/agent/controller/reconciliation_test.go
+++ b/pkg/agent/controller/reconciliation_test.go
@@ -117,6 +117,9 @@ var _ = Describe("Reconciliation", func() {
 			t = newTestDiver()
 			t.useClusterSetIP = true
 
+			// Re-initialize aggregatedIPFamilies from the saved localAggregatedServiceImport
+			t.aggregatedIPFamilies = toServiceImport(localAggregatedServiceImport).Spec.IPFamilies
+
 			brokerDynClient := t.syncerConfig.BrokerClient.(*fake.FakeDynamicClient)
 
 			// Use the broker client for cluster1 to simulate the broker being on the same cluster.

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -385,6 +385,7 @@ func (c *ServiceImportController) onRemoteServiceImport(obj runtime.Object, _ in
 				aggregated.Spec.TrafficDistribution = precedentServiceImport.Spec.TrafficDistribution
 				aggregated.Spec.InternalTrafficPolicy = precedentServiceImport.Spec.InternalTrafficPolicy
 				aggregated.Spec.Ports = precedentServiceImport.Spec.Ports
+				aggregated.Spec.IPFamilies = precedentServiceImport.Spec.IPFamilies
 
 				return nil
 			})

--- a/pkg/agent/controller/service_import_aggregate.go
+++ b/pkg/agent/controller/service_import_aggregate.go
@@ -56,8 +56,9 @@ func (c *ServiceImportController) createOrUpdateAggregate(ctx context.Context, o
 			},
 		},
 		Spec: mcsv1a1.ServiceImportSpec{
-			Type:  localServiceImport.Spec.Type,
-			Ports: []mcsv1a1.ServicePort{},
+			Type:       localServiceImport.Spec.Type,
+			Ports:      []mcsv1a1.ServicePort{},
+			IPFamilies: localServiceImport.Spec.IPFamilies,
 		},
 		Status: mcsv1a1.ServiceImportStatus{
 			Clusters: []mcsv1a1.ClusterStatus{

--- a/pkg/agent/controller/service_import_conflict.go
+++ b/pkg/agent/controller/service_import_conflict.go
@@ -57,6 +57,7 @@ func (c *ServiceImportController) checkForConflicts(ctx context.Context, aggrega
 	precedentServiceImport := siList[0].(*mcsv1a1.ServiceImport)
 	intersectionOfServicePorts := precedentServiceImport.Spec.Ports
 	unionOfServicePorts := precedentServiceImport.Spec.Ports
+	unionOfIPFamilies := precedentServiceImport.Spec.IPFamilies
 
 	exportingClusters := set.New[string](precedentServiceImport.Labels[mcsv1a1.LabelSourceCluster])
 	conflictingServiceTypeClusters := set.New[string]()
@@ -66,6 +67,7 @@ func (c *ServiceImportController) checkForConflicts(ctx context.Context, aggrega
 	conflictingTrafficDistributionClusters := set.New[string]()
 	conflictingInternalTrafficPolicyClusters := set.New[string]()
 	conflictingClusterSetIPEnablementClusters := set.New[string]()
+	ipFamilyConflict := false
 
 	for i := 1; i < len(siList); i++ {
 		serviceImport := siList[i].(*mcsv1a1.ServiceImport)
@@ -106,6 +108,12 @@ func (c *ServiceImportController) checkForConflicts(ctx context.Context, aggrega
 		intersectionOfServicePorts = slices.Intersect(intersectionOfServicePorts, serviceImport.Spec.Ports, servicePortKey)
 
 		portConflict = portConflict || !slices.Equivalent(precedentServiceImport.Spec.Ports, serviceImport.Spec.Ports, servicePortKey)
+
+		unionOfIPFamilies = slices.Union(unionOfIPFamilies, serviceImport.Spec.IPFamilies, func(f corev1.IPFamily) string {
+			return string(f)
+		})
+
+		ipFamilyConflict = ipFamilyConflict || !goslices.Equal(serviceImport.Spec.IPFamilies, precedentServiceImport.Spec.IPFamilies)
 	}
 
 	var conditions []metav1.Condition
@@ -189,9 +197,17 @@ func (c *ServiceImportController) checkForConflicts(ctx context.Context, aggrega
 				toStringClusterNames(conflictingClusterSetIPEnablementClusters))
 		})
 
+	addConflictCondition(ipFamilyConflict, mcsv1a1.ServiceExportReasonIPFamilyConflict, func() string {
+		return fmt.Sprintf("The service IP families conflict between the constituent clusters %s. "+
+			"The service will expose the union of all backends, but network traffic may only reach backends in a subset of clusters "+
+			"depending on the client's IP family capabilities.",
+			toStringClusterNames(exportingClusters))
+	})
+
 	c.serviceExportClient.UpdateStatusConditions(ctx, serviceName, serviceNamespace, conditions...)
 
 	precedentServiceImport.Spec.Ports = unionOfServicePorts
+	precedentServiceImport.Spec.IPFamilies = unionOfIPFamilies
 
 	return precedentServiceImport
 }


### PR DESCRIPTION
Populate `ServiceImport.IPFamilies` from `Service.IPFamilies` and implement detection and handling of IP family conflicts when services are exported across multiple clusters with different IP families. This follows the Kubernetes MCS KEP guidance for IP family conflicts.

When constituent services with different IP families are exported, all backends are exposed (union semantics), but a conflict condition is raised since network traffic may only reach backends in a subset' of clusters depending on client IP capabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ServiceImport now tracks and propagates IP family information from exported services.
  * Added detection and handling of IP family conflicts when services across clusters use different IP families.
  * IP families are aggregated when combining service imports from multiple clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->