### PR TITLE
Grant id-token write for cosign OIDC signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,9 @@ on:
       - release-0.19
       - release-*
 
-permissions: {}
+permissions:
+  id-token: write   # cosign keyless via Sigstore OIDC
+  contents: read
 
 jobs:
   release:


### PR DESCRIPTION
Grants `id-token: write` on the release workflow so shipyard's cosign keyless signing (FIND-015) can mint a GitHub OIDC token from inside the Dapper container.

Effective only after shipyard's FIND-015 change merges and the shipyard-dapper-base image is rebuilt/republished.

See commit messages for details.