### PR TITLE
Derive conflict precedence from broker creation time

### DIFF
--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -266,7 +266,6 @@ func (a *Controller) serviceExportToServiceImport(obj runtime.Object, _ int, op 
 
 	serviceImport := a.newServiceImport(svcExport.Name, svcExport.Namespace)
 	serviceImport.Annotations[constants.PublishNotReadyAddresses] = strconv.FormatBool(svc.Spec.PublishNotReadyAddresses)
-	serviceImport.Annotations[constants.ServiceExportTimestamp] = strconv.FormatInt(svcExport.CreationTimestamp.UTC().UnixNano(), 10)
 
 	if svcExport.Annotations[constants.UseClustersetIP] != "" {
 		serviceImport.Annotations[constants.UseClustersetIP] = svcExport.Annotations[constants.UseClustersetIP]

--- a/pkg/agent/controller/service_import_conflict.go
+++ b/pkg/agent/controller/service_import_conflict.go
@@ -24,7 +24,6 @@ import (
 	"math"
 	"reflect"
 	goslices "slices"
-	"strconv"
 	"strings"
 
 	"github.com/submariner-io/admiral/pkg/slices"
@@ -234,16 +233,12 @@ func toSessionAffinityConfigString(c *corev1.SessionAffinityConfig) string {
 	return "none"
 }
 
-func parseTimestamp(si *mcsv1b1.ServiceImport) int64 {
-	v := si.Annotations[constants.ServiceExportTimestamp]
-
-	t, err := strconv.ParseInt(v, 10, 64)
-	if err != nil {
-		logger.Warningf("Invalid %q annotation value %q for ServiceImport %q", constants.ServiceExportTimestamp, v, si.Name)
+func getTimestamp(si *mcsv1b1.ServiceImport) int64 {
+	if si.CreationTimestamp.IsZero() {
 		return math.MaxInt64
 	}
 
-	return t
+	return si.CreationTimestamp.UnixNano()
 }
 
 func sortServiceImportsByTimestamp(siList []runtime.Object, aggregatedType mcsv1b1.ServiceImportType) {
@@ -260,8 +255,8 @@ func sortServiceImportsByTimestamp(siList []runtime.Object, aggregatedType mcsv1
 			return -1
 		}
 
-		tsA := parseTimestamp(siA)
-		tsB := parseTimestamp(siB)
+		tsA := getTimestamp(siA)
+		tsB := getTimestamp(siB)
 
 		if tsA < tsB {
 			return -1

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -27,7 +27,6 @@ const (
 	GlobalnetEnabled         = "lighthouse.submariner.io/globalnet-enabled"
 	UseClustersetIP          = "lighthouse.submariner.io/use-clusterset-ip"
 	ClustersetIPAllocatedBy  = "lighthouse.submariner.io/clusterset-ip-allocated-by"
-	ServiceExportTimestamp   = "lighthouse.submariner.io/svc-export-timestanp"
 )
 
 const ServiceExportReady = "Ready"


### PR DESCRIPTION
When multiple clusters export the same {namespace, service}, the precedent cluster (whose spec is propagated to the aggregated ServiceImport) was chosen by sorting on the
`lighthouse.submariner.io/svc-export-timestanp` annotation. That annotation is written by each exporting agent and read without authentication, so a compromised member cluster could set it to "1" and become precedent for any conflicting export, controlling SessionAffinity / TrafficDistribution / InternalTrafficPolicy / IPFamilies fleet-wide and disabling honest-cluster reconciliation.

Use the per-cluster `ServiceImport's` `metadata.creationTimestamp` on the broker instead. This field is assigned by the broker apiserver on create and cannot be set by clients, so precedence is now tamper-resistant within broker RBAC.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Service import precedence now uses the Kubernetes creation timestamp for more consistent conflict resolution.
  * Legacy timestamp annotations are no longer used.
  * Service imports without a timestamp are treated as the newest entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->