### PR TITLE
Reject special-range IPs from imported records

### DIFF
--- a/coredns/resolver/address_internal_test.go
+++ b/coredns/resolver/address_internal_test.go
@@ -1,0 +1,49 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolver
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("isPermittedEndpointAddress", func() {
+	DescribeTable("should validate endpoint addresses",
+		func(address string, expected bool) {
+			Expect(isPermittedEndpointAddress(address)).To(Equal(expected))
+		},
+		Entry("valid IPv4 private address 10.x", "10.0.0.1", true),
+		Entry("valid IPv4 private address 172.16.x", "172.16.5.4", true),
+		Entry("valid IPv4 private address 192.168.x", "192.168.1.1", true),
+		Entry("valid IPv4 public address", "203.0.113.7", true),
+		Entry("valid IPv6 ULA address", "fd00::1", true),
+		Entry("valid IPv6 documentation address", "2001:db8::1", true),
+		Entry("empty string", "", false),
+		Entry("invalid IP string", "not-an-ip", false),
+		Entry("IPv4 unspecified address", "0.0.0.0", false),
+		Entry("IPv6 unspecified address", "::", false),
+		Entry("IPv4 loopback address", "127.0.0.1", false),
+		Entry("IPv6 loopback address", "::1", false),
+		Entry("IPv4 link-local address", "169.254.169.254", false),
+		Entry("IPv6 link-local address", "fe80::1", false),
+		Entry("IPv4 multicast address", "224.0.0.1", false),
+		Entry("IPv6 multicast address", "ff02::1", false),
+		Entry("IPv4 broadcast address", "255.255.255.255", false),
+	)
+})

--- a/coredns/resolver/clusterip_service_test.go
+++ b/coredns/resolver/clusterip_service_test.go
@@ -447,11 +447,15 @@ func testClusterIPServiceMisc() {
 }
 
 func testClusterSetIP() {
-	const clusterSetIP = "243.1.0.1"
-
 	t := newTestDriver()
 
+	var clusterSetIP string
+
 	BeforeEach(func(ctx context.Context) {
+		clusterSetIP = "243.1.0.1"
+	})
+
+	JustBeforeEach(func(ctx context.Context) {
 		si := newAggregatedServiceImport(namespace1, service1)
 
 		si.Spec.IPs = []string{clusterSetIP}
@@ -482,6 +486,16 @@ func testClusterSetIP() {
 				Ports:       []mcsv1b1.ServicePort{port1},
 				ClusterName: clusterID1,
 			})
+		})
+	})
+
+	Context("that is invalid", func() {
+		BeforeEach(func(ctx context.Context) {
+			clusterSetIP = "127.0.0.0"
+		})
+
+		It("should return no DNS records found", func() {
+			t.assertDNSRecordsNotFound(namespace1, service1, "", "")
 		})
 	})
 }

--- a/coredns/resolver/endpoint_slice.go
+++ b/coredns/resolver/endpoint_slice.go
@@ -21,6 +21,7 @@ package resolver
 import (
 	"context"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 
@@ -108,9 +109,21 @@ func (i *Interface) putClusterIPEndpointSlice(key, clusterID string, endpointSli
 		return
 	}
 
+	address := endpointSlice.Endpoints[0].Addresses[0]
+	if !isPermittedEndpointAddress(address) {
+		logger.Warningf("Rejecting non-routable address %q in EndpointSlice %q from cluster %q", address, key, clusterID)
+
+		delete(ipFamilyInfo.clusters, clusterID)
+		ipFamilyInfo.mergePorts()
+		ipFamilyInfo.resetLoadBalancing()
+
+		return
+	}
+
 	clusterInfo := ipFamilyInfo.ensureClusterInfo(clusterID)
+
 	clusterInfo.endpointRecords = []DNSRecord{{
-		IP:          endpointSlice.Endpoints[0].Addresses[0],
+		IP:          address,
 		Ports:       mcsServicePortsFrom(endpointSlice.Ports),
 		ClusterName: clusterID,
 	}}
@@ -163,6 +176,13 @@ func (i *Interface) putHeadlessEndpointSlices(key, clusterID string, endpointSli
 				}
 
 				allAddresses.Insert(address)
+
+				if !isPermittedEndpointAddress(address) {
+					logger.Warningf("Rejecting non-routable address %q in headless EndpointSlice %q from cluster %q",
+						address, key, clusterID)
+
+					continue
+				}
 
 				var hostname string
 
@@ -307,4 +327,19 @@ func isHeadless(endpointSlice *discovery.EndpointSlice) bool {
 func shouldRetrieveLocalEndpointSlicesFor(endpointSlice *discovery.EndpointSlice) bool {
 	return endpointSlice.AddressType == discovery.AddressTypeIPv4 &&
 		isHeadless(endpointSlice) && endpointSlice.Annotations[constants.GlobalnetEnabled] == strconv.FormatBool(true)
+}
+
+// isPermittedEndpointAddress reports whether the given broker-supplied address may be served as a clusterset.local DNS answer.
+// Endpoint and ServiceImport addresses originate from remote member clusters via the broker and are therefore untrusted; serving them
+// without range validation lets a compromised peer steer cross-cluster DNS to loopback, link-local (incl. 169.254.169.254 cloud metadata),
+// unspecified, multicast or broadcast addresses. This guards the DNS sink only and does not attempt source-cluster CIDR matching, which
+// requires data not available to the resolver.
+func isPermittedEndpointAddress(address string) bool {
+	ip := net.ParseIP(address)
+	if ip == nil {
+		return false
+	}
+
+	return !ip.IsUnspecified() && !ip.IsLoopback() && !ip.IsLinkLocalUnicast() && !ip.IsLinkLocalMulticast() && !ip.IsMulticast() &&
+		!ip.Equal(net.IPv4bcast)
 }

--- a/coredns/resolver/endpoint_slice_test.go
+++ b/coredns/resolver/endpoint_slice_test.go
@@ -24,8 +24,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
 	"github.com/submariner-io/lighthouse/coredns/constants"
+	"github.com/submariner-io/lighthouse/coredns/resolver"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8snet "k8s.io/utils/net"
 	mcsv1b1 "sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 )
 
@@ -66,6 +68,49 @@ var _ = Describe("PutEndpointSlices", func() {
 					},
 				},
 			})
+		})
+	})
+
+	When("a ClusterIP EndpointSlice has a non-routable address", func() {
+		It("should not add a DNS record", func(ctx context.Context) {
+			t.resolver.PutServiceImport(newAggregatedServiceImport(namespace1, service1))
+
+			t.putEndpointSlice(ctx, newClusterIPEndpointSlice(namespace1, service1, clusterID1, "10.253.2.2", true, port1))
+			t.putEndpointSlice(ctx, newClusterIPEndpointSlice(namespace1, service1, clusterID1, "127.0.0.1", true, port1))
+
+			t.assertDNSRecordsFound(namespace1, service1, "", "", k8snet.IPv4, false)
+		})
+	})
+
+	When("a headless EndpointSlice has non-routable addresses", func() {
+		It("should not add DNS records for those addresses", func(ctx context.Context) {
+			t.resolver.PutServiceImport(newHeadlessAggregatedServiceImport(namespace1, service1))
+
+			// EndpointSlice with mix of routable and non-routable addresses
+			t.putEndpointSlice(ctx, newEndpointSlice(namespace1, service1, clusterID1, []mcsv1b1.ServicePort{port1},
+				discovery.Endpoint{
+					Addresses:  []string{endpointIP1}, // Routable
+					Conditions: discovery.EndpointConditions{Ready: &ready},
+				},
+				discovery.Endpoint{
+					Addresses:  []string{"127.0.0.1"}, // Non-routable: loopback
+					Conditions: discovery.EndpointConditions{Ready: &ready},
+				},
+				discovery.Endpoint{
+					Addresses:  []string{"0.0.0.0"}, // Non-routable: unspecified
+					Conditions: discovery.EndpointConditions{Ready: &ready},
+				},
+			))
+
+			// Should only have the routable address
+			t.assertDNSRecordsFound(namespace1, service1, clusterID1, "", k8snet.IPv4, true,
+				resolver.DNSRecord{
+					IP:          endpointIP1,
+					Ports:       []mcsv1b1.ServicePort{port1},
+					ClusterName: clusterID1,
+					HostName:    endpointHostname1,
+				},
+			)
 		})
 	})
 })

--- a/coredns/resolver/resolver.go
+++ b/coredns/resolver/resolver.go
@@ -82,11 +82,15 @@ func (i *Interface) getClusterIPRecord(serviceInfo *serviceInfo, addrType discov
 		return &clusterInfo.endpointRecords[0], true
 	}
 
-	if len(serviceInfo.spec.IPs) > 0 {
-		return &DNSRecord{
-			IP:    serviceInfo.spec.IPs[0],
-			Ports: serviceInfo.spec.Ports,
-		}, true
+	if serviceInfo.isClusterset {
+		if len(serviceInfo.spec.IPs) > 0 {
+			return &DNSRecord{
+				IP:    serviceInfo.spec.IPs[0],
+				Ports: serviceInfo.spec.Ports,
+			}, true
+		}
+
+		return nil, false
 	}
 
 	// If we are aware of the local cluster and we found some accessible IP, we shall return it.

--- a/coredns/resolver/service_import.go
+++ b/coredns/resolver/service_import.go
@@ -57,6 +57,17 @@ func (i *Interface) PutServiceImport(serviceImport *mcsv1b1.ServiceImport) {
 
 	svcInfo.spec = serviceImport.Spec
 	svcInfo.isExported = true
+	svcInfo.isClusterset = len(serviceImport.Spec.IPs) > 0
+
+	for _, ip := range svcInfo.spec.IPs {
+		if !isPermittedEndpointAddress(ip) {
+			logger.Warningf("Rejecting non-routable clusterset IP %q on ServiceImport %q", ip, key)
+
+			svcInfo.spec.IPs = nil
+
+			break
+		}
+	}
 }
 
 func (i *Interface) RemoveServiceImport(serviceImport *mcsv1b1.ServiceImport) {

--- a/coredns/resolver/types.go
+++ b/coredns/resolver/types.go
@@ -62,8 +62,9 @@ type IPFamilyInfo struct {
 }
 
 type serviceInfo struct {
-	ipv4Info   IPFamilyInfo
-	ipv6Info   IPFamilyInfo
-	isExported bool
-	spec       mcsv1b1.ServiceImportSpec
+	ipv4Info     IPFamilyInfo
+	ipv6Info     IPFamilyInfo
+	isExported   bool
+	isClusterset bool
+	spec         mcsv1b1.ServiceImportSpec
 }


### PR DESCRIPTION
The resolver builds clusterset.local A records by copying `EndpointSlice.Endpoints[].Addresses[]` and `ServiceImport.Spec.IPs[]` verbatim from broker-originated objects. `Broker` objects are written by remote member-cluster `ServiceAccounts` and are untrusted. A compromised peer can advertise 127.0.0.1, 169.254.169.254 (cloud metadata), 0.0.0.0, link-local or multicast addresses and have every peer's lighthouse-coredns serve them, enabling DNS-rebinding and local-service redirection.

Add `isPermittedEndpointAddress()` and reject unparseable, unspecified, loopback, link-local and multicast addresses at the three ingestion sites (ClusterIP slice, headless slice, ServiceImport.Spec.IPs). Records with rejected addresses are dropped and logged at warning level; legitimate Pod/Service/Globalnet addresses are unaffected.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS endpoint validation to exclude invalid, unspecified, loopback, link-local, multicast, broadcast, and other non-routable addresses.
  * Prevented invalid service-import addresses from being stored.
  * Removed invalid ClusterIP endpoint data and reset related routing information when necessary.
  * Preserved valid, routable addresses in ClusterIP and headless service records.
  * Added warning logs when invalid addresses are rejected.
  * Improved handling of ClusterSet services to ensure their configured addresses are resolved correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->