### PR TITLE
Automated backport of CVE fixes

### DIFF
--- a/coredns/resolver/address_internal_test.go
+++ b/coredns/resolver/address_internal_test.go
@@ -1,0 +1,49 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resolver
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("isPermittedEndpointAddress", func() {
+	DescribeTable("should validate endpoint addresses",
+		func(address string, expected bool) {
+			Expect(isPermittedEndpointAddress(address)).To(Equal(expected))
+		},
+		Entry("valid IPv4 private address 10.x", "10.0.0.1", true),
+		Entry("valid IPv4 private address 172.16.x", "172.16.5.4", true),
+		Entry("valid IPv4 private address 192.168.x", "192.168.1.1", true),
+		Entry("valid IPv4 public address", "203.0.113.7", true),
+		Entry("valid IPv6 ULA address", "fd00::1", true),
+		Entry("valid IPv6 documentation address", "2001:db8::1", true),
+		Entry("empty string", "", false),
+		Entry("invalid IP string", "not-an-ip", false),
+		Entry("IPv4 unspecified address", "0.0.0.0", false),
+		Entry("IPv6 unspecified address", "::", false),
+		Entry("IPv4 loopback address", "127.0.0.1", false),
+		Entry("IPv6 loopback address", "::1", false),
+		Entry("IPv4 link-local address", "169.254.169.254", false),
+		Entry("IPv6 link-local address", "fe80::1", false),
+		Entry("IPv4 multicast address", "224.0.0.1", false),
+		Entry("IPv6 multicast address", "ff02::1", false),
+		Entry("IPv4 broadcast address", "255.255.255.255", false),
+	)
+})

--- a/coredns/resolver/endpoint_slice.go
+++ b/coredns/resolver/endpoint_slice.go
@@ -21,6 +21,7 @@ package resolver
 import (
 	"context"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 
@@ -119,9 +120,21 @@ func (i *Interface) putClusterIPEndpointSlice(key, clusterID string, endpointSli
 		return false
 	}
 
+	address := endpointSlice.Endpoints[0].Addresses[0]
+	if !isPermittedEndpointAddress(address) {
+		logger.Warningf("Rejecting non-routable address %q in EndpointSlice %q from cluster %q", address, key, clusterID)
+
+		delete(serviceInfo.clusters, clusterID)
+		serviceInfo.mergePorts()
+		serviceInfo.resetLoadBalancing()
+
+		return false
+	}
+
 	clusterInfo := serviceInfo.ensureClusterInfo(clusterID)
+
 	clusterInfo.endpointRecords = []DNSRecord{{
-		IP:          endpointSlice.Endpoints[0].Addresses[0],
+		IP:          address,
 		Ports:       mcsServicePortsFrom(endpointSlice.Ports),
 		ClusterName: clusterID,
 	}}
@@ -178,6 +191,13 @@ func (i *Interface) putHeadlessEndpointSlices(key, clusterID string, endpointSli
 				}
 
 				allAddresses.Insert(address)
+
+				if !isPermittedEndpointAddress(address) {
+					logger.Warningf("Rejecting non-routable address %q in headless EndpointSlice %q from cluster %q",
+						address, key, clusterID)
+
+					continue
+				}
 
 				record := DNSRecord{
 					IP:          address,
@@ -324,4 +344,19 @@ func shouldRetrieveLocalEndpointSlicesFor(endpointSlice *discovery.EndpointSlice
 	}
 
 	return isHeadless(endpointSlice) && globalnetEnabled == strconv.FormatBool(true)
+}
+
+// isPermittedEndpointAddress reports whether the given broker-supplied address may be served as a clusterset.local DNS answer.
+// Endpoint and ServiceImport addresses originate from remote member clusters via the broker and are therefore untrusted; serving them
+// without range validation lets a compromised peer steer cross-cluster DNS to loopback, link-local (incl. 169.254.169.254 cloud metadata),
+// unspecified, multicast or broadcast addresses. This guards the DNS sink only and does not attempt source-cluster CIDR matching, which
+// requires data not available to the resolver.
+func isPermittedEndpointAddress(address string) bool {
+	ip := net.ParseIP(address)
+	if ip == nil {
+		return false
+	}
+
+	return !ip.IsUnspecified() && !ip.IsLoopback() && !ip.IsLinkLocalUnicast() && !ip.IsLinkLocalMulticast() && !ip.IsMulticast() &&
+		!ip.Equal(net.IPv4bcast)
 }

--- a/coredns/resolver/endpoint_slice_test.go
+++ b/coredns/resolver/endpoint_slice_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
 	"github.com/submariner-io/lighthouse/coredns/constants"
+	"github.com/submariner-io/lighthouse/coredns/resolver"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	mcsv1a1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
@@ -64,6 +65,48 @@ var _ = Describe("PutEndpointSlices", func() {
 					},
 				},
 			})
+		})
+	})
+
+	When("a ClusterIP EndpointSlice has a non-routable address", func() {
+		It("should not add a DNS record", func() {
+			t.resolver.PutServiceImport(newAggregatedServiceImport(namespace1, service1))
+
+			t.putEndpointSlice(newClusterIPEndpointSlice(namespace1, service1, clusterID1, "10.253.2.2", true, port1))
+			t.putEndpointSlice(newClusterIPEndpointSlice(namespace1, service1, clusterID1, "127.0.0.1", true, port1))
+
+			t.assertDNSRecordsFound(namespace1, service1, "", "", false)
+		})
+	})
+
+	When("a headless EndpointSlice has non-routable addresses", func() {
+		It("should not add DNS records for those addresses", func() {
+			t.resolver.PutServiceImport(newHeadlessAggregatedServiceImport(namespace1, service1))
+
+			// EndpointSlice with mix of routable and non-routable addresses
+			t.putEndpointSlice(newEndpointSlice(namespace1, service1, clusterID1, []mcsv1a1.ServicePort{port1},
+				discovery.Endpoint{
+					Addresses:  []string{endpointIP1}, // Routable
+					Conditions: discovery.EndpointConditions{Ready: &ready},
+				},
+				discovery.Endpoint{
+					Addresses:  []string{"127.0.0.1"}, // Non-routable: loopback
+					Conditions: discovery.EndpointConditions{Ready: &ready},
+				},
+				discovery.Endpoint{
+					Addresses:  []string{"0.0.0.0"}, // Non-routable: unspecified
+					Conditions: discovery.EndpointConditions{Ready: &ready},
+				},
+			))
+
+			// Should only have the routable address
+			t.assertDNSRecordsFound(namespace1, service1, clusterID1, "", true,
+				resolver.DNSRecord{
+					IP:          endpointIP1,
+					Ports:       []mcsv1a1.ServicePort{port1},
+					ClusterName: clusterID1,
+				},
+			)
 		})
 	})
 })

--- a/pkg/agent/controller/agent.go
+++ b/pkg/agent/controller/agent.go
@@ -64,9 +64,10 @@ func New(spec *AgentSpecification, syncerConf broker.SyncerConfig, syncerMetricN
 	}
 
 	agentController := &Controller{
-		clusterID:        spec.ClusterID,
-		namespace:        spec.Namespace,
-		globalnetEnabled: spec.GlobalnetEnabled,
+		clusterID:          spec.ClusterID,
+		namespace:          spec.Namespace,
+		globalnetEnabled:   spec.GlobalnetEnabled,
+		namespaceValidator: NewNamespaceValidator(syncerConf.LocalClient),
 	}
 
 	_, gvr, err := util.ToUnstructuredResource(&mcsv1a1.ServiceExport{}, syncerConf.RestMapper)
@@ -126,7 +127,7 @@ func New(spec *AgentSpecification, syncerConf broker.SyncerConfig, syncerMetricN
 	}
 
 	agentController.endpointSliceController, err = newEndpointSliceController(spec, syncerConf, agentController.serviceExportClient,
-		agentController.serviceSyncer)
+		agentController.serviceSyncer, agentController.namespaceValidator)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +137,7 @@ func New(spec *AgentSpecification, syncerConf broker.SyncerConfig, syncerMetricN
 		agentController.endpointSliceController.syncer.GetBrokerNamespace(), agentController.serviceExportClient,
 		func(selector k8slabels.Selector) []runtime.Object {
 			return agentController.endpointSliceController.syncer.ListLocalResourcesBySelector(&discovery.EndpointSlice{}, selector)
-		})
+		}, agentController.namespaceValidator)
 	if err != nil {
 		return nil, err
 	}
@@ -197,6 +198,7 @@ func (a *Controller) Start(stopCh <-chan struct{}) error {
 	return nil
 }
 
+//nolint:gocyclo // Refactoring would create helper functions requiring 4-5 parameters each.
 func (a *Controller) serviceExportToServiceImport(obj runtime.Object, _ int, op syncer.Operation) (runtime.Object, bool) {
 	svcExport := obj.(*mcsv1a1.ServiceExport)
 
@@ -206,6 +208,22 @@ func (a *Controller) serviceExportToServiceImport(obj runtime.Object, _ int, op 
 
 	if op == syncer.Delete {
 		return a.newServiceImport(svcExport.Name, svcExport.Namespace), false
+	}
+
+	if err := a.namespaceValidator.CheckAllowed(svcExport.Namespace); err != nil {
+		a.serviceExportClient.updateStatusConditions(ctx, svcExport.Name, svcExport.Namespace,
+			newServiceExportCondition(mcsv1a1.ServiceExportValid, corev1.ConditionFalse,
+				ServiceExportReasonRestrictedNamespace,
+				fmt.Sprintf("Service in namespace %q cannot be exported due to namespace restriction", svcExport.Namespace)))
+
+		err = a.localServiceImportFederator.Delete(ctx, a.newServiceImport(svcExport.Name, svcExport.Namespace))
+		if err != nil && !apierrors.IsNotFound(err) {
+			logger.Errorf(err, "Error deleting ServiceImport for restricted Service (%s/%s)", svcExport.Namespace, svcExport.Name)
+
+			return nil, true
+		}
+
+		return nil, false
 	}
 
 	obj, found, err := a.serviceSyncer.GetResource(svcExport.Name, svcExport.Namespace)

--- a/pkg/agent/controller/clusterip_service_test.go
+++ b/pkg/agent/controller/clusterip_service_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/resource"
 	"github.com/submariner-io/admiral/pkg/syncer/test"
 	testutil "github.com/submariner-io/admiral/pkg/test"
+	"github.com/submariner-io/lighthouse/pkg/agent/controller"
 	"github.com/submariner-io/lighthouse/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
@@ -157,6 +158,24 @@ func testClusterIPServiceInOneCluster() {
 
 				t.awaitNonHeadlessServiceExported(&t.cluster1)
 			})
+		})
+	})
+
+	When("a ServiceExport is created for a Service whose namespace is restricted", func() {
+		BeforeEach(func() {
+			t.cluster1.service.Namespace = metav1.NamespaceSystem
+			t.cluster1.serviceExport.Namespace = metav1.NamespaceSystem
+		})
+
+		JustBeforeEach(func() {
+			t.cluster1.createService()
+			t.cluster1.createServiceExport()
+		})
+
+		It("should not export the service", func() {
+			t.cluster1.awaitServiceExportCondition(newServiceExportValidCondition(corev1.ConditionFalse,
+				controller.ServiceExportReasonRestrictedNamespace))
+			t.cluster1.ensureNoServiceExportCondition(constants.ServiceExportReady)
 		})
 	})
 

--- a/pkg/agent/controller/controller_suite_test.go
+++ b/pkg/agent/controller/controller_suite_test.go
@@ -119,7 +119,6 @@ func TestController(t *testing.T) {
 type cluster struct {
 	agentSpec                 controller.AgentSpecification
 	localDynClient            *dynamicfake.FakeDynamicClient
-	localServiceExportClient  dynamic.ResourceInterface
 	localServiceImportClient  dynamic.NamespaceableResourceInterface
 	localIngressIPClient      dynamic.ResourceInterface
 	localEndpointSliceClient  dynamic.ResourceInterface
@@ -342,9 +341,6 @@ func (c *cluster) init(syncerConfig *broker.SyncerConfig, dynClient *dynamicfake
 
 	c.localServiceImportReactor = fake.NewFailingReactorForResource(&c.localDynClient.Fake, "serviceimports")
 
-	c.localServiceExportClient = c.localDynClient.Resource(*test.GetGroupVersionResourceFor(syncerConfig.RestMapper,
-		&mcsv1a1.ServiceExport{})).Namespace(serviceNamespace)
-
 	c.localServiceImportClient = c.localDynClient.Resource(*test.GetGroupVersionResourceFor(syncerConfig.RestMapper,
 		&mcsv1a1.ServiceImport{}))
 
@@ -405,11 +401,15 @@ func (c *cluster) deleteService() {
 }
 
 func (c *cluster) createServiceExport() {
-	test.CreateResource(c.localServiceExportClient, c.serviceExport)
+	test.CreateResource(c.localServiceExportClient(), c.serviceExport)
 }
 
 func (c *cluster) deleteServiceExport() {
-	Expect(c.localServiceExportClient.Delete(context.TODO(), c.serviceExport.GetName(), metav1.DeleteOptions{})).To(Succeed())
+	Expect(c.localServiceExportClient().Delete(context.TODO(), c.serviceExport.GetName(), metav1.DeleteOptions{})).To(Succeed())
+}
+
+func (c *cluster) localServiceExportClient() dynamic.ResourceInterface {
+	return serviceExportClientFor(c.localDynClient, c.serviceExport.Namespace)
 }
 
 func (c *cluster) createServiceEndpointSlices() {
@@ -526,7 +526,7 @@ func (c *cluster) awaitServiceExportCondition(expected ...*mcsv1a1.ServiceExport
 	last := len(expected) - 1
 
 	Eventually(func() interface{} {
-		obj, err := c.localServiceExportClient.Get(context.Background(), c.serviceExport.Name, metav1.GetOptions{})
+		obj, err := c.localServiceExportClient().Get(context.Background(), c.serviceExport.Name, metav1.GetOptions{})
 		Expect(err).To(Succeed())
 		se := toServiceExport(obj)
 

--- a/pkg/agent/controller/endpoint_slice.go
+++ b/pkg/agent/controller/endpoint_slice.go
@@ -44,13 +44,15 @@ import (
 
 //nolint:gocritic // (hugeParam) This function modifies syncerConf so we don't want to pass by pointer.
 func newEndpointSliceController(spec *AgentSpecification, syncerConfig broker.SyncerConfig,
-	serviceExportClient *ServiceExportClient, serviceSyncer syncer.Interface,
+	serviceExportClient *ServiceExportClient, serviceSyncer syncer.Interface, namespaceValidator *NamespaceValidator,
 ) (*EndpointSliceController, error) {
 	c := &EndpointSliceController{
 		clusterID:              spec.ClusterID,
 		serviceExportClient:    serviceExportClient,
 		serviceSyncer:          serviceSyncer,
 		conflictCheckWorkQueue: workqueue.New("ConflictChecker"),
+		localClient:                   syncerConfig.LocalClient,
+		namespaceValidator:            namespaceValidator,
 	}
 
 	syncerConfig.LocalNamespace = metav1.NamespaceAll
@@ -151,9 +153,28 @@ func isLegacyEndpointSlice(endpointSlice *discovery.EndpointSlice) bool {
 	return strings.HasSuffix(endpointSlice.Name, "-"+endpointSlice.Labels[constants.MCSLabelSourceCluster])
 }
 
-func (c *EndpointSliceController) onRemoteEndpointSlice(obj runtime.Object, _ int, _ syncer.Operation) (runtime.Object, bool) {
+func (c *EndpointSliceController) onRemoteEndpointSlice(obj runtime.Object, _ int, op syncer.Operation) (runtime.Object, bool) {
 	endpointSlice := obj.(*discovery.EndpointSlice)
-	endpointSlice.Namespace = endpointSlice.GetObjectMeta().GetLabels()[constants.LabelSourceNamespace]
+	targetNamespace := endpointSlice.GetObjectMeta().GetLabels()[constants.LabelSourceNamespace]
+
+	if op != syncer.Delete {
+		if err := c.namespaceValidator.CheckAllowed(targetNamespace); err != nil {
+			logger.Warningf("Rejecting EndpointSlice from cluster %q: %v", endpointSlice.Labels[constants.MCSLabelSourceCluster], err)
+
+			// Delete stale local ServiceImport if it exists
+			deleteErr := c.localClient.Resource(endpointSliceGVR).Namespace(targetNamespace).Delete(
+				context.TODO(), endpointSlice.Name, metav1.DeleteOptions{})
+			if deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+				logger.Errorf(deleteErr, "Error deleting rejected EndpointSlice %s/%s", targetNamespace, endpointSlice.Name)
+
+				return nil, true
+			}
+
+			return nil, false
+		}
+	}
+
+	endpointSlice.Namespace = targetNamespace
 
 	return endpointSlice, false
 }

--- a/pkg/agent/controller/endpoint_slice.go
+++ b/pkg/agent/controller/endpoint_slice.go
@@ -161,15 +161,8 @@ func (c *EndpointSliceController) onRemoteEndpointSlice(obj runtime.Object, _ in
 		if err := c.namespaceValidator.CheckAllowed(targetNamespace); err != nil {
 			logger.Warningf("Rejecting EndpointSlice from cluster %q: %v", endpointSlice.Labels[constants.MCSLabelSourceCluster], err)
 
-			// Delete stale local ServiceImport if it exists
-			deleteErr := c.localClient.Resource(endpointSliceGVR).Namespace(targetNamespace).Delete(
-				context.TODO(), endpointSlice.Name, metav1.DeleteOptions{})
-			if deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
-				logger.Errorf(deleteErr, "Error deleting rejected EndpointSlice %s/%s", targetNamespace, endpointSlice.Name)
-
-				return nil, true
-			}
-
+			// Do not delete local resources based on rejected broker objects - they cannot be trusted.
+			// Stale local resources should be cleaned up by administrators.
 			return nil, false
 		}
 	}

--- a/pkg/agent/controller/endpoint_slice.go
+++ b/pkg/agent/controller/endpoint_slice.go
@@ -157,14 +157,13 @@ func (c *EndpointSliceController) onRemoteEndpointSlice(obj runtime.Object, _ in
 	endpointSlice := obj.(*discovery.EndpointSlice)
 	targetNamespace := endpointSlice.GetObjectMeta().GetLabels()[constants.LabelSourceNamespace]
 
-	if op != syncer.Delete {
-		if err := c.namespaceValidator.CheckAllowed(targetNamespace); err != nil {
-			logger.Warningf("Rejecting EndpointSlice from cluster %q: %v", endpointSlice.Labels[constants.MCSLabelSourceCluster], err)
+	if err := c.namespaceValidator.CheckAllowed(targetNamespace); err != nil {
+		logger.Warningf("Rejecting EndpointSlice %q from cluster %q: %v",
+			endpointSlice.Name, endpointSlice.Labels[constants.MCSLabelSourceCluster], err)
 
-			// Do not delete local resources based on rejected broker objects - they cannot be trusted.
-			// Stale local resources should be cleaned up by administrators.
-			return nil, false
-		}
+		// Do not delete local resources based on rejected broker objects - they cannot be trusted.
+		// Stale local resources should be cleaned up by administrators.
+		return nil, false
 	}
 
 	endpointSlice.Namespace = targetNamespace

--- a/pkg/agent/controller/namespace_validator.go
+++ b/pkg/agent/controller/namespace_validator.go
@@ -1,0 +1,105 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/submariner-io/admiral/pkg/resource"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+)
+
+const (
+	ConfigKeyImportNamespaceDenyList = "import-namespace-deny-list"
+	DefaultImportNamespaceDenyList   = "kube-,openshift-,openshift"
+)
+
+// NamespaceValidator validates broker-supplied namespace labels against a configurable denylist.
+type NamespaceValidator struct {
+	denyList []string
+}
+
+// NewNamespaceValidator creates a validator using the configured denylist from ConfigMap.
+// If not configured, uses DefaultImportNamespaceDenyList.
+func NewNamespaceValidator(dynClient dynamic.Interface) *NamespaceValidator {
+	denyListStr := DefaultImportNamespaceDenyList
+
+	obj, err := dynClient.Resource(corev1.SchemeGroupVersion.WithResource("configmaps")).Namespace("submariner-operator").Get(
+		context.TODO(), "submariner-lighthouse-agent", metav1.GetOptions{})
+	if err == nil {
+		cm := resource.MustFromUnstructured(obj, &corev1.ConfigMap{})
+
+		s := cm.Data[ConfigKeyImportNamespaceDenyList]
+		if s != "" {
+			denyListStr = s
+		}
+	} else if err != nil && !apierrors.IsNotFound(err) {
+		logger.Errorf(err, "Failed to get submariner-lighthouse-agent configmap")
+	}
+
+	var denyList []string
+	if denyListStr != "" {
+		denyList = strings.Split(denyListStr, ",")
+		// Trim whitespace from each entry
+		for i := range denyList {
+			denyList[i] = strings.TrimSpace(denyList[i])
+		}
+	}
+
+	logger.Infof("Namespace validator using deny list: %v", denyList)
+
+	return &NamespaceValidator{
+		denyList: denyList,
+	}
+}
+
+// CheckAllowed checks if a broker-supplied namespace is safe to use as a target namespace
+// in the local cluster. Broker objects are written by remote member-cluster ServiceAccounts
+// and are untrusted; allowing them to target privileged or system namespaces enables
+// namespace injection attacks (CWE-441: Confused Deputy) where a compromised peer can
+// pollute system namespaces fleet-wide, bypassing local ServiceExport admission policies.
+func (v *NamespaceValidator) CheckAllowed(namespace string) error {
+	// Reject empty namespace explicitly
+	if namespace == "" {
+		return errors.New("namespace cannot be empty")
+	}
+
+	// Check against denylist
+	for _, entry := range v.denyList {
+		if entry == "" {
+			continue
+		}
+
+		// If entry ends with hyphen, treat as prefix match only, otherwise use exact match.
+		if strings.HasSuffix(entry, "-") {
+			if strings.HasPrefix(namespace, entry) {
+				return errors.Errorf("namespace %q matches denied prefix %q", namespace, entry)
+			}
+		} else if namespace == entry {
+			return errors.Errorf("namespace %q is denied (matches %q)", namespace, entry)
+		}
+	}
+
+	return nil
+}

--- a/pkg/agent/controller/namespace_validator_test.go
+++ b/pkg/agent/controller/namespace_validator_test.go
@@ -1,0 +1,92 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/submariner-io/admiral/pkg/resource"
+	"github.com/submariner-io/lighthouse/pkg/agent/controller"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+var _ = Describe("NamespaceValidator", func() {
+	var (
+		validator *controller.NamespaceValidator
+		configMap *corev1.ConfigMap
+		dynClient dynamic.Interface
+	)
+
+	BeforeEach(func() {
+		configMap = nil
+		dynClient = dynamicfake.NewSimpleDynamicClient(scheme.Scheme)
+	})
+
+	JustBeforeEach(func() {
+		if configMap != nil {
+			_, err := dynClient.Resource(corev1.SchemeGroupVersion.WithResource("configmaps")).Namespace("submariner-operator").
+				Create(context.TODO(), resource.MustToUnstructured(configMap), metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		validator = controller.NewNamespaceValidator(dynClient)
+	})
+
+	Context("with no configured deny list", func() {
+		It("should use the default deny list", func() {
+			Expect(validator.CheckAllowed("kube-system")).NotTo(Succeed())
+			Expect(validator.CheckAllowed("kube-public")).NotTo(Succeed())
+			Expect(validator.CheckAllowed("kube-node-lease")).NotTo(Succeed())
+			Expect(validator.CheckAllowed("openshift-ovn-kubernetes")).NotTo(Succeed())
+			Expect(validator.CheckAllowed("openshift-console")).NotTo(Succeed())
+			Expect(validator.CheckAllowed("")).NotTo(Succeed())
+
+			Expect(validator.CheckAllowed("default")).To(Succeed())
+			Expect(validator.CheckAllowed("my-app")).To(Succeed())
+			Expect(validator.CheckAllowed("production")).To(Succeed())
+			Expect(validator.CheckAllowed("my-openshift-app")).To(Succeed())
+			Expect(validator.CheckAllowed("test-kube-demo")).To(Succeed())
+		})
+	})
+
+	Context("with a configured deny list", func() {
+		BeforeEach(func() {
+			configMap = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "submariner-lighthouse-agent"},
+				Data: map[string]string{
+					controller.ConfigKeyImportNamespaceDenyList: "default , system-",
+				},
+			}
+		})
+
+		It("should use it", func() {
+			Expect(validator.CheckAllowed("default")).NotTo(Succeed())
+			Expect(validator.CheckAllowed("system-core")).NotTo(Succeed())
+
+			Expect(validator.CheckAllowed("defaulttest")).To(Succeed())
+			Expect(validator.CheckAllowed("my-system")).To(Succeed())
+		})
+	})
+})

--- a/pkg/agent/controller/reconciliation_test.go
+++ b/pkg/agent/controller/reconciliation_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Reconciliation", func() {
 		Expect(endpointSlices).To(HaveLen(1))
 		localEndpointSlice = endpointSlices[0]
 
-		obj, err := t.cluster1.localServiceExportClient.Get(context.Background(), t.cluster1.serviceExport.Name, metav1.GetOptions{})
+		obj, err := t.cluster1.localServiceExportClient().Get(context.Background(), t.cluster1.serviceExport.Name, metav1.GetOptions{})
 		Expect(err).To(Succeed())
 		serviceExport = toServiceExport(obj)
 	})
@@ -112,7 +112,7 @@ var _ = Describe("Reconciliation", func() {
 
 			test.CreateResource(t.cluster1.localServiceImportClient.Namespace(test.LocalNamespace), localServiceImport)
 			test.CreateResource(t.cluster1.localEndpointSliceClient, localEndpointSlice)
-			test.CreateResource(t.cluster1.localServiceExportClient, serviceExport)
+			test.CreateResource(t.cluster1.localServiceExportClient(), serviceExport)
 
 			restoreBrokerResources()
 
@@ -272,7 +272,7 @@ var _ = Describe("Reconciliation", func() {
 				restoreBrokerResources()
 				test.CreateResource(t.cluster1.localServiceImportClient.Namespace(test.LocalNamespace), localServiceImport)
 				test.CreateResource(t.cluster1.localEndpointSliceClient, localEndpointSlice)
-				test.CreateResource(t.cluster1.localServiceExportClient, serviceExport)
+				test.CreateResource(t.cluster1.localServiceExportClient(), serviceExport)
 				t.cluster1.createService()
 
 				// Create a remote EPS for the same service and ensure it's not deleted.

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -406,14 +406,12 @@ func (c *ServiceImportController) onRemoteServiceImport(obj runtime.Object, _ in
 		serviceImport.Name = serviceName
 		targetNamespace := serviceImport.Annotations[constants.LabelSourceNamespace]
 
-		if op != syncer.Delete {
-			if err := c.namespaceValidator.CheckAllowed(targetNamespace); err != nil {
-				logger.Warningf("Rejecting aggregated ServiceImport %q: %v", serviceName, err)
+		if err := c.namespaceValidator.CheckAllowed(targetNamespace); err != nil {
+			logger.Warningf("Rejecting aggregated ServiceImport %q: %v", serviceName, err)
 
-				// Do not delete local resources based on rejected broker objects - they cannot be trusted.
-				// Stale local resources should be cleaned up by administrators.
-				return nil, false
-			}
+			// Do not delete local resources based on rejected broker objects - they cannot be trusted.
+			// Stale local resources should be cleaned up by administrators.
+			return nil, false
 		}
 
 		serviceImport.Namespace = targetNamespace

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -34,7 +34,6 @@ import (
 	"github.com/submariner-io/admiral/pkg/watcher"
 	"github.com/submariner-io/lighthouse/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -400,9 +399,7 @@ func (c *ServiceImportController) Delete(ctx context.Context, obj runtime.Object
 
 func (c *ServiceImportController) onRemoteServiceImport(obj runtime.Object, _ int, op syncer.Operation) (runtime.Object, bool) {
 	serviceImport := obj.(*mcsv1a1.ServiceImport)
-
-	ctx := context.TODO()
-
+	
 	serviceName, ok := serviceImport.Annotations[mcsv1a1.LabelServiceName]
 	if ok {
 		// This is an aggregated ServiceImport - sync it to the local service namespace.
@@ -411,17 +408,10 @@ func (c *ServiceImportController) onRemoteServiceImport(obj runtime.Object, _ in
 
 		if op != syncer.Delete {
 			if err := c.namespaceValidator.CheckAllowed(targetNamespace); err != nil {
-				logger.Warningf("Rejecting aggregated ServiceImport: %v", err)
+				logger.Warningf("Rejecting aggregated ServiceImport %q: %v", serviceName, err)
 
-				// Delete stale local ServiceImport if it exists
-				deleteErr := c.localClient.Resource(serviceImportGVR).Namespace(targetNamespace).Delete(
-					ctx, serviceName, metav1.DeleteOptions{})
-				if deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
-					logger.Errorf(deleteErr, "Error deleting rejected ServiceImport %s/%s", targetNamespace, serviceName)
-
-					return nil, true
-				}
-
+				// Do not delete local resources based on rejected broker objects - they cannot be trusted.
+				// Stale local resources should be cleaned up by administrators.
 				return nil, false
 			}
 		}

--- a/pkg/agent/controller/service_import.go
+++ b/pkg/agent/controller/service_import.go
@@ -34,6 +34,7 @@ import (
 	"github.com/submariner-io/admiral/pkg/watcher"
 	"github.com/submariner-io/lighthouse/pkg/constants"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -46,7 +47,7 @@ import (
 //nolint:gocritic // (hugeParam) This function modifies syncerConf so we don't want to pass by pointer.
 func newServiceImportController(spec *AgentSpecification, syncerMetricNames AgentConfig, syncerConfig broker.SyncerConfig,
 	brokerClient dynamic.Interface, brokerNamespace string, serviceExportClient *ServiceExportClient,
-	localLHEndpointSliceLister EndpointSliceListerFn,
+	localLHEndpointSliceLister EndpointSliceListerFn, namespaceValidator *NamespaceValidator,
 ) (*ServiceImportController, error) {
 	controller := &ServiceImportController{
 		localClient:                syncerConfig.LocalClient,
@@ -57,6 +58,7 @@ func newServiceImportController(spec *AgentSpecification, syncerMetricNames Agen
 		serviceImportAggregator:    newServiceImportAggregator(brokerClient, brokerNamespace, spec.ClusterID, syncerConfig.Scheme),
 		serviceExportClient:        serviceExportClient,
 		localLHEndpointSliceLister: localLHEndpointSliceLister,
+		namespaceValidator:         namespaceValidator,
 	}
 
 	var err error
@@ -396,14 +398,35 @@ func (c *ServiceImportController) Delete(ctx context.Context, obj runtime.Object
 	return c.serviceImportMigrator.onLocalServiceImportDeleted(ctx, localServiceImport)
 }
 
-func (c *ServiceImportController) onRemoteServiceImport(obj runtime.Object, _ int, _ syncer.Operation) (runtime.Object, bool) {
+func (c *ServiceImportController) onRemoteServiceImport(obj runtime.Object, _ int, op syncer.Operation) (runtime.Object, bool) {
 	serviceImport := obj.(*mcsv1a1.ServiceImport)
+
+	ctx := context.TODO()
 
 	serviceName, ok := serviceImport.Annotations[mcsv1a1.LabelServiceName]
 	if ok {
 		// This is an aggregated ServiceImport - sync it to the local service namespace.
 		serviceImport.Name = serviceName
-		serviceImport.Namespace = serviceImport.Annotations[constants.LabelSourceNamespace]
+		targetNamespace := serviceImport.Annotations[constants.LabelSourceNamespace]
+
+		if op != syncer.Delete {
+			if err := c.namespaceValidator.CheckAllowed(targetNamespace); err != nil {
+				logger.Warningf("Rejecting aggregated ServiceImport: %v", err)
+
+				// Delete stale local ServiceImport if it exists
+				deleteErr := c.localClient.Resource(serviceImportGVR).Namespace(targetNamespace).Delete(
+					ctx, serviceName, metav1.DeleteOptions{})
+				if deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+					logger.Errorf(deleteErr, "Error deleting rejected ServiceImport %s/%s", targetNamespace, serviceName)
+
+					return nil, true
+				}
+
+				return nil, false
+			}
+		}
+
+		serviceImport.Namespace = targetNamespace
 
 		delete(serviceImport.Annotations, mcsv1a1.LabelServiceName)
 		delete(serviceImport.Annotations, constants.LabelSourceNamespace)

--- a/pkg/agent/controller/types.go
+++ b/pkg/agent/controller/types.go
@@ -39,6 +39,7 @@ const (
 	exportFailedReason = "ExportFailed"
 	typeConflictReason = "ConflictingType"
 	portConflictReason = "ConflictingPorts"
+	ServiceExportReasonRestrictedNamespace = "RestrictedNamespace"
 )
 
 type EndpointSliceListerFn func(selector k8slabels.Selector) []runtime.Object
@@ -58,6 +59,7 @@ type Controller struct {
 	serviceImportController     *ServiceImportController
 	localServiceImportFederator federate.Federator
 	namespaceInformer           cache.SharedInformer
+	namespaceValidator          *NamespaceValidator
 }
 
 type AgentSpecification struct {
@@ -94,6 +96,7 @@ type ServiceImportController struct {
 	converter                  converter
 	globalIngressIPCache       *globalIngressIPCache
 	localLHEndpointSliceLister EndpointSliceListerFn
+	namespaceValidator         *NamespaceValidator
 }
 
 // Each ServiceEndpointSliceController watches for the EndpointSlices that backs a Service and have a ServiceImport.
@@ -121,6 +124,8 @@ type EndpointSliceController struct {
 	serviceExportClient     *ServiceExportClient
 	serviceSyncer           syncer.Interface
 	conflictCheckWorkQueue  workqueue.Interface
+	localClient                   dynamic.Interface
+	namespaceValidator            *NamespaceValidator
 }
 
 type ServiceExportClient struct {


### PR DESCRIPTION
Backport of #2254 on release-0.18.

#2254: Add configurable namespace validation for broker imports

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.