### PR TITLE
Gate pprof endpoint behind SUBMARINER_DEBUG env var

### DIFF
--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -80,6 +80,7 @@ type AgentSpecification struct {
 	// discovery works on clusters whose DNS cannot host the clusterset.local stanza
 	// (e.g. EKS Auto Mode's immutable node-local CoreDNS). Opt-in; default false.
 	ReflectClusterLocal bool `split_words:"true"`
+	Debug               bool
 }
 
 // The ServiceImportController encapsulates two resource syncers; one that watches for local cluster ServiceImports

--- a/pkg/agent/main.go
+++ b/pkg/agent/main.go
@@ -171,7 +171,12 @@ func main() {
 	err = lightHouseAgent.Start(ctx, ctx.Done())
 	exitOnError(err, "Failed to start lighthouse agent")
 
-	defer http.StartServer(http.Metrics|http.Profile, 8082)()
+	httpEndpoints := http.Metrics
+	if agentSpec.Debug {
+		httpEndpoints |= http.Profile
+	}
+
+	defer http.StartServer(httpEndpoints, 8082)()
 
 	<-ctx.Done()
 


### PR DESCRIPTION
The agent unconditionally started the admiral HTTP server with the Profile bit set, which registers the full `/debug/pprof/*` handler set on _0.0.0.0:8082_ with no authentication. Any pod on the cluster network can read `/debug/pprof/cmdline`, `goroutine?debug=2` stacks and trigger CPU/trace profiling.

Only include `http.Profile` in the `StartServer` mask when explicitly opted in via the SUBMARINER_DEBUG env var.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional debug mode for agents.
  * Profiling endpoints are now available only when debug mode is enabled, while metrics remain available by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->