### PR TITLE
Set ServiceImport Ready condition based on IP family support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/submariner-io/lighthouse
 go 1.25.0
 
 require (
+	github.com/google/go-cmp v0.7.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
@@ -34,7 +35,6 @@ require (
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect

--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -54,6 +54,7 @@ type AgentConfig struct {
 	ServiceImportCounterName string
 	ServiceExportCounterName string
 	IPPool                   *ipam.IPPool
+	SupportedIPFamilies      []corev1.IPFamily
 }
 
 var logger = log.Logger{Logger: logf.Log.WithName("agent")}

--- a/pkg/agent/controller/controller_suite_test.go
+++ b/pkg/agent/controller/controller_suite_test.go
@@ -24,13 +24,13 @@ import (
 	"fmt"
 	"maps"
 	"math/big"
-	"reflect"
 	"sort"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/fake"
@@ -51,7 +51,6 @@ import (
 	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -133,6 +132,8 @@ type cluster struct {
 	serviceEndpointSlices      []discovery.EndpointSlice
 	clusterID                  string
 	headlessEndpointAddresses  [][]discovery.Endpoint
+	supportedIPFamilies        []corev1.IPFamily
+	verifyImportReadyCondition func(c *metav1.Condition)
 }
 
 type testDriver struct {
@@ -175,7 +176,9 @@ func newTestDiver() *testDriver {
 		aggregatedSessionAffinity: corev1.ServiceAffinityNone,
 		aggregatedIPFamilies:      nil,
 		cluster1: cluster{
-			clusterID: clusterID1,
+			clusterID:                  clusterID1,
+			supportedIPFamilies:        nil,
+			verifyImportReadyCondition: assertImportReady,
 			agentSpec: controller.AgentSpecification{
 				ClusterID:        clusterID1,
 				Namespace:        test.LocalNamespace,
@@ -259,7 +262,9 @@ func newTestDiver() *testDriver {
 			},
 		},
 		cluster2: cluster{
-			clusterID: clusterID2,
+			clusterID:                  clusterID2,
+			supportedIPFamilies:        nil,
+			verifyImportReadyCondition: assertImportReady,
 			agentSpec: controller.AgentSpecification{
 				ClusterID:        clusterID2,
 				Namespace:        test.LocalNamespace,
@@ -412,11 +417,16 @@ func (c *cluster) start(t *testDriver, syncerConfig broker.SyncerConfig) {
 
 	serviceExportCounterName := "submariner_service_export" + bigint.String()
 
+	if c.supportedIPFamilies == nil {
+		c.supportedIPFamilies = c.service.Spec.IPFamilies
+	}
+
 	c.agentController, err = controller.New(&c.agentSpec, syncerConfig,
 		controller.AgentConfig{
 			ServiceImportCounterName: serviceImportCounterName,
 			ServiceExportCounterName: serviceExportCounterName,
 			IPPool:                   t.ipPool,
+			SupportedIPFamilies:      c.supportedIPFamilies,
 		})
 
 	Expect(err).To(Succeed())
@@ -659,11 +669,21 @@ func (c *cluster) ensureNoServiceExportActions() {
 	}, 500*time.Millisecond).Should(BeEmpty())
 }
 
+func (c *cluster) verifyServiceImportReady(si *mcsv1a1.ServiceImport) {
+	cond := meta.FindStatusCondition(si.Status.Conditions, string(mcsv1a1.ServiceImportConditionReady))
+	Expect(cond).ToNot(BeNil(), "ServiceImport Ready condition not found")
+	c.verifyImportReadyCondition(cond)
+}
+
 func awaitServiceImport(client dynamic.NamespaceableResourceInterface, expected *mcsv1a1.ServiceImport, ipPool *ipam.IPPool,
 ) *mcsv1a1.ServiceImport {
 	sortSlices := func(si *mcsv1a1.ServiceImport) {
 		sort.SliceStable(si.Spec.Ports, func(i, j int) bool {
 			return si.Spec.Ports[i].Port < si.Spec.Ports[j].Port
+		})
+
+		sort.SliceStable(si.Spec.IPFamilies, func(i, j int) bool {
+			return si.Spec.IPFamilies[i] < si.Spec.IPFamilies[j]
 		})
 
 		sort.SliceStable(si.Status.Clusters, func(i, j int) bool {
@@ -673,50 +693,28 @@ func awaitServiceImport(client dynamic.NamespaceableResourceInterface, expected 
 
 	sortSlices(expected)
 
-	expected = expected.DeepCopy()
-	expectedServiceImportIPs := expected.Spec.IPs
-	expected.Spec.IPs = nil
-
 	var serviceImport *mcsv1a1.ServiceImport
 
-	err := wait.PollUntilContextTimeout(context.Background(), 50*time.Millisecond, 5*time.Second, true,
-		func(ctx context.Context) (bool, error) {
-			obj, err := client.Namespace(expected.Namespace).Get(ctx, expected.Name, metav1.GetOptions{})
-			if apierrors.IsNotFound(err) {
-				return false, nil
-			}
+	Eventually(func(g Gomega) {
+		obj, err := client.Namespace(expected.Namespace).Get(context.TODO(), expected.Name, metav1.GetOptions{})
+		g.Expect(err).NotTo(HaveOccurred())
 
-			serviceImport = toServiceImport(obj)
+		serviceImport = toServiceImport(obj)
+		sortSlices(serviceImport)
 
-			sortSlices(serviceImport)
+		g.Expect(serviceImport.Spec.IPs).To(HaveLen(len(expected.Spec.IPs)))
 
-			ipsEquivalent := len(expectedServiceImportIPs) == len(serviceImport.Spec.IPs)
-			actualSpec := serviceImport.Spec.DeepCopy()
-			actualSpec.IPs = nil
-
-			return ipsEquivalent && reflect.DeepEqual(&expected.Spec, actualSpec) &&
-				reflect.DeepEqual(&expected.Status, &serviceImport.Status), nil
-		})
-
-	if !wait.Interrupted(err) {
-		Expect(err).To(Succeed())
-	}
-
-	if serviceImport == nil {
-		Fail(fmt.Sprintf("ServiceImport %s/%s not found", expected.Namespace, expected.Name))
-	}
-
-	Expect(serviceImport.Spec.IPs).To(HaveLen(len(expectedServiceImportIPs)))
+		g.Expect(serviceImport.Spec).To(BeComparableTo(expected.Spec,
+			cmpopts.IgnoreFields(mcsv1a1.ServiceImportSpec{}, "IPs")),
+			"Actual Spec: %s, Expected Spec %s", resource.ToJSON(serviceImport.Spec), resource.ToJSON(expected.Spec))
+		g.Expect(serviceImport.Status).To(BeComparableTo(expected.Status,
+			cmpopts.IgnoreFields(mcsv1a1.ServiceImportStatus{}, "Conditions")),
+			"Actual Status: %s, Expected Status %s", resource.ToJSON(serviceImport.Status), resource.ToJSON(expected.Status))
+	}).Within(5 * time.Second).ProbeEvery(50 * time.Millisecond).Should(Succeed())
 
 	if len(serviceImport.Spec.IPs) > 0 {
-		Expect(ipPool.Reserve(serviceImport.Spec.IPs...)).ToNot(Succeed(), ""+
-			"ServiceImport IP was not allocated or reserved")
+		Expect(ipPool.Reserve(serviceImport.Spec.IPs...)).ToNot(Succeed(), "ServiceImport IP was not allocated or reserved")
 	}
-
-	serviceImport.Spec.IPs = nil
-
-	Expect(serviceImport.Spec).To(Equal(expected.Spec))
-	Expect(serviceImport.Status).To(Equal(expected.Status))
 
 	Expect(serviceImport.Labels).To(BeEmpty())
 
@@ -855,8 +853,8 @@ func (t *testDriver) awaitAggregatedServiceImport(sType mcsv1a1.ServiceImportTyp
 	expServiceImport.Name = name
 	expServiceImport.Namespace = ns
 
-	awaitServiceImport(t.cluster1.localServiceImportClient, expServiceImport, t.ipPool)
-	awaitServiceImport(t.cluster2.localServiceImportClient, expServiceImport, t.ipPool)
+	t.cluster1.verifyServiceImportReady(awaitServiceImport(t.cluster1.localServiceImportClient, expServiceImport, t.ipPool))
+	t.cluster2.verifyServiceImportReady(awaitServiceImport(t.cluster2.localServiceImportClient, expServiceImport, t.ipPool))
 }
 
 func (t *testDriver) ensureAggregatedServiceImport(sType mcsv1a1.ServiceImportType, name, ns string, clusters ...*cluster) {
@@ -1107,4 +1105,14 @@ func toServicePort(port mcsv1a1.ServicePort) corev1.ServicePort {
 		Port:        port.Port,
 		AppProtocol: port.AppProtocol,
 	}
+}
+
+func assertImportReady(c *metav1.Condition) {
+	Expect(c.Status).To(Equal(metav1.ConditionTrue))
+	Expect(c.Reason).To(Equal(string(mcsv1a1.ServiceImportReasonReady)))
+}
+
+func assertImportNotReady(c *metav1.Condition) {
+	Expect(c.Status).To(Equal(metav1.ConditionFalse))
+	Expect(c.Reason).To(Equal(string(mcsv1a1.ServiceImportReasonIPFamilyNotSupported)))
 }

--- a/pkg/agent/controller/dual_stack_test.go
+++ b/pkg/agent/controller/dual_stack_test.go
@@ -120,6 +120,8 @@ var _ = Describe("Dual-stack", func() {
 			t.cluster1.service.Spec.IPFamilies = []corev1.IPFamily{corev1.IPv6Protocol}
 			t.cluster1.service.Spec.ClusterIPs = []string{ipv6ServiceIP}
 			t.cluster1.serviceEndpointSlices = []discovery.EndpointSlice{newIPv6ServiceEndpointSlice()}
+
+			t.cluster2.supportedIPFamilies = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
 		})
 
 		It("should only create an IPv6 EndpointSlice", func() {
@@ -147,6 +149,32 @@ var _ = Describe("Dual-stack", func() {
 				t.cluster1.awaitServiceExportCondition(newServiceExportReadyCondition(metav1.ConditionFalse,
 					controller.ServiceExportReasonUnsupportedIPFamily))
 				test.AwaitNoResource(t.cluster1.localServiceImportClient.Namespace(t.cluster1.service.Namespace), t.cluster1.service.Name)
+			})
+		})
+
+		Context("and the importing cluster only supports IPv4", func() {
+			BeforeEach(func() {
+				t.cluster2.supportedIPFamilies = []corev1.IPFamily{corev1.IPv4Protocol}
+				t.cluster2.verifyImportReadyCondition = assertImportNotReady
+			})
+
+			It("should set the Ready condition to false with IPFamilyNotSupported", func() {
+				t.awaitNonHeadlessServiceExported(&t.cluster1)
+			})
+
+			It("should eventually set the Ready condition to true after the service is exported on the importing cluster", func() {
+				t.awaitNonHeadlessServiceExported(&t.cluster1)
+
+				By("Exporting IPv4 service on second cluster")
+
+				t.aggregatedIPFamilies = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
+				t.cluster2.verifyImportReadyCondition = assertImportReady
+
+				t.cluster2.createServiceEndpointSlices()
+				t.cluster2.createService()
+				t.cluster2.createServiceExport()
+
+				t.awaitNonHeadlessServiceExported(&t.cluster1, &t.cluster2)
 			})
 		})
 	})
@@ -197,10 +225,23 @@ var _ = Describe("Dual-stack", func() {
 
 			t.cluster1.serviceEndpointSlices = []discovery.EndpointSlice{newIPv6ServiceEndpointSlice()}
 			t.cluster1.headlessEndpointAddresses = [][]discovery.Endpoint{t.cluster1.serviceEndpointSlices[0].Endpoints}
+
+			t.cluster2.supportedIPFamilies = t.cluster1.service.Spec.IPFamilies
 		})
 
 		It("should only create an IPv6 EndpointSlice", func() {
 			t.awaitHeadlessServiceExported(&t.cluster1)
+		})
+
+		Context("and the importing cluster only supports IPv4", func() {
+			BeforeEach(func() {
+				t.cluster2.supportedIPFamilies = []corev1.IPFamily{corev1.IPv4Protocol}
+				t.cluster2.verifyImportReadyCondition = assertImportNotReady
+			})
+
+			It("should set the ServiceImport Ready condition false with IPFamilyNotSupported", func() {
+				t.awaitHeadlessServiceExported(&t.cluster1)
+			})
 		})
 	})
 })

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"slices"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -36,6 +37,7 @@ import (
 	"github.com/submariner-io/lighthouse/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
@@ -60,6 +62,7 @@ func newServiceImportController(spec *AgentSpecification, agentConfig AgentConfi
 		localLHEndpointSliceLister: localLHEndpointSliceLister,
 		clustersetIPPool:           agentConfig.IPPool,
 		clustersetIPEnabled:        spec.ClustersetIPEnabled,
+		supportedIPFamilies:        agentConfig.SupportedIPFamilies,
 	}
 
 	localToBrokerFederator := federate.NewCreateOrUpdateFederator(federate.CreateOrUpdateOptions{
@@ -340,6 +343,27 @@ func (c *ServiceImportController) onRemoteServiceImport(obj runtime.Object, _ in
 
 		delete(serviceImport.Annotations, mcsv1a1.LabelServiceName)
 		delete(serviceImport.Annotations, constants.LabelSourceNamespace)
+
+		ready := metav1.Condition{
+			Type:   string(mcsv1a1.ServiceImportConditionReady),
+			Status: metav1.ConditionTrue,
+			Reason: string(mcsv1a1.ServiceImportReasonReady),
+		}
+
+		// Check if any of the ServiceImport's IPFamilies are supported
+		if !slices.ContainsFunc(serviceImport.Spec.IPFamilies, func(ipFamily corev1.IPFamily) bool {
+			return slices.Contains(c.supportedIPFamilies, ipFamily)
+		}) {
+			ready.Status = metav1.ConditionFalse
+			ready.Reason = string(mcsv1a1.ServiceImportReasonIPFamilyNotSupported)
+			ready.Message = fmt.Sprintf("Service IP families %v are not compatible with the importing cluster IP families %v. "+
+				"The service will not be accessible from this cluster", serviceImport.Spec.IPFamilies, c.supportedIPFamilies)
+		}
+
+		if meta.SetStatusCondition(&serviceImport.Status.Conditions, ready) {
+			logger.Infof("Set status condition for imported ServiceImport (%s/%s): Type: %q, Status: %q, Reason: %q, Message: %q",
+				serviceImport.Namespace, serviceImport.Name, ready.Type, ready.Status, ready.Reason, ready.Message)
+		}
 
 		return serviceImport, false
 	}

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -27,6 +27,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/syncer"
 	"github.com/submariner-io/admiral/pkg/syncer/broker"
 	"github.com/submariner-io/admiral/pkg/watcher"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8slabels "k8s.io/apimachinery/pkg/labels"
@@ -87,6 +88,7 @@ type ServiceImportController struct {
 	localSyncer                syncer.Interface
 	remoteSyncer               syncer.Interface
 	localFederator             federate.Federator
+	supportedIPFamilies        []corev1.IPFamily
 	endpointControllers        sync.Map
 	clusterID                  string
 	localNamespace             string

--- a/pkg/agent/main.go
+++ b/pkg/agent/main.go
@@ -21,6 +21,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strings"
 	"syscall"
 
 	"github.com/kelseyhightower/envconfig"
@@ -36,11 +37,13 @@ import (
 	"github.com/submariner-io/admiral/pkg/util"
 	admversion "github.com/submariner-io/admiral/pkg/version"
 	"github.com/submariner-io/lighthouse/pkg/agent/controller"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
+	k8snet "k8s.io/utils/net"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
@@ -150,6 +153,7 @@ func main() {
 		ServiceImportCounterName: "submariner_service_import",
 		ServiceExportCounterName: "submariner_service_export",
 		IPPool:                   ipPool,
+		SupportedIPFamilies:      determineSupportedIPFamilies(),
 	})
 	exitOnError(err, "Failed to create lighthouse agent")
 
@@ -170,6 +174,34 @@ func main() {
 	<-ctx.Done()
 
 	logger.Info("All controllers stopped or exited. Stopping main loop")
+}
+
+func determineSupportedIPFamilies() []corev1.IPFamily {
+	var ipFamilies []corev1.IPFamily
+
+	cidrEnvVar := os.Getenv("SUBMARINER_CLUSTERCIDR")
+
+	logger.Infof("SUBMARINER_CLUSTERCIDR env: %q", cidrEnvVar)
+
+	for cidr := range strings.SplitSeq(cidrEnvVar, ",") {
+		s := strings.TrimSpace(cidr)
+		if s != "" {
+			k8sIPFamily := k8snet.IPFamilyOfCIDRString(s)
+			if k8sIPFamily == k8snet.IPv4 {
+				ipFamilies = append(ipFamilies, corev1.IPv4Protocol)
+			} else if k8sIPFamily == k8snet.IPv6 {
+				ipFamilies = append(ipFamilies, corev1.IPv6Protocol)
+			}
+		}
+	}
+
+	if len(ipFamilies) == 0 {
+		ipFamilies = []corev1.IPFamily{corev1.IPv4Protocol}
+	}
+
+	logger.Infof("Supported IP families: %v", ipFamilies)
+
+	return ipFamilies
 }
 
 func init() {


### PR DESCRIPTION
Set the `ServiceImport` `Ready` condition to false with reason `IPFamilyNotSupported` when none of the `ServiceImport`'s IP families are supported by the importing cluster.

Fixes: https://github.com/submariner-io/lighthouse/issues/1881

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lighthouse agents now auto-detect supported IP families (IPv4/IPv6) and expose that capability to the controller. ServiceImport readiness is reported with explicit NotReady status and a clear IP-family-not-supported reason when imports use unsupported IP families.

* **Tests**
  * Expanded tests for IP-family permutations and readiness behaviors, including IPv4-only import scenarios and improved readiness verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->