### PR TITLE
Add namespace allow list configuration

### DIFF
--- a/pkg/agent/controller/namespace_validator.go
+++ b/pkg/agent/controller/namespace_validator.go
@@ -26,33 +26,29 @@ import (
 )
 
 const (
-	ConfigKeyImportNamespaceDenyList = "import-namespace-deny-list"
-	DefaultImportNamespaceDenyList   = "kube-,openshift-,openshift"
+	ConfigKeyImportNamespaceAllowList = "import-namespace-allow-list"
+	ConfigKeyImportNamespaceDenyList  = "import-namespace-deny-list"
+	DefaultImportNamespaceDenyList    = "kube-,openshift-,openshift"
+	DefaultImportNamespaceAllowList   = "openshift-storage"
 )
 
-// NamespaceValidator validates broker-supplied namespace labels against a configurable denylist.
+// NamespaceValidator validates broker-supplied namespace labels against a configurable allowlist and denylist.
 type NamespaceValidator struct {
-	denyList []string
+	allowList []string
+	denyList  []string
 }
 
-// NewNamespaceValidator creates a validator using the configured denylist from ConfigMap.
-// If not configured, uses DefaultImportNamespaceDenyList.
+// NewNamespaceValidator creates a validator using the configured allowlist and denylist from the global Config.
+// If not configured, uses DefaultImportNamespaceDenyList and DefaultImportNamespaceAllowList.
 func NewNamespaceValidator() *NamespaceValidator {
-	denyListStr := global.Get(ConfigKeyImportNamespaceDenyList, DefaultImportNamespaceDenyList)
+	allowList := parseListStr(global.Get(ConfigKeyImportNamespaceAllowList, DefaultImportNamespaceAllowList))
+	denyList := parseListStr(global.Get(ConfigKeyImportNamespaceDenyList, DefaultImportNamespaceDenyList))
 
-	var denyList []string
-	if denyListStr != "" {
-		denyList = strings.Split(denyListStr, ",")
-		// Trim whitespace from each entry
-		for i := range denyList {
-			denyList[i] = strings.TrimSpace(denyList[i])
-		}
-	}
-
-	logger.Infof("Namespace validator using deny list: %v", denyList)
+	logger.Infof("Namespace validator using allow list: %v, deny list: %v", allowList, denyList)
 
 	return &NamespaceValidator{
-		denyList: denyList,
+		allowList: allowList,
+		denyList:  denyList,
 	}
 }
 
@@ -69,19 +65,59 @@ func (v *NamespaceValidator) CheckAllowed(namespace string) error {
 
 	// Check against denylist
 	for _, entry := range v.denyList {
-		if entry == "" {
-			continue
-		}
-
 		// If entry ends with hyphen, treat as prefix match only, otherwise use exact match.
 		if strings.HasSuffix(entry, "-") {
 			if strings.HasPrefix(namespace, entry) {
+				// Check if allow list overrides this denial
+				if v.isInAllowList(namespace) {
+					return nil
+				}
+
 				return errors.Errorf("namespace %q matches denied prefix %q", namespace, entry)
 			}
 		} else if namespace == entry {
+			// Check if allow list overrides this denial
+			if v.isInAllowList(namespace) {
+				return nil
+			}
+
 			return errors.Errorf("namespace %q is denied (matches %q)", namespace, entry)
 		}
 	}
 
 	return nil
+}
+
+func (v *NamespaceValidator) isInAllowList(namespace string) bool {
+	for _, entry := range v.allowList {
+		// If entry ends with hyphen, treat as prefix match only, otherwise use exact match.
+		if strings.HasSuffix(entry, "-") {
+			if strings.HasPrefix(namespace, entry) {
+				return true
+			}
+		} else if namespace == entry {
+			return true
+		}
+	}
+
+	return false
+}
+
+func parseListStr(listStr string) []string {
+	var retList []string
+
+	if listStr != "" {
+		list := strings.Split(listStr, ",")
+		retList = make([]string, 0, len(list))
+
+		// Trim whitespace from each entry
+		for i := range list {
+			s := strings.TrimSpace(list[i])
+			if s != "" {
+				retList = append(retList, s)
+			}
+		}
+	}
+
+	return retList
 }

--- a/pkg/agent/controller/namespace_validator_test.go
+++ b/pkg/agent/controller/namespace_validator_test.go
@@ -46,8 +46,8 @@ var _ = Describe("NamespaceValidator", func() {
 		validator = controller.NewNamespaceValidator()
 	})
 
-	Context("with no configured deny list", func() {
-		It("should use the default deny list", func() {
+	Context("with no configured deny and allow lists", func() {
+		It("should use the defaults", func() {
 			Expect(validator.CheckAllowed("kube-system")).NotTo(Succeed())
 			Expect(validator.CheckAllowed("kube-public")).NotTo(Succeed())
 			Expect(validator.CheckAllowed("kube-node-lease")).NotTo(Succeed())
@@ -60,6 +60,7 @@ var _ = Describe("NamespaceValidator", func() {
 			Expect(validator.CheckAllowed("production")).To(Succeed())
 			Expect(validator.CheckAllowed("my-openshift-app")).To(Succeed())
 			Expect(validator.CheckAllowed("test-kube-demo")).To(Succeed())
+			Expect(validator.CheckAllowed("openshift-storage")).To(Succeed())
 		})
 	})
 
@@ -78,6 +79,45 @@ var _ = Describe("NamespaceValidator", func() {
 
 			Expect(validator.CheckAllowed("defaulttest")).To(Succeed())
 			Expect(validator.CheckAllowed("my-system")).To(Succeed())
+		})
+	})
+
+	Context("with allow list overriding deny list", func() {
+		BeforeEach(func() {
+			configMap = &corev1.ConfigMap{
+				Data: map[string]string{
+					controller.ConfigKeyImportNamespaceDenyList:  "app-,deny-override",
+					controller.ConfigKeyImportNamespaceAllowList: "app-allow,deny-override",
+				},
+			}
+		})
+
+		It("should allow exceptions to the deny list", func() {
+			Expect(validator.CheckAllowed("app-allow")).To(Succeed())
+			Expect(validator.CheckAllowed("app-disallow")).NotTo(Succeed())
+			Expect(validator.CheckAllowed("my-app")).To(Succeed())
+			Expect(validator.CheckAllowed("deny-override")).To(Succeed())
+		})
+	})
+
+	Context("with allow list using prefix matching", func() {
+		BeforeEach(func() {
+			configMap = &corev1.ConfigMap{
+				Data: map[string]string{
+					controller.ConfigKeyImportNamespaceDenyList:  "kube-, openshift-",
+					controller.ConfigKeyImportNamespaceAllowList: "openshift-storage, kube-public-",
+				},
+			}
+		})
+
+		It("should allow prefixes that override deny list", func() {
+			Expect(validator.CheckAllowed("openshift-storage")).To(Succeed())
+			Expect(validator.CheckAllowed("kube-public-test")).To(Succeed())
+			Expect(validator.CheckAllowed("kube-public-demo")).To(Succeed())
+
+			Expect(validator.CheckAllowed("openshift-console")).NotTo(Succeed())
+			Expect(validator.CheckAllowed("kube-system")).NotTo(Succeed())
+			Expect(validator.CheckAllowed("kube-public")).NotTo(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
Adds `import-namespace-allow-list` configuration to allow specific namespaces that would otherwise be denied by the deny list. The allow list acts as an exception mechanism, overriding deny list matches.

With default deny list (_kube-_, _openshift-_, _openshift_) and new default allow list (_openshift-storage_), _openshift-storage_ is now permitted by default while other openshift-* namespaces remain denied.

Both exact match and prefix match (ending with -) are supported in the allow list, consistent with deny list behavior.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable namespace allowlists alongside denylists.
  * Allowlist entries can override matching denylist rules, including supported prefix matches.
  * Added `openshift-storage` as a permitted default namespace.
* **Bug Fixes**
  * Improved configuration parsing by trimming whitespace and ignoring empty entries.
  * Preserved validation for empty namespaces and denied imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->