### PR TITLE
Revert Konflux RHEL10 updates

### DIFF
--- a/package/Dockerfile.lighthouse-agent.konflux
+++ b/package/Dockerfile.lighthouse-agent.konflux
@@ -1,7 +1,7 @@
 ARG BASE_BRANCH=release-0.23
 ARG SOURCE=/go/src/github.com/submariner-io/lighthouse
 
-FROM --platform=${BUILDPLATFORM} registry.redhat.io/ubi10/go-toolset:latest AS builder
+FROM --platform=${BUILDPLATFORM} registry.redhat.io/ubi9/go-toolset:latest AS builder
 ARG SOURCE
 ARG TARGETPLATFORM
 ARG BASE_BRANCH
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=1 GOARCH=${TARGETPLATFORM##*/} go build \
     -v -o ${SOURCE}/bin/${TARGETPLATFORM}/lighthouse-agent \
     ${SOURCE}/pkg/agent/main.go
 
-FROM --platform=${TARGETPLATFORM} registry.redhat.io/ubi10:latest
+FROM --platform=${TARGETPLATFORM} registry.redhat.io/ubi9:latest
 ARG BASE_BRANCH
 ARG SOURCE
 ARG TARGETPLATFORM
@@ -49,7 +49,7 @@ USER lighthouse
 ENTRYPOINT ["/usr/local/bin/lighthouse-agent", "-alsologtostderr"]
 
 LABEL com.redhat.component="lighthouse-agent-container" \
-      name="rhacm2/lighthouse-agent-rhel10" \
+      name="rhacm2/lighthouse-agent-rhel9" \
       version="v0.23.0" \
       summary="Lighthouse Agent" \
       description="The Lighthouse Agent provides service discovery for Submariner." \
@@ -59,4 +59,4 @@ LABEL com.redhat.component="lighthouse-agent-container" \
       maintainer="multi-cluster-networking@redhat.com" \
       com.github.url="https://github.com/submariner-io/lighthouse" \
       com.github.commit="${BASE_BRANCH}" \
-      cpe="cpe:/a:redhat:acm:2.16::el10"
+      cpe="cpe:/a:redhat:acm:2.16::el9"

--- a/package/Dockerfile.lighthouse-coredns.konflux
+++ b/package/Dockerfile.lighthouse-coredns.konflux
@@ -1,7 +1,7 @@
 ARG BASE_BRANCH=release-0.23
 ARG SOURCE=/go/src/github.com/submariner-io/lighthouse
 
-FROM --platform=${BUILDPLATFORM} registry.redhat.io/ubi10/go-toolset:latest AS builder
+FROM --platform=${BUILDPLATFORM} registry.redhat.io/ubi9/go-toolset:latest AS builder
 ARG SOURCE
 ARG TARGETPLATFORM
 ARG BASE_BRANCH
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=1 GOARCH=${TARGETPLATFORM##*/} go build \
     -v -o ${SOURCE}/bin/${TARGETPLATFORM}/lighthouse-coredns \
     .
 
-FROM --platform=${TARGETPLATFORM} registry.redhat.io/ubi10:latest
+FROM --platform=${TARGETPLATFORM} registry.redhat.io/ubi9:latest
 ARG BASE_BRANCH
 ARG SOURCE
 ARG TARGETPLATFORM
@@ -52,7 +52,7 @@ EXPOSE 53 53/udp
 ENTRYPOINT ["/usr/local/bin/lighthouse-coredns"]
 
 LABEL com.redhat.component="lighthouse-coredns-container" \
-      name="rhacm2/lighthouse-coredns-rhel10" \
+      name="rhacm2/lighthouse-coredns-rhel9" \
       version="v0.23.0" \
       summary="Lighthouse CoreDNS" \
       description="The Lighthouse CoreDNS provides DNS resolution for cross-cluster services." \
@@ -62,4 +62,4 @@ LABEL com.redhat.component="lighthouse-coredns-container" \
       maintainer="multi-cluster-networking@redhat.com" \
       com.github.url="https://github.com/submariner-io/lighthouse" \
       com.github.commit="${BASE_BRANCH}" \
-      cpe="cpe:/a:redhat:acm:2.16::el10"
+      cpe="cpe:/a:redhat:acm:2.16::el9"


### PR DESCRIPTION
Found way to get libreswan-5.x on RHEL10, fast datapath repo, so update not needed.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container base image versions for lighthouse components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->