### PR TITLE
Remove unused com.github.commit label from Konflux Dockerfiles

### DIFF
--- a/package/Dockerfile.lighthouse-agent.konflux
+++ b/package/Dockerfile.lighthouse-agent.konflux
@@ -58,5 +58,4 @@ LABEL com.redhat.component="lighthouse-agent-container" \
       io.openshift.tags="submariner, lighthouse-agent, rhacm" \
       maintainer="multi-cluster-networking@redhat.com" \
       com.github.url="https://github.com/submariner-io/lighthouse" \
-      com.github.commit="${BASE_BRANCH}" \
       cpe="cpe:/a:redhat:acm:2.16::el9"

--- a/package/Dockerfile.lighthouse-coredns.konflux
+++ b/package/Dockerfile.lighthouse-coredns.konflux
@@ -61,5 +61,4 @@ LABEL com.redhat.component="lighthouse-coredns-container" \
       io.openshift.tags="submariner, lighthouse-coredns, rhacm" \
       maintainer="multi-cluster-networking@redhat.com" \
       com.github.url="https://github.com/submariner-io/lighthouse" \
-      com.github.commit="${BASE_BRANCH}" \
       cpe="cpe:/a:redhat:acm:2.16::el9"


### PR DESCRIPTION
The label was never used by any tooling and contained stale values.