### PR TITLE
Update version labels to v0.23.2

### DIFF
--- a/package/Dockerfile.lighthouse-agent.konflux
+++ b/package/Dockerfile.lighthouse-agent.konflux
@@ -50,7 +50,7 @@ ENTRYPOINT ["/usr/local/bin/lighthouse-agent", "-alsologtostderr"]
 
 LABEL com.redhat.component="lighthouse-agent-container" \
       name="rhacm2/lighthouse-agent-rhel9" \
-      version="v0.23.0" \
+      version="v0.23.2" \
       summary="Lighthouse Agent" \
       description="The Lighthouse Agent provides service discovery for Submariner." \
       io.k8s.display-name="Lighthouse Agent" \

--- a/package/Dockerfile.lighthouse-coredns.konflux
+++ b/package/Dockerfile.lighthouse-coredns.konflux
@@ -53,7 +53,7 @@ ENTRYPOINT ["/usr/local/bin/lighthouse-coredns"]
 
 LABEL com.redhat.component="lighthouse-coredns-container" \
       name="rhacm2/lighthouse-coredns-rhel9" \
-      version="v0.23.0" \
+      version="v0.23.2" \
       summary="Lighthouse CoreDNS" \
       description="The Lighthouse CoreDNS provides DNS resolution for cross-cluster services." \
       io.k8s.display-name="Lighthouse CoreDNS" \


### PR DESCRIPTION
Enables correct Konflux image tagging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Lighthouse Agent and CoreDNS container image version labels from v0.23.0 to v0.23.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->