### PR TITLE
Automated backport of CVE fixes

### DIFF
--- a/coredns/resolver/address_internal_test.go
+++ b/coredns/resolver/address_internal_test.go
@@ -1,0 +1,49 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolver
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("isPermittedEndpointAddress", func() {
+	DescribeTable("should validate endpoint addresses",
+		func(address string, expected bool) {
+			Expect(isPermittedEndpointAddress(address)).To(Equal(expected))
+		},
+		Entry("valid IPv4 private address 10.x", "10.0.0.1", true),
+		Entry("valid IPv4 private address 172.16.x", "172.16.5.4", true),
+		Entry("valid IPv4 private address 192.168.x", "192.168.1.1", true),
+		Entry("valid IPv4 public address", "203.0.113.7", true),
+		Entry("valid IPv6 ULA address", "fd00::1", true),
+		Entry("valid IPv6 documentation address", "2001:db8::1", true),
+		Entry("empty string", "", false),
+		Entry("invalid IP string", "not-an-ip", false),
+		Entry("IPv4 unspecified address", "0.0.0.0", false),
+		Entry("IPv6 unspecified address", "::", false),
+		Entry("IPv4 loopback address", "127.0.0.1", false),
+		Entry("IPv6 loopback address", "::1", false),
+		Entry("IPv4 link-local address", "169.254.169.254", false),
+		Entry("IPv6 link-local address", "fe80::1", false),
+		Entry("IPv4 multicast address", "224.0.0.1", false),
+		Entry("IPv6 multicast address", "ff02::1", false),
+		Entry("IPv4 broadcast address", "255.255.255.255", false),
+	)
+})

--- a/coredns/resolver/clusterip_service_test.go
+++ b/coredns/resolver/clusterip_service_test.go
@@ -445,11 +445,15 @@ func testClusterIPServiceMisc() {
 }
 
 func testClusterSetIP() {
-	const clusterSetIP = "243.1.0.1"
-
 	t := newTestDriver()
 
+	var clusterSetIP string
+
 	BeforeEach(func() {
+		clusterSetIP = "243.1.0.1"
+	})
+
+	JustBeforeEach(func() {
 		si := newAggregatedServiceImport(namespace1, service1)
 
 		si.Spec.IPs = []string{clusterSetIP}
@@ -480,6 +484,16 @@ func testClusterSetIP() {
 				Ports:       []mcsv1a1.ServicePort{port1},
 				ClusterName: clusterID1,
 			})
+		})
+	})
+
+	Context("that is invalid", func() {
+		BeforeEach(func() {
+			clusterSetIP = "127.0.0.0"
+		})
+
+		It("should return no DNS records found", func() {
+			t.assertDNSRecordsNotFound(namespace1, service1, "", "")
 		})
 	})
 }

--- a/coredns/resolver/endpoint_slice.go
+++ b/coredns/resolver/endpoint_slice.go
@@ -21,6 +21,7 @@ package resolver
 import (
 	"context"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 
@@ -108,9 +109,21 @@ func (i *Interface) putClusterIPEndpointSlice(key, clusterID string, endpointSli
 		return
 	}
 
+	address := endpointSlice.Endpoints[0].Addresses[0]
+	if !isPermittedEndpointAddress(address) {
+		logger.Warningf("Rejecting non-routable address %q in EndpointSlice %q from cluster %q", address, key, clusterID)
+
+		delete(ipFamilyInfo.clusters, clusterID)
+		ipFamilyInfo.mergePorts()
+		ipFamilyInfo.resetLoadBalancing()
+
+		return
+	}
+
 	clusterInfo := ipFamilyInfo.ensureClusterInfo(clusterID)
+
 	clusterInfo.endpointRecords = []DNSRecord{{
-		IP:          endpointSlice.Endpoints[0].Addresses[0],
+		IP:          address,
 		Ports:       mcsServicePortsFrom(endpointSlice.Ports),
 		ClusterName: clusterID,
 	}}
@@ -156,6 +169,13 @@ func (i *Interface) putHeadlessEndpointSlices(key, clusterID string, endpointSli
 				}
 
 				allAddresses.Insert(address)
+
+				if !isPermittedEndpointAddress(address) {
+					logger.Warningf("Rejecting non-routable address %q in headless EndpointSlice %q from cluster %q",
+						address, key, clusterID)
+
+					continue
+				}
 
 				var hostname string
 
@@ -300,4 +320,19 @@ func isHeadless(endpointSlice *discovery.EndpointSlice) bool {
 func shouldRetrieveLocalEndpointSlicesFor(endpointSlice *discovery.EndpointSlice) bool {
 	return endpointSlice.AddressType == discovery.AddressTypeIPv4 &&
 		isHeadless(endpointSlice) && endpointSlice.Annotations[constants.GlobalnetEnabled] == strconv.FormatBool(true)
+}
+
+// isPermittedEndpointAddress reports whether the given broker-supplied address may be served as a clusterset.local DNS answer.
+// Endpoint and ServiceImport addresses originate from remote member clusters via the broker and are therefore untrusted; serving them
+// without range validation lets a compromised peer steer cross-cluster DNS to loopback, link-local (incl. 169.254.169.254 cloud metadata),
+// unspecified, multicast or broadcast addresses. This guards the DNS sink only and does not attempt source-cluster CIDR matching, which
+// requires data not available to the resolver.
+func isPermittedEndpointAddress(address string) bool {
+	ip := net.ParseIP(address)
+	if ip == nil {
+		return false
+	}
+
+	return !ip.IsUnspecified() && !ip.IsLoopback() && !ip.IsLinkLocalUnicast() && !ip.IsLinkLocalMulticast() && !ip.IsMulticast() &&
+		!ip.Equal(net.IPv4bcast)
 }

--- a/coredns/resolver/endpoint_slice_test.go
+++ b/coredns/resolver/endpoint_slice_test.go
@@ -22,8 +22,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
 	"github.com/submariner-io/lighthouse/coredns/constants"
+	"github.com/submariner-io/lighthouse/coredns/resolver"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8snet "k8s.io/utils/net"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
@@ -64,6 +66,49 @@ var _ = Describe("PutEndpointSlices", func() {
 					},
 				},
 			})
+		})
+	})
+
+	When("a ClusterIP EndpointSlice has a non-routable address", func() {
+		It("should not add a DNS record", func() {
+			t.resolver.PutServiceImport(newAggregatedServiceImport(namespace1, service1))
+
+			t.putEndpointSlice(newClusterIPEndpointSlice(namespace1, service1, clusterID1, "10.253.2.2", true, port1))
+			t.putEndpointSlice(newClusterIPEndpointSlice(namespace1, service1, clusterID1, "127.0.0.1", true, port1))
+
+			t.assertDNSRecordsFound(namespace1, service1, "", "", k8snet.IPv4, false)
+		})
+	})
+
+	When("a headless EndpointSlice has non-routable addresses", func() {
+		It("should not add DNS records for those addresses", func() {
+			t.resolver.PutServiceImport(newHeadlessAggregatedServiceImport(namespace1, service1))
+
+			// EndpointSlice with mix of routable and non-routable addresses
+			t.putEndpointSlice(newEndpointSlice(namespace1, service1, clusterID1, []mcsv1a1.ServicePort{port1},
+				discovery.Endpoint{
+					Addresses:  []string{endpointIP1}, // Routable
+					Conditions: discovery.EndpointConditions{Ready: &ready},
+				},
+				discovery.Endpoint{
+					Addresses:  []string{"127.0.0.1"}, // Non-routable: loopback
+					Conditions: discovery.EndpointConditions{Ready: &ready},
+				},
+				discovery.Endpoint{
+					Addresses:  []string{"0.0.0.0"}, // Non-routable: unspecified
+					Conditions: discovery.EndpointConditions{Ready: &ready},
+				},
+			))
+
+			// Should only have the routable address
+			t.assertDNSRecordsFound(namespace1, service1, clusterID1, "", k8snet.IPv4, true,
+				resolver.DNSRecord{
+					IP:          endpointIP1,
+					Ports:       []mcsv1a1.ServicePort{port1},
+					ClusterName: clusterID1,
+					HostName:    endpointHostname1,
+				},
+			)
 		})
 	})
 })

--- a/coredns/resolver/resolver.go
+++ b/coredns/resolver/resolver.go
@@ -82,11 +82,15 @@ func (i *Interface) getClusterIPRecord(serviceInfo *serviceInfo, addrType discov
 		return &clusterInfo.endpointRecords[0], true
 	}
 
-	if len(serviceInfo.spec.IPs) > 0 {
-		return &DNSRecord{
-			IP:    serviceInfo.spec.IPs[0],
-			Ports: serviceInfo.spec.Ports,
-		}, true
+	if serviceInfo.isClusterset {
+		if len(serviceInfo.spec.IPs) > 0 {
+			return &DNSRecord{
+				IP:    serviceInfo.spec.IPs[0],
+				Ports: serviceInfo.spec.Ports,
+			}, true
+		}
+
+		return nil, false
 	}
 
 	// If we are aware of the local cluster and we found some accessible IP, we shall return it.

--- a/coredns/resolver/service_import.go
+++ b/coredns/resolver/service_import.go
@@ -57,6 +57,17 @@ func (i *Interface) PutServiceImport(serviceImport *mcsv1a1.ServiceImport) {
 
 	svcInfo.spec = serviceImport.Spec
 	svcInfo.isExported = true
+	svcInfo.isClusterset = len(serviceImport.Spec.IPs) > 0
+
+	for _, ip := range svcInfo.spec.IPs {
+		if !isPermittedEndpointAddress(ip) {
+			logger.Warningf("Rejecting non-routable clusterset IP %q on ServiceImport %q", ip, key)
+
+			svcInfo.spec.IPs = nil
+
+			break
+		}
+	}
 }
 
 func (i *Interface) RemoveServiceImport(serviceImport *mcsv1a1.ServiceImport) {

--- a/coredns/resolver/types.go
+++ b/coredns/resolver/types.go
@@ -62,8 +62,9 @@ type IPFamilyInfo struct {
 }
 
 type serviceInfo struct {
-	ipv4Info   IPFamilyInfo
-	ipv6Info   IPFamilyInfo
-	isExported bool
-	spec       mcsv1a1.ServiceImportSpec
+	ipv4Info     IPFamilyInfo
+	ipv6Info     IPFamilyInfo
+	isExported   bool
+	isClusterset bool
+	spec         mcsv1a1.ServiceImportSpec
 }

--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -270,7 +270,6 @@ func (a *Controller) serviceExportToServiceImport(obj runtime.Object, _ int, op 
 
 	serviceImport := a.newServiceImport(svcExport.Name, svcExport.Namespace)
 	serviceImport.Annotations[constants.PublishNotReadyAddresses] = strconv.FormatBool(svc.Spec.PublishNotReadyAddresses)
-	serviceImport.Annotations[constants.ServiceExportTimestamp] = strconv.FormatInt(svcExport.CreationTimestamp.UTC().UnixNano(), 10)
 
 	if svcExport.Annotations[constants.UseClustersetIP] != "" {
 		serviceImport.Annotations[constants.UseClustersetIP] = svcExport.Annotations[constants.UseClustersetIP]

--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -65,9 +65,10 @@ func New(spec *AgentSpecification, syncerConf broker.SyncerConfig, agentConfig A
 	}
 
 	agentController := &Controller{
-		clusterID:        spec.ClusterID,
-		namespace:        spec.Namespace,
-		globalnetEnabled: spec.GlobalnetEnabled,
+		clusterID:          spec.ClusterID,
+		namespace:          spec.Namespace,
+		globalnetEnabled:   spec.GlobalnetEnabled,
+		namespaceValidator: NewNamespaceValidator(),
 	}
 
 	agentController.localServiceImportFederator = federate.NewCreateOrUpdateFederator(federate.CreateOrUpdateOptions{
@@ -128,7 +129,7 @@ func New(spec *AgentSpecification, syncerConf broker.SyncerConfig, agentConfig A
 	agentController.serviceExportClient.localSyncer = agentController.serviceExportSyncer
 
 	agentController.endpointSliceController, err = newEndpointSliceController(spec, syncerConf, agentController.serviceExportClient,
-		agentController.serviceSyncer)
+		agentController.serviceSyncer, agentController.namespaceValidator)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +139,7 @@ func New(spec *AgentSpecification, syncerConf broker.SyncerConfig, agentConfig A
 		agentController.endpointSliceController.syncer.GetBrokerNamespace(), agentController.serviceExportClient,
 		func(selector k8slabels.Selector) []runtime.Object {
 			return agentController.endpointSliceController.syncer.ListLocalResourcesBySelector(&discovery.EndpointSlice{}, selector)
-		})
+		}, agentController.namespaceValidator)
 	if err != nil {
 		return nil, err
 	}
@@ -199,6 +200,7 @@ func (a *Controller) Start(stopCh <-chan struct{}) error {
 	return nil
 }
 
+//nolint:gocyclo // Refactoring would create helper functions requiring 4-5 parameters each.
 func (a *Controller) serviceExportToServiceImport(obj runtime.Object, _ int, op syncer.Operation) (runtime.Object, bool) {
 	svcExport := obj.(*mcsv1a1.ServiceExport)
 
@@ -208,6 +210,22 @@ func (a *Controller) serviceExportToServiceImport(obj runtime.Object, _ int, op 
 
 	if op == syncer.Delete {
 		return a.newServiceImport(svcExport.Name, svcExport.Namespace), false
+	}
+
+	if err := a.namespaceValidator.CheckAllowed(svcExport.Namespace); err != nil {
+		a.serviceExportClient.UpdateStatusConditions(ctx, svcExport.Name, svcExport.Namespace,
+			mcsv1a1.NewServiceExportCondition(mcsv1a1.ServiceExportConditionValid, metav1.ConditionFalse,
+				ServiceExportReasonRestrictedNamespace,
+				fmt.Sprintf("Service in namespace %q cannot be exported due to namespace restriction", svcExport.Namespace)))
+
+		err = a.localServiceImportFederator.Delete(ctx, a.newServiceImport(svcExport.Name, svcExport.Namespace))
+		if err != nil && !apierrors.IsNotFound(err) {
+			logger.Errorf(err, "Error deleting ServiceImport for restricted Service (%s/%s)", svcExport.Namespace, svcExport.Name)
+
+			return nil, true
+		}
+
+		return nil, false
 	}
 
 	obj, found, err := a.serviceSyncer.GetResource(svcExport.Name, svcExport.Namespace)

--- a/pkg/agent/controller/clusterip_service_test.go
+++ b/pkg/agent/controller/clusterip_service_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/submariner-io/admiral/pkg/fake"
+	"github.com/submariner-io/admiral/pkg/federate"
 	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
 	testutil "github.com/submariner-io/admiral/pkg/test"
@@ -167,6 +168,24 @@ func testClusterIPServiceInOneCluster() {
 
 				t.awaitNonHeadlessServiceExported(&t.cluster1)
 			})
+		})
+	})
+
+	When("a ServiceExport is created for a Service whose namespace is restricted", func() {
+		BeforeEach(func() {
+			t.cluster1.service.Namespace = metav1.NamespaceSystem
+			t.cluster1.serviceExport.Namespace = metav1.NamespaceSystem
+		})
+
+		JustBeforeEach(func() {
+			t.cluster1.createService()
+			t.cluster1.createServiceExport()
+		})
+
+		It("should not export the service", func() {
+			t.cluster1.awaitServiceExportCondition(newServiceExportValidCondition(metav1.ConditionFalse,
+				controller.ServiceExportReasonRestrictedNamespace))
+			t.cluster1.ensureNoServiceExportCondition(mcsv1a1.ServiceExportConditionReady)
 		})
 	})
 
@@ -486,6 +505,25 @@ func testClusterIPServiceInOneCluster() {
 
 			t.awaitNonHeadlessServiceExported(&t.cluster1)
 		})
+	})
+
+	Specify("an EndpointSlice with a restricted service namespace should not be synced from the broker", func() {
+		restrictedNamespace := metav1.NamespaceSystem
+
+		test.CreateResource(endpointSliceClientFor(t.syncerConfig.BrokerClient, test.RemoteNamespace),
+			&discovery.EndpointSlice{ObjectMeta: metav1.ObjectMeta{
+				Name: "restricted-eps",
+				Labels: map[string]string{
+					discovery.LabelManagedBy:       constants.LabelValueManagedBy,
+					constants.LabelSourceNamespace: restrictedNamespace,
+					mcsv1a1.LabelSourceCluster:     "south",
+					mcsv1a1.LabelServiceName:       serviceName,
+					federate.ClusterIDLabelKey:     "south",
+				},
+			}})
+
+		testutil.EnsureNoResource(resource.ForDynamic(endpointSliceClientFor(t.cluster1.localDynClient,
+			restrictedNamespace)), "restricted-eps")
 	})
 }
 
@@ -817,11 +855,11 @@ func testClusterIPServiceInTwoClusters() {
 
 			By("Updating the ServiceExport on the second cluster")
 
-			se, err := t.cluster2.localServiceExportClient.Get(context.TODO(), t.cluster2.serviceExport.Name, metav1.GetOptions{})
+			se, err := t.cluster2.localServiceExportClient().Get(context.TODO(), t.cluster2.serviceExport.Name, metav1.GetOptions{})
 			Expect(err).To(Succeed())
 
 			se.SetAnnotations(map[string]string{constants.UseClustersetIP: strconv.FormatBool(true)})
-			test.UpdateResource(t.cluster2.localServiceExportClient, se)
+			test.UpdateResource(t.cluster2.localServiceExportClient(), se)
 
 			t.cluster1.awaitServiceExportCondition(noConflictCondition)
 			t.cluster2.awaitServiceExportCondition(noConflictCondition)

--- a/pkg/agent/controller/controller_suite_test.go
+++ b/pkg/agent/controller/controller_suite_test.go
@@ -121,7 +121,6 @@ type cluster struct {
 	agentSpec                  controller.AgentSpecification
 	localDynClient             dynamic.Interface
 	localDynClientFake         *k8stesting.Fake
-	localServiceExportClient   dynamic.ResourceInterface
 	localServiceImportClient   dynamic.NamespaceableResourceInterface
 	localIngressIPClient       dynamic.ResourceInterface
 	localEndpointSliceClient   dynamic.ResourceInterface
@@ -357,9 +356,6 @@ func (c *cluster) init(syncerConfig *broker.SyncerConfig, dynClient dynamic.Inte
 
 	c.localServiceImportReactor = fake.NewFailingReactorForResource(c.localDynClientFake, mcsv1a1.ServiceImportPluralName)
 
-	c.localServiceExportClient = c.localDynClient.Resource(*test.GetGroupVersionResourceFor(syncerConfig.RestMapper,
-		&mcsv1a1.ServiceExport{})).Namespace(serviceNamespace)
-
 	c.localServiceImportClient = c.localDynClient.Resource(*test.GetGroupVersionResourceFor(syncerConfig.RestMapper,
 		&mcsv1a1.ServiceImport{}))
 
@@ -432,11 +428,11 @@ func (c *cluster) deleteService() {
 }
 
 func (c *cluster) createServiceExport() {
-	test.CreateResource(c.localServiceExportClient, c.serviceExport)
+	test.CreateResource(c.localServiceExportClient(), c.serviceExport)
 }
 
 func (c *cluster) deleteServiceExport() {
-	Expect(c.localServiceExportClient.Delete(context.TODO(), c.serviceExport.GetName(), metav1.DeleteOptions{})).To(Succeed())
+	Expect(c.localServiceExportClient().Delete(context.TODO(), c.serviceExport.GetName(), metav1.DeleteOptions{})).To(Succeed())
 }
 
 func (c *cluster) createServiceEndpointSlices() {
@@ -561,7 +557,7 @@ func (c *cluster) awaitServiceExportCondition(expected ...metav1.Condition) {
 	last := len(expected) - 1
 
 	Eventually(func(g Gomega) {
-		obj, err := c.localServiceExportClient.Get(context.Background(), c.serviceExport.Name, metav1.GetOptions{})
+		obj, err := c.localServiceExportClient().Get(context.Background(), c.serviceExport.Name, metav1.GetOptions{})
 		Expect(err).To(Succeed())
 
 		se := toServiceExport(obj)
@@ -569,7 +565,7 @@ func (c *cluster) awaitServiceExportCondition(expected ...metav1.Condition) {
 
 		g.Expect(c).NotTo(BeNil(), "ServiceExport condition not found for type %q", expected[last].Type)
 		assertEquivalentConditions(g, c, &expected[last])
-	}).Should(Succeed())
+	}).Within(time.Second * 3).Should(Succeed())
 }
 
 //nolint:gocritic // Ignore hugeParam
@@ -649,6 +645,10 @@ func (c *cluster) ensureNoServiceExportActions() {
 	Consistently(func() []string {
 		return testutil.GetOccurredActionVerbs(c.localDynClientFake, mcsv1a1.ServiceExportPluralName, "get", "update")
 	}, 500*time.Millisecond).Should(BeEmpty())
+}
+
+func (c *cluster) localServiceExportClient() dynamic.ResourceInterface {
+	return serviceExportClientFor(c.localDynClient, c.serviceExport.Namespace)
 }
 
 func awaitServiceImport(client dynamic.NamespaceableResourceInterface, expected *mcsv1a1.ServiceImport, ipPool *ipam.IPPool,

--- a/pkg/agent/controller/endpoint_slice.go
+++ b/pkg/agent/controller/endpoint_slice.go
@@ -38,12 +38,14 @@ import (
 
 //nolint:gocritic // (hugeParam) This function modifies syncerConf so we don't want to pass by pointer.
 func newEndpointSliceController(spec *AgentSpecification, syncerConfig broker.SyncerConfig,
-	serviceExportClient *ServiceExportClient, serviceSyncer syncer.Interface,
+	serviceExportClient *ServiceExportClient, serviceSyncer syncer.Interface, namespaceValidator *NamespaceValidator,
 ) (*EndpointSliceController, error) {
 	c := &EndpointSliceController{
 		clusterID:           spec.ClusterID,
 		serviceExportClient: serviceExportClient,
 		serviceSyncer:       serviceSyncer,
+		localClient:         syncerConfig.LocalClient,
+		namespaceValidator:  namespaceValidator,
 	}
 
 	syncerConfig.LocalNamespace = metav1.NamespaceAll
@@ -137,9 +139,28 @@ func isLegacyEndpointSlice(endpointSlice *discovery.EndpointSlice) bool {
 	return strings.HasSuffix(endpointSlice.Name, "-"+endpointSlice.Labels[mcsv1a1.LabelSourceCluster])
 }
 
-func (c *EndpointSliceController) onRemoteEndpointSlice(obj runtime.Object, _ int, _ syncer.Operation) (runtime.Object, bool) {
+func (c *EndpointSliceController) onRemoteEndpointSlice(obj runtime.Object, _ int, op syncer.Operation) (runtime.Object, bool) {
 	endpointSlice := obj.(*discovery.EndpointSlice)
-	endpointSlice.Namespace = endpointSlice.GetObjectMeta().GetLabels()[constants.LabelSourceNamespace]
+	targetNamespace := endpointSlice.GetObjectMeta().GetLabels()[constants.LabelSourceNamespace]
+
+	if op != syncer.Delete {
+		if err := c.namespaceValidator.CheckAllowed(targetNamespace); err != nil {
+			logger.Warningf("Rejecting EndpointSlice from cluster %q: %v", endpointSlice.Labels[mcsv1a1.LabelSourceCluster], err)
+
+			// Delete stale local ServiceImport if it exists
+			deleteErr := c.localClient.Resource(endpointSliceGVR).Namespace(targetNamespace).Delete(
+				context.TODO(), endpointSlice.Name, metav1.DeleteOptions{})
+			if deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+				logger.Errorf(deleteErr, "Error deleting rejected EndpointSlice %s/%s", targetNamespace, endpointSlice.Name)
+
+				return nil, true
+			}
+
+			return nil, false
+		}
+	}
+
+	endpointSlice.Namespace = targetNamespace
 
 	return endpointSlice, false
 }

--- a/pkg/agent/controller/endpoint_slice.go
+++ b/pkg/agent/controller/endpoint_slice.go
@@ -145,17 +145,11 @@ func (c *EndpointSliceController) onRemoteEndpointSlice(obj runtime.Object, _ in
 
 	if op != syncer.Delete {
 		if err := c.namespaceValidator.CheckAllowed(targetNamespace); err != nil {
-			logger.Warningf("Rejecting EndpointSlice from cluster %q: %v", endpointSlice.Labels[mcsv1a1.LabelSourceCluster], err)
+			logger.Warningf("Rejecting EndpointSlice %q from cluster %q: %v",
+				endpointSlice.Name, endpointSlice.Labels[mcsv1a1.LabelSourceCluster], err)
 
-			// Delete stale local ServiceImport if it exists
-			deleteErr := c.localClient.Resource(endpointSliceGVR).Namespace(targetNamespace).Delete(
-				context.TODO(), endpointSlice.Name, metav1.DeleteOptions{})
-			if deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
-				logger.Errorf(deleteErr, "Error deleting rejected EndpointSlice %s/%s", targetNamespace, endpointSlice.Name)
-
-				return nil, true
-			}
-
+			// Do not delete local resources based on rejected broker objects - they cannot be trusted.
+			// Stale local resources should be cleaned up by administrators.
 			return nil, false
 		}
 	}

--- a/pkg/agent/controller/endpoint_slice.go
+++ b/pkg/agent/controller/endpoint_slice.go
@@ -143,15 +143,13 @@ func (c *EndpointSliceController) onRemoteEndpointSlice(obj runtime.Object, _ in
 	endpointSlice := obj.(*discovery.EndpointSlice)
 	targetNamespace := endpointSlice.GetObjectMeta().GetLabels()[constants.LabelSourceNamespace]
 
-	if op != syncer.Delete {
-		if err := c.namespaceValidator.CheckAllowed(targetNamespace); err != nil {
-			logger.Warningf("Rejecting EndpointSlice %q from cluster %q: %v",
-				endpointSlice.Name, endpointSlice.Labels[mcsv1a1.LabelSourceCluster], err)
+	if err := c.namespaceValidator.CheckAllowed(targetNamespace); err != nil {
+		logger.Warningf("Rejecting EndpointSlice %q from cluster %q: %v",
+			endpointSlice.Name, endpointSlice.Labels[mcsv1a1.LabelSourceCluster], err)
 
-			// Do not delete local resources based on rejected broker objects - they cannot be trusted.
-			// Stale local resources should be cleaned up by administrators.
-			return nil, false
-		}
+		// Do not delete local resources based on rejected broker objects - they cannot be trusted.
+		// Stale local resources should be cleaned up by administrators.
+		return nil, false
 	}
 
 	endpointSlice.Namespace = targetNamespace

--- a/pkg/agent/controller/namespace_validator.go
+++ b/pkg/agent/controller/namespace_validator.go
@@ -1,0 +1,87 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/global"
+)
+
+const (
+	ConfigKeyImportNamespaceDenyList = "import-namespace-deny-list"
+	DefaultImportNamespaceDenyList   = "kube-,openshift-,openshift"
+)
+
+// NamespaceValidator validates broker-supplied namespace labels against a configurable denylist.
+type NamespaceValidator struct {
+	denyList []string
+}
+
+// NewNamespaceValidator creates a validator using the configured denylist from ConfigMap.
+// If not configured, uses DefaultImportNamespaceDenyList.
+func NewNamespaceValidator() *NamespaceValidator {
+	denyListStr := global.Get(ConfigKeyImportNamespaceDenyList, DefaultImportNamespaceDenyList)
+
+	var denyList []string
+	if denyListStr != "" {
+		denyList = strings.Split(denyListStr, ",")
+		// Trim whitespace from each entry
+		for i := range denyList {
+			denyList[i] = strings.TrimSpace(denyList[i])
+		}
+	}
+
+	logger.Infof("Namespace validator using deny list: %v", denyList)
+
+	return &NamespaceValidator{
+		denyList: denyList,
+	}
+}
+
+// CheckAllowed checks if a broker-supplied namespace is safe to use as a target namespace
+// in the local cluster. Broker objects are written by remote member-cluster ServiceAccounts
+// and are untrusted; allowing them to target privileged or system namespaces enables
+// namespace injection attacks (CWE-441: Confused Deputy) where a compromised peer can
+// pollute system namespaces fleet-wide, bypassing local ServiceExport admission policies.
+func (v *NamespaceValidator) CheckAllowed(namespace string) error {
+	// Reject empty namespace explicitly
+	if namespace == "" {
+		return errors.New("namespace cannot be empty")
+	}
+
+	// Check against denylist
+	for _, entry := range v.denyList {
+		if entry == "" {
+			continue
+		}
+
+		// If entry ends with hyphen, treat as prefix match only, otherwise use exact match.
+		if strings.HasSuffix(entry, "-") {
+			if strings.HasPrefix(namespace, entry) {
+				return errors.Errorf("namespace %q matches denied prefix %q", namespace, entry)
+			}
+		} else if namespace == entry {
+			return errors.Errorf("namespace %q is denied (matches %q)", namespace, entry)
+		}
+	}
+
+	return nil
+}

--- a/pkg/agent/controller/namespace_validator_test.go
+++ b/pkg/agent/controller/namespace_validator_test.go
@@ -1,0 +1,83 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/global"
+	"github.com/submariner-io/lighthouse/pkg/agent/controller"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("NamespaceValidator", func() {
+	var (
+		validator *controller.NamespaceValidator
+		configMap *corev1.ConfigMap
+	)
+
+	BeforeEach(func() {
+		configMap = nil
+	})
+
+	JustBeforeEach(func() {
+		global.Init(configMap)
+
+		DeferCleanup(func() {
+			global.Init(nil)
+		})
+
+		validator = controller.NewNamespaceValidator()
+	})
+
+	Context("with no configured deny list", func() {
+		It("should use the default deny list", func() {
+			Expect(validator.CheckAllowed("kube-system")).NotTo(Succeed())
+			Expect(validator.CheckAllowed("kube-public")).NotTo(Succeed())
+			Expect(validator.CheckAllowed("kube-node-lease")).NotTo(Succeed())
+			Expect(validator.CheckAllowed("openshift-ovn-kubernetes")).NotTo(Succeed())
+			Expect(validator.CheckAllowed("openshift-console")).NotTo(Succeed())
+			Expect(validator.CheckAllowed("")).NotTo(Succeed())
+
+			Expect(validator.CheckAllowed("default")).To(Succeed())
+			Expect(validator.CheckAllowed("my-app")).To(Succeed())
+			Expect(validator.CheckAllowed("production")).To(Succeed())
+			Expect(validator.CheckAllowed("my-openshift-app")).To(Succeed())
+			Expect(validator.CheckAllowed("test-kube-demo")).To(Succeed())
+		})
+	})
+
+	Context("with a configured deny list", func() {
+		BeforeEach(func() {
+			configMap = &corev1.ConfigMap{
+				Data: map[string]string{
+					controller.ConfigKeyImportNamespaceDenyList: "default , system-",
+				},
+			}
+		})
+
+		It("should use it", func() {
+			Expect(validator.CheckAllowed("default")).NotTo(Succeed())
+			Expect(validator.CheckAllowed("system-core")).NotTo(Succeed())
+
+			Expect(validator.CheckAllowed("defaulttest")).To(Succeed())
+			Expect(validator.CheckAllowed("my-system")).To(Succeed())
+		})
+	})
+})

--- a/pkg/agent/controller/reconciliation_test.go
+++ b/pkg/agent/controller/reconciliation_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Reconciliation", func() {
 		Expect(endpointSlices).To(HaveLen(1))
 		localEndpointSlice = endpointSlices[0]
 
-		obj, err := t.cluster1.localServiceExportClient.Get(context.Background(), t.cluster1.serviceExport.Name, metav1.GetOptions{})
+		obj, err := t.cluster1.localServiceExportClient().Get(context.Background(), t.cluster1.serviceExport.Name, metav1.GetOptions{})
 		Expect(err).To(Succeed())
 		serviceExport = toServiceExport(obj)
 	})
@@ -123,7 +123,7 @@ var _ = Describe("Reconciliation", func() {
 
 			test.CreateResource(t.cluster1.localServiceImportClient.Namespace(test.LocalNamespace), localServiceImport)
 			test.CreateResource(t.cluster1.localEndpointSliceClient, localEndpointSlice)
-			test.CreateResource(t.cluster1.localServiceExportClient, serviceExport)
+			test.CreateResource(t.cluster1.localServiceExportClient(), serviceExport)
 
 			_, err := t.cluster1.localServiceImportClient.Namespace(serviceNamespace).Create(context.TODO(), localAggregatedServiceImport,
 				metav1.CreateOptions{})
@@ -276,7 +276,7 @@ var _ = Describe("Reconciliation", func() {
 				restoreBrokerResources()
 				test.CreateResource(t.cluster1.localServiceImportClient.Namespace(test.LocalNamespace), localServiceImport)
 				test.CreateResource(t.cluster1.localEndpointSliceClient, localEndpointSlice)
-				test.CreateResource(t.cluster1.localServiceExportClient, serviceExport)
+				test.CreateResource(t.cluster1.localServiceExportClient(), serviceExport)
 				t.cluster1.createService()
 
 				// Create a remote EPS for the same service and ensure it's not deleted.

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -46,7 +46,7 @@ import (
 //nolint:gocritic // (hugeParam) This function modifies syncerConf so we don't want to pass by pointer.
 func newServiceImportController(spec *AgentSpecification, agentConfig AgentConfig, syncerConfig broker.SyncerConfig,
 	brokerClient dynamic.Interface, brokerNamespace string, serviceExportClient *ServiceExportClient,
-	localLHEndpointSliceLister EndpointSliceListerFn,
+	localLHEndpointSliceLister EndpointSliceListerFn, namespaceValidator *NamespaceValidator,
 ) (*ServiceImportController, error) {
 	controller := &ServiceImportController{
 		localClient:                syncerConfig.LocalClient,
@@ -60,6 +60,7 @@ func newServiceImportController(spec *AgentSpecification, agentConfig AgentConfi
 		localLHEndpointSliceLister: localLHEndpointSliceLister,
 		clustersetIPPool:           agentConfig.IPPool,
 		clustersetIPEnabled:        spec.ClustersetIPEnabled,
+		namespaceValidator:         namespaceValidator,
 	}
 
 	localToBrokerFederator := federate.NewCreateOrUpdateFederator(federate.CreateOrUpdateOptions{
@@ -328,11 +329,32 @@ func (c *ServiceImportController) transformLocalToBroker(serviceImport *mcsv1a1.
 func (c *ServiceImportController) onRemoteServiceImport(obj runtime.Object, _ int, op syncer.Operation) (runtime.Object, bool) {
 	serviceImport := obj.(*mcsv1a1.ServiceImport)
 
+	ctx := context.TODO()
+
 	serviceName, ok := serviceImport.Annotations[mcsv1a1.LabelServiceName]
 	if ok {
 		// This is an aggregated ServiceImport - sync it to the local service namespace.
 		serviceImport.Name = serviceName
-		serviceImport.Namespace = serviceImport.Annotations[constants.LabelSourceNamespace]
+		targetNamespace := serviceImport.Annotations[constants.LabelSourceNamespace]
+
+		if op != syncer.Delete {
+			if err := c.namespaceValidator.CheckAllowed(targetNamespace); err != nil {
+				logger.Warningf("Rejecting aggregated ServiceImport: %v", err)
+
+				// Delete stale local ServiceImport if it exists
+				deleteErr := c.localClient.Resource(serviceImportGVR).Namespace(targetNamespace).Delete(
+					ctx, serviceName, metav1.DeleteOptions{})
+				if deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+					logger.Errorf(deleteErr, "Error deleting rejected ServiceImport %s/%s", targetNamespace, serviceName)
+
+					return nil, true
+				}
+
+				return nil, false
+			}
+		}
+
+		serviceImport.Namespace = targetNamespace
 
 		delete(serviceImport.Annotations, mcsv1a1.LabelServiceName)
 		delete(serviceImport.Annotations, constants.LabelSourceNamespace)
@@ -340,7 +362,6 @@ func (c *ServiceImportController) onRemoteServiceImport(obj runtime.Object, _ in
 		return serviceImport, false
 	}
 
-	ctx := context.TODO()
 	serviceName = serviceImport.Labels[mcsv1a1.LabelServiceName]
 	serviceNamespace := serviceImport.Labels[constants.LabelSourceNamespace]
 

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -339,17 +339,10 @@ func (c *ServiceImportController) onRemoteServiceImport(obj runtime.Object, _ in
 
 		if op != syncer.Delete {
 			if err := c.namespaceValidator.CheckAllowed(targetNamespace); err != nil {
-				logger.Warningf("Rejecting aggregated ServiceImport: %v", err)
+				logger.Warningf("Rejecting aggregated ServiceImport %q: %v", serviceName, err)
 
-				// Delete stale local ServiceImport if it exists
-				deleteErr := c.localClient.Resource(serviceImportGVR).Namespace(targetNamespace).Delete(
-					ctx, serviceName, metav1.DeleteOptions{})
-				if deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
-					logger.Errorf(deleteErr, "Error deleting rejected ServiceImport %s/%s", targetNamespace, serviceName)
-
-					return nil, true
-				}
-
+				// Do not delete local resources based on rejected broker objects - they cannot be trusted.
+				// Stale local resources should be cleaned up by administrators.
 				return nil, false
 			}
 		}

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -337,14 +337,12 @@ func (c *ServiceImportController) onRemoteServiceImport(obj runtime.Object, _ in
 		serviceImport.Name = serviceName
 		targetNamespace := serviceImport.Annotations[constants.LabelSourceNamespace]
 
-		if op != syncer.Delete {
-			if err := c.namespaceValidator.CheckAllowed(targetNamespace); err != nil {
-				logger.Warningf("Rejecting aggregated ServiceImport %q: %v", serviceName, err)
+		if err := c.namespaceValidator.CheckAllowed(targetNamespace); err != nil {
+			logger.Warningf("Rejecting aggregated ServiceImport %q: %v", serviceName, err)
 
-				// Do not delete local resources based on rejected broker objects - they cannot be trusted.
-				// Stale local resources should be cleaned up by administrators.
-				return nil, false
-			}
+			// Do not delete local resources based on rejected broker objects - they cannot be trusted.
+			// Stale local resources should be cleaned up by administrators.
+			return nil, false
 		}
 
 		serviceImport.Namespace = targetNamespace

--- a/pkg/agent/controller/service_import_conflict.go
+++ b/pkg/agent/controller/service_import_conflict.go
@@ -24,7 +24,6 @@ import (
 	"math"
 	"reflect"
 	goslices "slices"
-	"strconv"
 	"strings"
 
 	"github.com/submariner-io/admiral/pkg/slices"
@@ -191,16 +190,12 @@ func toSessionAffinityConfigString(c *corev1.SessionAffinityConfig) string {
 	return "none"
 }
 
-func parseTimestamp(si *mcsv1a1.ServiceImport) int64 {
-	v := si.Annotations[constants.ServiceExportTimestamp]
-
-	t, err := strconv.ParseInt(v, 10, 64)
-	if err != nil {
-		logger.Warningf("Invalid %q annotation value %q for ServiceImport %q", constants.ServiceExportTimestamp, v, si.Name)
+func getTimestamp(si *mcsv1a1.ServiceImport) int64 {
+	if si.CreationTimestamp.IsZero() {
 		return math.MaxInt64
 	}
 
-	return t
+	return si.CreationTimestamp.UnixNano()
 }
 
 func sortServiceImportsByTimestamp(siList []runtime.Object, aggregatedType mcsv1a1.ServiceImportType) {
@@ -217,8 +212,8 @@ func sortServiceImportsByTimestamp(siList []runtime.Object, aggregatedType mcsv1
 			return -1
 		}
 
-		tsA := parseTimestamp(siA)
-		tsB := parseTimestamp(siB)
+		tsA := getTimestamp(siA)
+		tsB := getTimestamp(siB)
 
 		if tsA < tsB {
 			return -1

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -42,6 +42,7 @@ const (
 	ServiceExportReasonClusterSetIPEnablementConflict mcsv1a1.ServiceExportConditionReason = "ClusterSetIPEnablementConflict"
 	ServiceExportReasonUnsupportedIPFamily            mcsv1a1.ServiceExportConditionReason = "UnsupportedIPFamily"
 	ServiceExportReasonGlobalIPUnavailable            mcsv1a1.ServiceExportConditionReason = "ServiceGlobalIPUnavailable"
+	ServiceExportReasonRestrictedNamespace            mcsv1a1.ServiceExportConditionReason = "RestrictedNamespace"
 )
 
 type EndpointSliceListerFn func(selector k8slabels.Selector) []runtime.Object
@@ -63,6 +64,7 @@ type Controller struct {
 	serviceImportController     *ServiceImportController
 	localServiceImportFederator federate.Federator
 	namespaceInformer           cache.SharedInformer
+	namespaceValidator          *NamespaceValidator
 }
 
 type AgentSpecification struct {
@@ -95,6 +97,7 @@ type ServiceImportController struct {
 	localLHEndpointSliceLister EndpointSliceListerFn
 	clustersetIPPool           *ipam.IPPool
 	clustersetIPEnabled        bool
+	namespaceValidator         *NamespaceValidator
 }
 
 // ServiceEndpointSliceController watches for the EndpointSlices that backs a Service and have a ServiceImport.
@@ -120,6 +123,8 @@ type EndpointSliceController struct {
 	syncer              *broker.Syncer
 	serviceExportClient *ServiceExportClient
 	serviceSyncer       syncer.Interface
+	localClient         dynamic.Interface
+	namespaceValidator  *NamespaceValidator
 }
 
 type ServiceExportClient struct {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -27,7 +27,6 @@ const (
 	GlobalnetEnabled         = "lighthouse.submariner.io/globalnet-enabled"
 	UseClustersetIP          = "lighthouse.submariner.io/use-clusterset-ip"
 	ClustersetIPAllocatedBy  = "lighthouse.submariner.io/clusterset-ip-allocated-by"
-	ServiceExportTimestamp   = "lighthouse.submariner.io/svc-export-timestanp"
 )
 
 const ServiceExportReady = "Ready"


### PR DESCRIPTION
Backport of #2249 on release-0.23.

#2249: Add configurable namespace validation for broker imports

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Validation**
  * Added configurable namespace restrictions for exported and imported services.
  * Restricted namespaces are rejected and reported through ServiceExport status conditions.

* **Networking**
  * Invalid or non-routable addresses—including loopback, multicast, link-local, and broadcast addresses—are excluded from DNS records.
  * ClusterSet services use configured IPs only when they are valid and routable.

* **Reliability**
  * Invalid service and endpoint data is safely ignored without disrupting valid records or synchronized resources.
  * ServiceImport conflict resolution now uses Kubernetes creation timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->