### PR TITLE
Genericize loadbalancer.Interface with type parameters

### DIFF
--- a/coredns/loadbalancer/balancer.go
+++ b/coredns/loadbalancer/balancer.go
@@ -19,15 +19,15 @@ limitations under the License.
 package loadbalancer
 
 // Interface - general interface explaining the API of all load balancers available in the package.
-type Interface interface {
-	// Next returns next item accordingly or nil if none present.
-	Next() (item any)
+type Interface[T any] interface {
+	// Next returns the next item and whether one was available.
+	Next() (item T, ok bool)
 	// Skip selecting the given item for a full round. This is useful if the item encountered a temporary failure.
-	Skip(item any)
+	Skip(item T)
 	// Add adds a weighted item for selection, if not already present.
-	Add(item any, weight int64) (err error)
+	Add(item T, weight int64) (err error)
 	// Reset removes all weighted items and resets state while retaining capacity for reuse.
 	Reset()
-	// The number of items in this instance.
+	// ItemCount returns the number of items in this instance.
 	ItemCount() int
 }

--- a/coredns/loadbalancer/smooth_weighted_round_robin.go
+++ b/coredns/loadbalancer/smooth_weighted_round_robin.go
@@ -21,35 +21,34 @@ package loadbalancer
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/log"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var logger = log.Logger{Logger: logf.Log.WithName("LoadBalancer")}
 
-type weightedItem struct {
-	item            any
+type weightedItem[T comparable] struct {
+	item            T
 	weight          int64
 	currentWeight   int64
 	effectiveWeight int64
 }
 
 // Smooth Weighted Round Robin load balancer implementation.
-type smoothWeightedRR struct {
-	items   []*weightedItem
-	itemMap map[any]*weightedItem
+type smoothWeightedRR[T comparable] struct {
+	items   []*weightedItem[T]
+	itemMap map[T]*weightedItem[T]
 }
 
 // NewSmoothWeightedRR returns a Smooth Weighted Round Robin load balancer.
-func NewSmoothWeightedRR() Interface {
-	return &smoothWeightedRR{
-		items:   make([]*weightedItem, 0),
-		itemMap: make(map[any]*weightedItem),
+func NewSmoothWeightedRR[T comparable]() Interface[T] {
+	return &smoothWeightedRR[T]{
+		items:   make([]*weightedItem[T], 0),
+		itemMap: make(map[T]*weightedItem[T]),
 	}
 }
 
-func (lb *smoothWeightedRR) Skip(item any) {
+func (lb *smoothWeightedRR[T]) Skip(item T) {
 	if wt, ok := lb.itemMap[item]; ok {
 		wt.effectiveWeight -= wt.weight
 		if wt.effectiveWeight < 0 {
@@ -61,16 +60,12 @@ func (lb *smoothWeightedRR) Skip(item any) {
 }
 
 // ItemCount returns the number of items.
-func (lb *smoothWeightedRR) ItemCount() int {
+func (lb *smoothWeightedRR[T]) ItemCount() int {
 	return len(lb.items)
 }
 
 // Add - adds a new unique item to the list.
-func (lb *smoothWeightedRR) Add(item any, weight int64) error {
-	if item == nil {
-		return errors.New("item cannot be nil")
-	}
-
+func (lb *smoothWeightedRR[T]) Add(item T, weight int64) error {
 	if weight < 0 {
 		return fmt.Errorf("item weight %v cannot be negative", weight)
 	}
@@ -79,7 +74,7 @@ func (lb *smoothWeightedRR) Add(item any, weight int64) error {
 		return fmt.Errorf("item %v already present", item)
 	}
 
-	weightedItem := &weightedItem{item: item, weight: weight, currentWeight: 0, effectiveWeight: weight}
+	weightedItem := &weightedItem[T]{item: item, weight: weight, currentWeight: 0, effectiveWeight: weight}
 
 	lb.itemMap[item] = weightedItem
 	lb.items = append(lb.items, weightedItem)
@@ -87,23 +82,24 @@ func (lb *smoothWeightedRR) Add(item any, weight int64) error {
 	return nil
 }
 
-// Reset - removes all items and resets state while retaining slice capacity for reuse.
-func (lb *smoothWeightedRR) Reset() {
+// Reset - removes all items and resets state while retaining capacity for reuse.
+func (lb *smoothWeightedRR[T]) Reset() {
+	clear(lb.items)
 	lb.items = lb.items[:0]
-	lb.itemMap = make(map[any]*weightedItem)
+	clear(lb.itemMap)
 }
 
 // Next - fetches the next item according to the smooth weighted round robin algorithm.
-func (lb *smoothWeightedRR) Next() any {
+func (lb *smoothWeightedRR[T]) Next() (T, bool) {
 	i := lb.nextWeightedItem()
 	if i == nil {
-		return nil
+		return *new(T), false
 	}
 
-	return i.item
+	return i.item, true
 }
 
-func (lb *smoothWeightedRR) nextWeightedItem() *weightedItem {
+func (lb *smoothWeightedRR[T]) nextWeightedItem() *weightedItem[T] {
 	itemsCount := len(lb.items)
 	if itemsCount == 0 {
 		return nil
@@ -113,7 +109,7 @@ func (lb *smoothWeightedRR) nextWeightedItem() *weightedItem {
 		return lb.items[0]
 	}
 
-	var best *weightedItem
+	var best *weightedItem[T]
 	total := int64(0)
 
 	for _, item := range lb.items {

--- a/coredns/loadbalancer/smooth_weighted_round_robin_test.go
+++ b/coredns/loadbalancer/smooth_weighted_round_robin_test.go
@@ -36,7 +36,14 @@ var _ = Describe("Smooth Weighted RR", func() {
 	var servers []server
 	var smoothTestingServers []server
 	var roundRobinServers []server
-	var lb loadbalancer.Interface
+	var lb loadbalancer.Interface[string]
+
+	nextOK := func() string {
+		name, ok := lb.Next()
+		Expect(ok).To(BeTrue())
+
+		return name
+	}
 
 	addServer := func(s server) {
 		err := lb.Add(s.name, s.weight)
@@ -61,7 +68,7 @@ var _ = Describe("Smooth Weighted RR", func() {
 	// Validations
 	validateServerAdded := func(s server) {
 		for range 100 {
-			if lb.Next() == s.name {
+			if nextOK() == s.name {
 				return
 			}
 		}
@@ -78,7 +85,9 @@ var _ = Describe("Smooth Weighted RR", func() {
 		Expect(lb.ItemCount()).To(Equal(0))
 
 		for range 100 {
-			Expect(lb.Next()).To(BeNil())
+			name, ok := lb.Next()
+			Expect(ok).To(BeFalse())
+			Expect(name).To(BeEmpty())
 		}
 	}
 
@@ -87,8 +96,7 @@ var _ = Describe("Smooth Weighted RR", func() {
 		results := make(map[string]int64)
 
 		for range rounds {
-			s := lb.Next().(string)
-			results[s]++
+			results[nextOK()]++
 		}
 
 		for _, s := range servers {
@@ -99,18 +107,18 @@ var _ = Describe("Smooth Weighted RR", func() {
 	}
 
 	validateSmoothLoadBalancing := func(servers []server) {
-		Expect(lb.Next().(string)).To(Equal(servers[0].name))
-		Expect(lb.Next().(string)).To(Equal(servers[0].name))
-		Expect(lb.Next().(string)).To(Equal(servers[1].name))
-		Expect(lb.Next().(string)).To(Equal(servers[0].name))
-		Expect(lb.Next().(string)).To(Equal(servers[2].name))
-		Expect(lb.Next().(string)).To(Equal(servers[0].name))
-		Expect(lb.Next().(string)).To(Equal(servers[0].name))
+		Expect(nextOK()).To(Equal(servers[0].name))
+		Expect(nextOK()).To(Equal(servers[0].name))
+		Expect(nextOK()).To(Equal(servers[1].name))
+		Expect(nextOK()).To(Equal(servers[0].name))
+		Expect(nextOK()).To(Equal(servers[2].name))
+		Expect(nextOK()).To(Equal(servers[0].name))
+		Expect(nextOK()).To(Equal(servers[0].name))
 	}
 
 	//nolint:gosec // Use of math/rand over crypto/rand is fine here as this is a unit test and is not security-sensitive.
 	BeforeEach(func() {
-		lb = loadbalancer.NewSmoothWeightedRR()
+		lb = loadbalancer.NewSmoothWeightedRR[string]()
 		smoothTestingServers = []server{
 			{name: "server1", weight: 5},
 			{name: "server2", weight: 1},
@@ -154,17 +162,18 @@ var _ = Describe("Smooth Weighted RR", func() {
 		})
 	})
 
-	When("a nil is added", func() {
-		It("should return an error", func() {
-			err := lb.Add(nil, 100)
-			Expect(err).To(HaveOccurred())
-			validateEmptyLBState()
+	When("a zero-value item is added", func() {
+		It("should be accepted like any other item", func() {
+			err := lb.Add("", 100)
+			Expect(err).To(Succeed())
+			Expect(lb.ItemCount()).To(Equal(1))
+			Expect(nextOK()).To(Equal(""))
 		})
 	})
 
 	When("an item is added with a negative weight", func() {
 		It("should return an error", func() {
-			err := lb.Add(servers[0], -100)
+			err := lb.Add(servers[0].name, -100)
 			Expect(err).To(HaveOccurred())
 			validateEmptyLBState()
 		})
@@ -176,7 +185,7 @@ var _ = Describe("Smooth Weighted RR", func() {
 			addServer(s)
 
 			for range 10 {
-				Expect(lb.Next()).To(Equal(s.name))
+				Expect(nextOK()).To(Equal(s.name))
 			}
 		})
 	})
@@ -200,7 +209,7 @@ var _ = Describe("Smooth Weighted RR", func() {
 
 			for range 100 {
 				for _, s := range roundRobinServers {
-					Expect(lb.Next().(string)).To(Equal(s.name))
+					Expect(nextOK()).To(Equal(s.name))
 				}
 			}
 		})
@@ -230,9 +239,9 @@ var _ = Describe("Smooth Weighted RR", func() {
 			failedItem := smoothTestingServers[0].name
 			lb.Skip(failedItem)
 			// Not to appear until a full round
-			Expect(lb.Next().(string)).To(Equal(smoothTestingServers[1].name))
-			Expect(lb.Next().(string)).To(Equal(smoothTestingServers[2].name))
-			Expect(lb.Next().(string)).To(Equal(smoothTestingServers[0].name))
+			Expect(nextOK()).To(Equal(smoothTestingServers[1].name))
+			Expect(nextOK()).To(Equal(smoothTestingServers[2].name))
+			Expect(nextOK()).To(Equal(smoothTestingServers[0].name))
 		})
 	})
 
@@ -240,23 +249,23 @@ var _ = Describe("Smooth Weighted RR", func() {
 		It("should accommodate the addition", func() {
 			addAllServers(smoothTestingServers)
 
-			Expect(lb.Next().(string)).To(Equal(smoothTestingServers[0].name))
-			Expect(lb.Next().(string)).To(Equal(smoothTestingServers[0].name))
-			Expect(lb.Next().(string)).To(Equal(smoothTestingServers[1].name))
+			Expect(nextOK()).To(Equal(smoothTestingServers[0].name))
+			Expect(nextOK()).To(Equal(smoothTestingServers[0].name))
+			Expect(nextOK()).To(Equal(smoothTestingServers[1].name))
 
 			newServer := server{name: "server4", weight: 1}
 			smoothTestingServers = append(smoothTestingServers, newServer)
 			err := lb.Add(newServer.name, newServer.weight)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(lb.Next().(string)).To(Equal(smoothTestingServers[0].name))
-			Expect(lb.Next().(string)).To(Equal(smoothTestingServers[2].name))
-			Expect(lb.Next().(string)).To(Equal(smoothTestingServers[0].name))
-			Expect(lb.Next().(string)).To(Equal(smoothTestingServers[0].name))
-			Expect(lb.Next().(string)).To(Equal(smoothTestingServers[3].name)) // new
-			Expect(lb.Next().(string)).To(Equal(smoothTestingServers[0].name))
-			Expect(lb.Next().(string)).To(Equal(smoothTestingServers[0].name))
-			Expect(lb.Next().(string)).To(Equal(smoothTestingServers[1].name))
+			Expect(nextOK()).To(Equal(smoothTestingServers[0].name))
+			Expect(nextOK()).To(Equal(smoothTestingServers[2].name))
+			Expect(nextOK()).To(Equal(smoothTestingServers[0].name))
+			Expect(nextOK()).To(Equal(smoothTestingServers[0].name))
+			Expect(nextOK()).To(Equal(smoothTestingServers[3].name)) // new
+			Expect(nextOK()).To(Equal(smoothTestingServers[0].name))
+			Expect(nextOK()).To(Equal(smoothTestingServers[0].name))
+			Expect(nextOK()).To(Equal(smoothTestingServers[1].name))
 
 			validateLoadBalancingByCount(100, smoothTestingServers)
 		})

--- a/coredns/resolver/ip_family_info.go
+++ b/coredns/resolver/ip_family_info.go
@@ -76,9 +76,12 @@ func (i *IPFamilyInfo) newRecordFrom(from *DNSRecord) *DNSRecord {
 }
 
 func (i *IPFamilyInfo) selectIP(checkCluster func(string, k8snet.IPFamily) bool) *DNSRecord {
-	queueLength := i.balancer.ItemCount()
-	for range queueLength {
-		clusterID := i.balancer.Next().(string)
+	for range i.balancer.ItemCount() {
+		clusterID, ok := i.balancer.Next()
+		if !ok {
+			break
+		}
+
 		clusterInfo := i.clusters[clusterID]
 
 		if checkCluster(clusterID, i.getNetIPFamily()) && clusterInfo.endpointsHealthy {

--- a/coredns/resolver/service_import.go
+++ b/coredns/resolver/service_import.go
@@ -43,12 +43,12 @@ func (i *Interface) PutServiceImport(serviceImport *mcsv1a1.ServiceImport) {
 			ipv4Info: IPFamilyInfo{
 				addrType: discovery.AddressTypeIPv4,
 				clusters: make(map[string]*clusterInfo),
-				balancer: loadbalancer.NewSmoothWeightedRR(),
+				balancer: loadbalancer.NewSmoothWeightedRR[string](),
 			},
 			ipv6Info: IPFamilyInfo{
 				addrType: discovery.AddressTypeIPv6,
 				clusters: make(map[string]*clusterInfo),
-				balancer: loadbalancer.NewSmoothWeightedRR(),
+				balancer: loadbalancer.NewSmoothWeightedRR[string](),
 			},
 		}
 

--- a/coredns/resolver/types.go
+++ b/coredns/resolver/types.go
@@ -57,7 +57,7 @@ type clusterInfo struct {
 type IPFamilyInfo struct {
 	addrType discovery.AddressType
 	clusters map[string]*clusterInfo
-	balancer loadbalancer.Interface
+	balancer loadbalancer.Interface[string]
 	ports    []mcsv1a1.ServicePort
 }
 


### PR DESCRIPTION
Changed `loadbalancer.Interface` to use Go generics with a comparable type parameter, eliminating runtime type assertions and providing compile-time type safety.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Load balancer converted to a generic, type-safe implementation for stronger compile-time checks and clearer APIs.
* **Bug Fixes**
  * Improved empty-state handling in selection so no invalid targets are returned and loops exit early when no items remain.
* **Tests**
  * Unit tests updated to reflect stronger typing and revised empty-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->