### PR TITLE
Add HTTP client tracing metrics

### DIFF
--- a/coredns/go.mod
+++ b/coredns/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/onsi/gomega v1.40.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
-	github.com/submariner-io/admiral v0.24.0-m0.0.20260414184357-802f5267fa1c
+	github.com/submariner-io/admiral v0.24.0-m0.0.20260504071955-504d709fa512
 	k8s.io/api v0.35.4
 	k8s.io/apimachinery v0.35.4
 	k8s.io/client-go v0.35.4
@@ -139,7 +139,7 @@ require (
 	github.com/puzpuzpuz/xsync/v3 v3.5.1 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.0 // indirect
-	github.com/rs/zerolog v1.35.0 // indirect
+	github.com/rs/zerolog v1.35.1 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.10.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.2 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect

--- a/coredns/go.sum
+++ b/coredns/go.sum
@@ -325,8 +325,8 @@ github.com/richardartoul/molecule v1.0.1-0.20240531184615-7ca0df43c0b3 h1:4+LEVO
 github.com/richardartoul/molecule v1.0.1-0.20240531184615-7ca0df43c0b3/go.mod h1:vl5+MqJ1nBINuSsUI2mGgH79UweUT/B5Fy8857PqyyI=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/rs/zerolog v1.35.0 h1:VD0ykx7HMiMJytqINBsKcbLS+BJ4WYjz+05us+LRTdI=
-github.com/rs/zerolog v1.35.0/go.mod h1:EjML9kdfa/RMA7h/6z6pYmq1ykOuA8/mjWaEvGI+jcw=
+github.com/rs/zerolog v1.35.1 h1:m7xQeoiLIiV0BCEY4Hs+j2NG4Gp2o2KPKmhnnLiazKI=
+github.com/rs/zerolog v1.35.1/go.mod h1:EjML9kdfa/RMA7h/6z6pYmq1ykOuA8/mjWaEvGI+jcw=
 github.com/secure-systems-lab/go-securesystemslib v0.10.0 h1:l+H5ErcW0PAehBNrBxoGv1jjNpGYdZ9RcheFkB2WI14=
 github.com/secure-systems-lab/go-securesystemslib v0.10.0/go.mod h1:MRKONWmRoFzPNQ9USRF9i1mc7MvAVvF1LlW8X5VWDvk=
 github.com/shirou/gopsutil/v4 v4.26.2 h1:X8i6sicvUFih4BmYIGT1m2wwgw2VG9YgrDTi7cIRGUI=
@@ -350,8 +350,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/submariner-io/admiral v0.24.0-m0.0.20260414184357-802f5267fa1c h1:2Gzkk360NOwGbsaVTwmy515KkrfxSqdDNxY52p9AYd4=
-github.com/submariner-io/admiral v0.24.0-m0.0.20260414184357-802f5267fa1c/go.mod h1:XoUsIaK3BptXiCCx5ugfWuQ2yFVnVbgV5RH9k4AWFcY=
+github.com/submariner-io/admiral v0.24.0-m0.0.20260504071955-504d709fa512 h1:VOM/cAE7aF2+NUEy0r4M8BQbn9yJgT2jJ5LuhX7F+4s=
+github.com/submariner-io/admiral v0.24.0-m0.0.20260504071955-504d709fa512/go.mod h1:HDn54kTQb6Y1Nt6ZtrU6INIU2sXvPWikSLa0t4JQwl8=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=

--- a/coredns/plugin/setup.go
+++ b/coredns/plugin/setup.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/submariner-io/admiral/pkg/configmap"
 	"github.com/submariner-io/admiral/pkg/global"
+	"github.com/submariner-io/admiral/pkg/http"
 	"github.com/submariner-io/admiral/pkg/names"
 	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/watcher"
@@ -100,6 +101,8 @@ func lighthouseParse(c *caddy.Controller) (*Lighthouse, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "error building kubeconfig")
 	}
+
+	http.AddTraceMetrics(cfg, "coredns")
 
 	gwController := gateway.NewController()
 

--- a/coredns/plugin/setup_internal_test.go
+++ b/coredns/plugin/setup_internal_test.go
@@ -21,6 +21,7 @@ package lighthouse
 import (
 	"context"
 	"errors"
+	"maps"
 	"os"
 
 	"github.com/coredns/caddy"
@@ -30,6 +31,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/global"
+	"github.com/submariner-io/admiral/pkg/http"
 	"github.com/submariner-io/admiral/pkg/names"
 	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
@@ -82,9 +84,7 @@ var _ = Describe("Plugin setup", func() {
 			}), nil
 		}
 
-		newK8sClient = func(_ *rest.Config) (kubernetes.Interface, error) {
-			return k8sfake.NewClientset(), nil
-		}
+		setupGlobalConfigMap(map[string]string{})
 
 		restMapper = test.GetRESTMapperFor(&discovery.EndpointSlice{}, &mcsv1b1.ServiceImport{})
 	})
@@ -322,6 +322,9 @@ func verifyPluginError(err error, str string) {
 }
 
 func setupGlobalConfigMap(data map[string]string) {
+	data = maps.Clone(data)
+	data[http.DisableHTTPTraceMetrics] = "true"
+
 	newK8sClient = func(_ *rest.Config) (kubernetes.Interface, error) {
 		return k8sfake.NewClientset(&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/gomega v1.40.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.23.2
-	github.com/submariner-io/admiral v0.24.0-m0.0.20260414184357-802f5267fa1c
+	github.com/submariner-io/admiral v0.24.0-m0.0.20260504071955-504d709fa512
 	github.com/submariner-io/shipyard v0.24.0-m0.0.20260508204850-b306434bc296
 	k8s.io/api v0.35.4
 	k8s.io/apimachinery v0.35.4
@@ -52,7 +52,7 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
-	github.com/rs/zerolog v1.35.0 // indirect
+	github.com/rs/zerolog v1.35.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzM
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/rs/zerolog v1.35.0 h1:VD0ykx7HMiMJytqINBsKcbLS+BJ4WYjz+05us+LRTdI=
-github.com/rs/zerolog v1.35.0/go.mod h1:EjML9kdfa/RMA7h/6z6pYmq1ykOuA8/mjWaEvGI+jcw=
+github.com/rs/zerolog v1.35.1 h1:m7xQeoiLIiV0BCEY4Hs+j2NG4Gp2o2KPKmhnnLiazKI=
+github.com/rs/zerolog v1.35.1/go.mod h1:EjML9kdfa/RMA7h/6z6pYmq1ykOuA8/mjWaEvGI+jcw=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -126,8 +126,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/submariner-io/admiral v0.24.0-m0.0.20260414184357-802f5267fa1c h1:2Gzkk360NOwGbsaVTwmy515KkrfxSqdDNxY52p9AYd4=
-github.com/submariner-io/admiral v0.24.0-m0.0.20260414184357-802f5267fa1c/go.mod h1:XoUsIaK3BptXiCCx5ugfWuQ2yFVnVbgV5RH9k4AWFcY=
+github.com/submariner-io/admiral v0.24.0-m0.0.20260504071955-504d709fa512 h1:VOM/cAE7aF2+NUEy0r4M8BQbn9yJgT2jJ5LuhX7F+4s=
+github.com/submariner-io/admiral v0.24.0-m0.0.20260504071955-504d709fa512/go.mod h1:HDn54kTQb6Y1Nt6ZtrU6INIU2sXvPWikSLa0t4JQwl8=
 github.com/submariner-io/shipyard v0.24.0-m0.0.20260508204850-b306434bc296 h1:WBkXVS7fGU3F1lTpqeUg7hSQn8tpGgJlwxaPN8v7EF0=
 github.com/submariner-io/shipyard v0.24.0-m0.0.20260508204850-b306434bc296/go.mod h1:nc3rHJGSuMbptjT9tIA7YUAYYdds9EaiyAxBtmX9qcQ=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=

--- a/pkg/agent/main.go
+++ b/pkg/agent/main.go
@@ -112,6 +112,8 @@ func main() {
 	cfg, err := clientcmd.BuildConfigFromFlags(masterURL, kubeConfig)
 	exitOnError(err, "Error building kubeconfig")
 
+	http.AddTraceMetrics(cfg, "lighthouse")
+
 	// set up signals so we handle the first shutdown signal gracefully
 	ctx := signals.SetupSignalHandler()
 


### PR DESCRIPTION
Integrate Admiral's HTTP tracing metrics to monitor Kubernetes client performance in both lighthouse agent and CoreDNS plugin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Go module dependencies to newer upstream versions for dependency hygiene.

* **New Features**
  * Enabled trace metrics collection in CoreDNS plugin and the Kubernetes agent to improve observability and telemetry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/submariner-io/lighthouse/pull/2163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->