### PR TITLE
Add configurable namespace validation for broker imports

### DIFF
--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -66,9 +66,10 @@ func New(ctx context.Context, spec *AgentSpecification, syncerConf broker.Syncer
 	}
 
 	agentController := &Controller{
-		clusterID:        spec.ClusterID,
-		namespace:        spec.Namespace,
-		globalnetEnabled: spec.GlobalnetEnabled,
+		clusterID:          spec.ClusterID,
+		namespace:          spec.Namespace,
+		globalnetEnabled:   spec.GlobalnetEnabled,
+		namespaceValidator: NewNamespaceValidator(),
 	}
 
 	agentController.localServiceImportFederator = federate.NewCreateOrUpdateFederator(federate.CreateOrUpdateOptions{
@@ -129,7 +130,7 @@ func New(ctx context.Context, spec *AgentSpecification, syncerConf broker.Syncer
 	agentController.serviceExportClient.localSyncer = agentController.serviceExportSyncer
 
 	agentController.endpointSliceController, err = newEndpointSliceController(ctx, spec, syncerConf, agentController.serviceExportClient,
-		agentController.serviceSyncer)
+		agentController.serviceSyncer, agentController.namespaceValidator)
 	if err != nil {
 		return nil, err
 	}
@@ -139,13 +140,13 @@ func New(ctx context.Context, spec *AgentSpecification, syncerConf broker.Syncer
 		agentController.endpointSliceController.syncer.GetBrokerNamespace(), agentController.serviceExportClient,
 		func(selector k8slabels.Selector) []runtime.Object {
 			return agentController.endpointSliceController.syncer.ListLocalResourcesBySelector(&discovery.EndpointSlice{}, selector)
-		})
+		}, agentController.namespaceValidator)
 	if err != nil {
 		return nil, err
 	}
 
 	if spec.ReflectClusterLocal {
-		agentController.clusterLocalReflector, err = newClusterLocalReflector(spec, syncerConf)
+		agentController.clusterLocalReflector, err = newClusterLocalReflector(spec, syncerConf, agentController.namespaceValidator)
 		if err != nil {
 			return nil, err
 		}
@@ -213,6 +214,7 @@ func (a *Controller) Start(ctx context.Context, stopCh <-chan struct{}) error {
 	return nil
 }
 
+//nolint:gocyclo // Refactoring would create helper functions requiring 4-5 parameters each.
 func (a *Controller) serviceExportToServiceImport(obj runtime.Object, _ int, op syncer.Operation) (runtime.Object, bool) {
 	svcExport := obj.(*mcsv1b1.ServiceExport)
 
@@ -222,6 +224,22 @@ func (a *Controller) serviceExportToServiceImport(obj runtime.Object, _ int, op 
 
 	if op == syncer.Delete {
 		return a.newServiceImport(svcExport.Name, svcExport.Namespace), false
+	}
+
+	if err := a.namespaceValidator.CheckAllowed(svcExport.Namespace); err != nil {
+		a.serviceExportClient.UpdateStatusConditions(ctx, svcExport.Name, svcExport.Namespace,
+			mcsv1b1.NewServiceExportCondition(mcsv1b1.ServiceExportConditionValid, metav1.ConditionFalse,
+				ServiceExportReasonRestrictedNamespace,
+				fmt.Sprintf("Service in namespace %q cannot be exported due to namespace restriction", svcExport.Namespace)))
+
+		err = a.localServiceImportFederator.Delete(ctx, a.newServiceImport(svcExport.Name, svcExport.Namespace))
+		if err != nil && !apierrors.IsNotFound(err) {
+			logger.Errorf(err, "Error deleting ServiceImport for restricted Service (%s/%s)", svcExport.Namespace, svcExport.Name)
+
+			return nil, true
+		}
+
+		return nil, false
 	}
 
 	obj, found, err := a.serviceSyncer.GetResource(svcExport.Name, svcExport.Namespace)

--- a/pkg/agent/controller/clusterip_service_test.go
+++ b/pkg/agent/controller/clusterip_service_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/fake"
+	"github.com/submariner-io/admiral/pkg/federate"
 	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
 	testutil "github.com/submariner-io/admiral/pkg/test"
@@ -167,6 +168,24 @@ func testClusterIPServiceInOneCluster() {
 
 				t.awaitNonHeadlessServiceExported(ctx, &t.cluster1)
 			})
+		})
+	})
+
+	When("a ServiceExport is created for a Service whose namespace is restricted", func() {
+		BeforeEach(func() {
+			t.cluster1.service.Namespace = metav1.NamespaceSystem
+			t.cluster1.serviceExport.Namespace = metav1.NamespaceSystem
+		})
+
+		JustBeforeEach(func(ctx context.Context) {
+			t.cluster1.createService(ctx)
+			t.cluster1.createServiceExport(ctx)
+		})
+
+		It("should not export the service", func(ctx context.Context) {
+			t.cluster1.awaitServiceExportCondition(ctx, newServiceExportValidCondition(metav1.ConditionFalse,
+				controller.ServiceExportReasonRestrictedNamespace))
+			t.cluster1.ensureNoServiceExportCondition(ctx, mcsv1b1.ServiceExportConditionReady)
 		})
 	})
 
@@ -510,6 +529,25 @@ func testClusterIPServiceInOneCluster() {
 
 			t.awaitNonHeadlessServiceExported(ctx, &t.cluster1)
 		})
+	})
+
+	Specify("an EndpointSlice with a restricted service namespace should not be synced from the broker", func(ctx context.Context) {
+		restrictedNamespace := metav1.NamespaceSystem
+
+		test.CreateResource(ctx, endpointSliceClientFor(t.syncerConfig.BrokerClient, test.RemoteNamespace),
+			&discovery.EndpointSlice{ObjectMeta: metav1.ObjectMeta{
+				Name: "restricted-eps",
+				Labels: map[string]string{
+					discovery.LabelManagedBy:       constants.LabelValueManagedBy,
+					constants.LabelSourceNamespace: restrictedNamespace,
+					mcsv1b1.LabelSourceCluster:     "south",
+					mcsv1b1.LabelServiceName:       serviceName,
+					federate.ClusterIDLabelKey:     "south",
+				},
+			}})
+
+		testutil.EnsureNoResource(ctx, resource.ForDynamic(endpointSliceClientFor(t.cluster1.localDynClient,
+			restrictedNamespace)), "restricted-eps")
 	})
 }
 
@@ -904,11 +942,11 @@ func testClusterIPServiceInTwoClusters() {
 
 			By("Updating the ServiceExport on the second cluster")
 
-			se, err := t.cluster2.localServiceExportClient.Get(ctx, t.cluster2.serviceExport.Name, metav1.GetOptions{})
+			se, err := t.cluster2.localServiceExportClient().Get(ctx, t.cluster2.serviceExport.Name, metav1.GetOptions{})
 			Expect(err).To(Succeed())
 
 			se.SetAnnotations(map[string]string{constants.UseClustersetIP: strconv.FormatBool(true)})
-			test.UpdateResource(ctx, t.cluster2.localServiceExportClient, se)
+			test.UpdateResource(ctx, t.cluster2.localServiceExportClient(), se)
 
 			t.cluster1.awaitServiceExportCondition(ctx, noConflictCondition)
 			t.cluster2.awaitServiceExportCondition(ctx, noConflictCondition)

--- a/pkg/agent/controller/clusterlocal_reflector.go
+++ b/pkg/agent/controller/clusterlocal_reflector.go
@@ -78,14 +78,17 @@ type ClusterLocalReflector struct {
 	federator           federate.Federator
 	serviceClient       dynamic.NamespaceableResourceInterface
 	endpointSliceClient dynamic.NamespaceableResourceInterface
+	namespaceValidator  *NamespaceValidator
 }
 
 //nolint:gocritic // (hugeParam) matches the other controller constructors.
-func newClusterLocalReflector(spec *AgentSpecification, syncerConfig broker.SyncerConfig) (*ClusterLocalReflector, error) {
+func newClusterLocalReflector(spec *AgentSpecification, syncerConfig broker.SyncerConfig, namespaceValidator *NamespaceValidator,
+) (*ClusterLocalReflector, error) {
 	c := &ClusterLocalReflector{
 		clusterID:           spec.ClusterID,
 		serviceClient:       syncerConfig.LocalClient.Resource(ServiceGVR),
 		endpointSliceClient: syncerConfig.LocalClient.Resource(endpointSliceGVR),
+		namespaceValidator:  namespaceValidator,
 	}
 
 	// Empty TargetNamespace => the federator uses each object's own namespace.
@@ -195,6 +198,14 @@ func (c *ClusterLocalReflector) reflect(obj runtime.Object, _ int, op syncer.Ope
 	// services already exist locally under their real cluster.local name.
 	if serviceName == "" || serviceNamespace == "" || sourceCluster == "" || sourceCluster == c.clusterID {
 		return nil, false
+	}
+
+	if op != syncer.Delete {
+		if err := c.namespaceValidator.CheckAllowed(serviceNamespace); err != nil {
+			logger.Warningf("Rejecting EndpointSlice from cluster %q: %v", imported.Labels[mcsv1b1.LabelSourceCluster], err)
+
+			return nil, false
+		}
 	}
 
 	reflectedName := serviceName + "-" + sourceCluster

--- a/pkg/agent/controller/controller_suite_test.go
+++ b/pkg/agent/controller/controller_suite_test.go
@@ -119,7 +119,6 @@ type cluster struct {
 	agentSpec                  controller.AgentSpecification
 	localDynClient             dynamic.Interface
 	localDynClientFake         *k8stesting.Fake
-	localServiceExportClient   dynamic.ResourceInterface
 	localServiceImportClient   dynamic.NamespaceableResourceInterface
 	localIngressIPClient       dynamic.ResourceInterface
 	localEndpointSliceClient   dynamic.ResourceInterface
@@ -370,9 +369,6 @@ func (c *cluster) init(ctx context.Context, syncerConfig *broker.SyncerConfig, d
 
 	c.localServiceImportReactor = fake.NewFailingReactorForResource(c.localDynClientFake, mcsv1b1.ServiceImportPluralName)
 
-	c.localServiceExportClient = c.localDynClient.Resource(*test.GetGroupVersionResourceFor(syncerConfig.RestMapper,
-		&mcsv1b1.ServiceExport{})).Namespace(serviceNamespace)
-
 	c.localServiceImportClient = c.localDynClient.Resource(*test.GetGroupVersionResourceFor(syncerConfig.RestMapper,
 		&mcsv1b1.ServiceImport{}))
 
@@ -450,11 +446,11 @@ func (c *cluster) deleteService(ctx context.Context) {
 }
 
 func (c *cluster) createServiceExport(ctx context.Context) {
-	test.CreateResource(ctx, c.localServiceExportClient, c.serviceExport)
+	test.CreateResource(ctx, c.localServiceExportClient(), c.serviceExport)
 }
 
 func (c *cluster) deleteServiceExport(ctx context.Context) {
-	Expect(c.localServiceExportClient.Delete(ctx, c.serviceExport.GetName(), metav1.DeleteOptions{})).To(Succeed())
+	Expect(c.localServiceExportClient().Delete(ctx, c.serviceExport.GetName(), metav1.DeleteOptions{})).To(Succeed())
 }
 
 func (c *cluster) createServiceEndpointSlices(ctx context.Context) {
@@ -581,7 +577,7 @@ func (c *cluster) awaitServiceExportCondition(ctx context.Context, expected ...m
 	last := len(expected) - 1
 
 	Eventually(ctx, func(g Gomega, ctx context.Context) {
-		obj, err := c.localServiceExportClient.Get(ctx, c.serviceExport.Name, metav1.GetOptions{})
+		obj, err := c.localServiceExportClient().Get(ctx, c.serviceExport.Name, metav1.GetOptions{})
 		Expect(err).To(Succeed())
 
 		se := toServiceExport(obj)
@@ -589,7 +585,7 @@ func (c *cluster) awaitServiceExportCondition(ctx context.Context, expected ...m
 
 		g.Expect(c).NotTo(BeNil(), "ServiceExport condition not found for type %q", expected[last].Type)
 		assertEquivalentConditions(g, c, &expected[last])
-	}).Should(Succeed())
+	}).Within(time.Second * 3).Should(Succeed())
 }
 
 //nolint:gocritic // Ignore hugeParam
@@ -677,6 +673,10 @@ func (c *cluster) verifyServiceImportReady(si *mcsv1b1.ServiceImport) {
 	cond := meta.FindStatusCondition(si.Status.Conditions, string(mcsv1b1.ServiceImportConditionReady))
 	Expect(cond).ToNot(BeNil(), "ServiceImport Ready condition not found")
 	c.verifyImportReadyCondition(cond)
+}
+
+func (c *cluster) localServiceExportClient() dynamic.ResourceInterface {
+	return serviceExportClientFor(c.localDynClient, c.serviceExport.Namespace)
 }
 
 func awaitServiceImport(ctx context.Context, client dynamic.NamespaceableResourceInterface, expected *mcsv1b1.ServiceImport,

--- a/pkg/agent/controller/endpoint_slice.go
+++ b/pkg/agent/controller/endpoint_slice.go
@@ -38,12 +38,14 @@ import (
 
 //nolint:gocritic // (hugeParam) This function modifies syncerConf so we don't want to pass by pointer.
 func newEndpointSliceController(ctx context.Context, spec *AgentSpecification, syncerConfig broker.SyncerConfig,
-	serviceExportClient *ServiceExportClient, serviceSyncer syncer.Interface,
+	serviceExportClient *ServiceExportClient, serviceSyncer syncer.Interface, namespaceValidator *NamespaceValidator,
 ) (*EndpointSliceController, error) {
 	c := &EndpointSliceController{
 		clusterID:           spec.ClusterID,
 		serviceExportClient: serviceExportClient,
 		serviceSyncer:       serviceSyncer,
+		localClient:         syncerConfig.LocalClient,
+		namespaceValidator:  namespaceValidator,
 	}
 
 	syncerConfig.LocalNamespace = metav1.NamespaceAll
@@ -137,9 +139,28 @@ func isLegacyEndpointSlice(endpointSlice *discovery.EndpointSlice) bool {
 	return strings.HasSuffix(endpointSlice.Name, "-"+endpointSlice.Labels[mcsv1b1.LabelSourceCluster])
 }
 
-func (c *EndpointSliceController) onRemoteEndpointSlice(obj runtime.Object, _ int, _ syncer.Operation) (runtime.Object, bool) {
+func (c *EndpointSliceController) onRemoteEndpointSlice(obj runtime.Object, _ int, op syncer.Operation) (runtime.Object, bool) {
 	endpointSlice := obj.(*discovery.EndpointSlice)
-	endpointSlice.Namespace = endpointSlice.GetObjectMeta().GetLabels()[constants.LabelSourceNamespace]
+	targetNamespace := endpointSlice.GetObjectMeta().GetLabels()[constants.LabelSourceNamespace]
+
+	if op != syncer.Delete {
+		if err := c.namespaceValidator.CheckAllowed(targetNamespace); err != nil {
+			logger.Warningf("Rejecting EndpointSlice from cluster %q: %v", endpointSlice.Labels[mcsv1b1.LabelSourceCluster], err)
+
+			// Delete stale local ServiceImport if it exists
+			deleteErr := c.localClient.Resource(endpointSliceGVR).Namespace(targetNamespace).Delete(
+				context.TODO(), endpointSlice.Name, metav1.DeleteOptions{})
+			if deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+				logger.Errorf(deleteErr, "Error deleting rejected EndpointSlice %s/%s", targetNamespace, endpointSlice.Name)
+
+				return nil, true
+			}
+
+			return nil, false
+		}
+	}
+
+	endpointSlice.Namespace = targetNamespace
 
 	return endpointSlice, false
 }

--- a/pkg/agent/controller/namespace_validator.go
+++ b/pkg/agent/controller/namespace_validator.go
@@ -1,0 +1,87 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/global"
+)
+
+const (
+	ConfigKeyImportNamespaceDenyList = "import-namespace-deny-list"
+	DefaultImportNamespaceDenyList   = "kube-,openshift-,openshift"
+)
+
+// NamespaceValidator validates broker-supplied namespace labels against a configurable denylist.
+type NamespaceValidator struct {
+	denyList []string
+}
+
+// NewNamespaceValidator creates a validator using the configured denylist from ConfigMap.
+// If not configured, uses DefaultImportNamespaceDenyList.
+func NewNamespaceValidator() *NamespaceValidator {
+	denyListStr := global.Get(ConfigKeyImportNamespaceDenyList, DefaultImportNamespaceDenyList)
+
+	var denyList []string
+	if denyListStr != "" {
+		denyList = strings.Split(denyListStr, ",")
+		// Trim whitespace from each entry
+		for i := range denyList {
+			denyList[i] = strings.TrimSpace(denyList[i])
+		}
+	}
+
+	logger.Infof("Namespace validator using deny list: %v", denyList)
+
+	return &NamespaceValidator{
+		denyList: denyList,
+	}
+}
+
+// CheckAllowed checks if a broker-supplied namespace is safe to use as a target namespace
+// in the local cluster. Broker objects are written by remote member-cluster ServiceAccounts
+// and are untrusted; allowing them to target privileged or system namespaces enables
+// namespace injection attacks (CWE-441: Confused Deputy) where a compromised peer can
+// pollute system namespaces fleet-wide, bypassing local ServiceExport admission policies.
+func (v *NamespaceValidator) CheckAllowed(namespace string) error {
+	// Reject empty namespace explicitly
+	if namespace == "" {
+		return errors.New("namespace cannot be empty")
+	}
+
+	// Check against denylist
+	for _, entry := range v.denyList {
+		if entry == "" {
+			continue
+		}
+
+		// If entry ends with hyphen, treat as prefix match only, otherwise use exact match.
+		if strings.HasSuffix(entry, "-") {
+			if strings.HasPrefix(namespace, entry) {
+				return errors.Errorf("namespace %q matches denied prefix %q", namespace, entry)
+			}
+		} else if namespace == entry {
+			return errors.Errorf("namespace %q is denied (matches %q)", namespace, entry)
+		}
+	}
+
+	return nil
+}

--- a/pkg/agent/controller/namespace_validator_test.go
+++ b/pkg/agent/controller/namespace_validator_test.go
@@ -1,0 +1,83 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/global"
+	"github.com/submariner-io/lighthouse/pkg/agent/controller"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("NamespaceValidator", func() {
+	var (
+		validator *controller.NamespaceValidator
+		configMap *corev1.ConfigMap
+	)
+
+	BeforeEach(func() {
+		configMap = nil
+	})
+
+	JustBeforeEach(func() {
+		global.Init(configMap)
+
+		DeferCleanup(func() {
+			global.Init(nil)
+		})
+
+		validator = controller.NewNamespaceValidator()
+	})
+
+	Context("with no configured deny list", func() {
+		It("should use the default deny list", func() {
+			Expect(validator.CheckAllowed("kube-system")).NotTo(Succeed())
+			Expect(validator.CheckAllowed("kube-public")).NotTo(Succeed())
+			Expect(validator.CheckAllowed("kube-node-lease")).NotTo(Succeed())
+			Expect(validator.CheckAllowed("openshift-ovn-kubernetes")).NotTo(Succeed())
+			Expect(validator.CheckAllowed("openshift-console")).NotTo(Succeed())
+			Expect(validator.CheckAllowed("")).NotTo(Succeed())
+
+			Expect(validator.CheckAllowed("default")).To(Succeed())
+			Expect(validator.CheckAllowed("my-app")).To(Succeed())
+			Expect(validator.CheckAllowed("production")).To(Succeed())
+			Expect(validator.CheckAllowed("my-openshift-app")).To(Succeed())
+			Expect(validator.CheckAllowed("test-kube-demo")).To(Succeed())
+		})
+	})
+
+	Context("with a configured deny list", func() {
+		BeforeEach(func() {
+			configMap = &corev1.ConfigMap{
+				Data: map[string]string{
+					controller.ConfigKeyImportNamespaceDenyList: "default , system-",
+				},
+			}
+		})
+
+		It("should use it", func() {
+			Expect(validator.CheckAllowed("default")).NotTo(Succeed())
+			Expect(validator.CheckAllowed("system-core")).NotTo(Succeed())
+
+			Expect(validator.CheckAllowed("defaulttest")).To(Succeed())
+			Expect(validator.CheckAllowed("my-system")).To(Succeed())
+		})
+	})
+})

--- a/pkg/agent/controller/reconciliation_test.go
+++ b/pkg/agent/controller/reconciliation_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Reconciliation", func() {
 		Expect(endpointSlices).To(HaveLen(1))
 		localEndpointSlice = endpointSlices[0]
 
-		obj, err := t.cluster1.localServiceExportClient.Get(ctx, t.cluster1.serviceExport.Name, metav1.GetOptions{})
+		obj, err := t.cluster1.localServiceExportClient().Get(ctx, t.cluster1.serviceExport.Name, metav1.GetOptions{})
 		Expect(err).To(Succeed())
 
 		serviceExport = toServiceExport(obj)
@@ -127,7 +127,7 @@ var _ = Describe("Reconciliation", func() {
 
 			test.CreateResource(ctx, t.cluster1.localServiceImportClient.Namespace(test.LocalNamespace), localServiceImport)
 			test.CreateResource(ctx, t.cluster1.localEndpointSliceClient, localEndpointSlice)
-			test.CreateResource(ctx, t.cluster1.localServiceExportClient, serviceExport)
+			test.CreateResource(ctx, t.cluster1.localServiceExportClient(), serviceExport)
 
 			_, err := t.cluster1.localServiceImportClient.Namespace(serviceNamespace).Create(ctx, localAggregatedServiceImport,
 				metav1.CreateOptions{})
@@ -281,7 +281,7 @@ var _ = Describe("Reconciliation", func() {
 				restoreBrokerResources(ctx)
 				test.CreateResource(ctx, t.cluster1.localServiceImportClient.Namespace(test.LocalNamespace), localServiceImport)
 				test.CreateResource(ctx, t.cluster1.localEndpointSliceClient, localEndpointSlice)
-				test.CreateResource(ctx, t.cluster1.localServiceExportClient, serviceExport)
+				test.CreateResource(ctx, t.cluster1.localServiceExportClient(), serviceExport)
 				t.cluster1.createService(ctx)
 
 				// Create a remote EPS for the same service and ensure it's not deleted.

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -48,7 +48,7 @@ import (
 //nolint:gocritic // (hugeParam) This function modifies syncerConf so we don't want to pass by pointer.
 func newServiceImportController(spec *AgentSpecification, agentConfig AgentConfig, syncerConfig broker.SyncerConfig,
 	brokerClient dynamic.Interface, brokerNamespace string, serviceExportClient *ServiceExportClient,
-	localLHEndpointSliceLister EndpointSliceListerFn,
+	localLHEndpointSliceLister EndpointSliceListerFn, namespaceValidator *NamespaceValidator,
 ) (*ServiceImportController, error) {
 	controller := &ServiceImportController{
 		localClient:                syncerConfig.LocalClient,
@@ -63,6 +63,7 @@ func newServiceImportController(spec *AgentSpecification, agentConfig AgentConfi
 		clustersetIPPool:           agentConfig.IPPool,
 		clustersetIPEnabled:        spec.ClustersetIPEnabled,
 		supportedIPFamilies:        agentConfig.SupportedIPFamilies,
+		namespaceValidator:         namespaceValidator,
 	}
 
 	localToBrokerFederator := federate.NewCreateOrUpdateFederator(federate.CreateOrUpdateOptions{
@@ -335,11 +336,32 @@ func (c *ServiceImportController) transformLocalToBroker(serviceImport *mcsv1b1.
 func (c *ServiceImportController) onRemoteServiceImport(obj runtime.Object, _ int, op syncer.Operation) (runtime.Object, bool) {
 	serviceImport := obj.(*mcsv1b1.ServiceImport)
 
+	ctx := context.TODO()
+
 	serviceName, ok := serviceImport.Annotations[mcsv1b1.LabelServiceName]
 	if ok {
 		// This is an aggregated ServiceImport - sync it to the local service namespace.
 		serviceImport.Name = serviceName
-		serviceImport.Namespace = serviceImport.Annotations[constants.LabelSourceNamespace]
+		targetNamespace := serviceImport.Annotations[constants.LabelSourceNamespace]
+
+		if op != syncer.Delete {
+			if err := c.namespaceValidator.CheckAllowed(targetNamespace); err != nil {
+				logger.Warningf("Rejecting aggregated ServiceImport: %v", err)
+
+				// Delete stale local ServiceImport if it exists
+				deleteErr := c.localClient.Resource(serviceImportGVR).Namespace(targetNamespace).Delete(
+					ctx, serviceName, metav1.DeleteOptions{})
+				if deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+					logger.Errorf(deleteErr, "Error deleting rejected ServiceImport %s/%s", targetNamespace, serviceName)
+
+					return nil, true
+				}
+
+				return nil, false
+			}
+		}
+
+		serviceImport.Namespace = targetNamespace
 
 		delete(serviceImport.Annotations, mcsv1b1.LabelServiceName)
 		delete(serviceImport.Annotations, constants.LabelSourceNamespace)
@@ -368,7 +390,6 @@ func (c *ServiceImportController) onRemoteServiceImport(obj runtime.Object, _ in
 		return serviceImport, false
 	}
 
-	ctx := context.TODO()
 	serviceName = serviceImport.Labels[mcsv1b1.LabelServiceName]
 	serviceNamespace := serviceImport.Labels[constants.LabelSourceNamespace]
 

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -43,6 +43,7 @@ const (
 	ServiceExportReasonClusterSetIPEnablementConflict mcsv1b1.ServiceExportConditionReason = "ClusterSetIPEnablementConflict"
 	ServiceExportReasonUnsupportedIPFamily            mcsv1b1.ServiceExportConditionReason = "UnsupportedIPFamily"
 	ServiceExportReasonGlobalIPUnavailable            mcsv1b1.ServiceExportConditionReason = "ServiceGlobalIPUnavailable"
+	ServiceExportReasonRestrictedNamespace            mcsv1b1.ServiceExportConditionReason = "RestrictedNamespace"
 )
 
 type EndpointSliceListerFn func(selector k8slabels.Selector) []runtime.Object
@@ -65,6 +66,7 @@ type Controller struct {
 	localServiceImportFederator federate.Federator
 	namespaceInformer           cache.SharedInformer
 	clusterLocalReflector       *ClusterLocalReflector
+	namespaceValidator          *NamespaceValidator
 }
 
 type AgentSpecification struct {
@@ -104,6 +106,7 @@ type ServiceImportController struct {
 	localLHEndpointSliceLister EndpointSliceListerFn
 	clustersetIPPool           *ipam.IPPool
 	clustersetIPEnabled        bool
+	namespaceValidator         *NamespaceValidator
 }
 
 // ServiceEndpointSliceController watches for the EndpointSlices that backs a Service and have a ServiceImport.
@@ -129,6 +132,8 @@ type EndpointSliceController struct {
 	syncer              *broker.Syncer
 	serviceExportClient *ServiceExportClient
 	serviceSyncer       syncer.Interface
+	localClient         dynamic.Interface
+	namespaceValidator  *NamespaceValidator
 }
 
 type ServiceExportClient struct {


### PR DESCRIPTION
Broker-supplied `ServiceImports` and `EndpointSlices` can target arbitrary local namespaces via attacker-controlled labels/annotations. This enables namespace injection attacks (CWE-441: Confused Deputy) where a compromised peer pollutes privileged namespaces (kube-system, openshift-*) fleet-wide, bypassing local `ServiceExport` admission.

Add a `NamespaceValidator` with configurable deny list via ConfigMap:
- Default blocks: kube-*, openshift-*, openshift
- Operators can customize via "import-namespace-deny-list" ConfigMap key
- Entries with trailing hyphen = prefix match (e.g., "kube-")
- Entries without hyphen = exact + prefix match (e.g., "openshift")

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable namespace restrictions for service exports, service imports, and EndpointSlices.
  * Supports exact namespace matches and prefix-based restrictions, including settings provided through configuration.
  * Restricted service exports now report a clear status condition explaining why they were blocked.

* **Bug Fixes**
  * Prevented resources from restricted namespaces from syncing to local clusters.
  * Improved cleanup and retry handling when restricted exports are removed.

* **Tests**
  * Added coverage for default and configured restrictions, including prefix matching and synchronization safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->