### PR TITLE
Automated backport of #2282: Add namespace allow list configuration

### DIFF
--- a/pkg/agent/controller/namespace_validator.go
+++ b/pkg/agent/controller/namespace_validator.go
@@ -31,19 +31,23 @@ import (
 )
 
 const (
-	ConfigKeyImportNamespaceDenyList = "import-namespace-deny-list"
-	DefaultImportNamespaceDenyList   = "kube-,openshift-,openshift"
+	ConfigKeyImportNamespaceAllowList = "import-namespace-allow-list"
+	ConfigKeyImportNamespaceDenyList  = "import-namespace-deny-list"
+	DefaultImportNamespaceDenyList    = "kube-,openshift-,openshift"
+	DefaultImportNamespaceAllowList   = "openshift-storage"
 )
 
-// NamespaceValidator validates broker-supplied namespace labels against a configurable denylist.
+// NamespaceValidator validates broker-supplied namespace labels against a configurable allowlist and denylist.
 type NamespaceValidator struct {
-	denyList []string
+	allowList []string
+	denyList  []string
 }
 
-// NewNamespaceValidator creates a validator using the configured denylist from ConfigMap.
-// If not configured, uses DefaultImportNamespaceDenyList.
+// NewNamespaceValidator creates a validator using the configured allowlist and denylist from ConfigMap.
+// If not configured, uses DefaultImportNamespaceDenyList and DefaultImportNamespaceAllowList.
 func NewNamespaceValidator(dynClient dynamic.Interface) *NamespaceValidator {
 	denyListStr := DefaultImportNamespaceDenyList
+	allowListStr := DefaultImportNamespaceAllowList
 
 	obj, err := dynClient.Resource(corev1.SchemeGroupVersion.WithResource("configmaps")).Namespace("submariner-operator").Get(
 		context.TODO(), "submariner-lighthouse-agent", metav1.GetOptions{})
@@ -54,23 +58,23 @@ func NewNamespaceValidator(dynClient dynamic.Interface) *NamespaceValidator {
 		if s != "" {
 			denyListStr = s
 		}
+
+		s = cm.Data[ConfigKeyImportNamespaceAllowList]
+		if s != "" {
+			allowListStr = s
+		}
 	} else if err != nil && !apierrors.IsNotFound(err) {
 		logger.Errorf(err, "Failed to get submariner-lighthouse-agent configmap")
 	}
 
-	var denyList []string
-	if denyListStr != "" {
-		denyList = strings.Split(denyListStr, ",")
-		// Trim whitespace from each entry
-		for i := range denyList {
-			denyList[i] = strings.TrimSpace(denyList[i])
-		}
-	}
+	denyList := parseListStr(denyListStr)
+	allowList := parseListStr(allowListStr)
 
-	logger.Infof("Namespace validator using deny list: %v", denyList)
+	logger.Infof("Namespace validator using allow list: %v, deny list: %v", allowList, denyList)
 
 	return &NamespaceValidator{
-		denyList: denyList,
+		allowList: allowList,
+		denyList:  denyList,
 	}
 }
 
@@ -87,19 +91,59 @@ func (v *NamespaceValidator) CheckAllowed(namespace string) error {
 
 	// Check against denylist
 	for _, entry := range v.denyList {
-		if entry == "" {
-			continue
-		}
-
 		// If entry ends with hyphen, treat as prefix match only, otherwise use exact match.
 		if strings.HasSuffix(entry, "-") {
 			if strings.HasPrefix(namespace, entry) {
+				// Check if allow list overrides this denial
+				if v.isInAllowList(namespace) {
+					return nil
+				}
+
 				return errors.Errorf("namespace %q matches denied prefix %q", namespace, entry)
 			}
 		} else if namespace == entry {
+			// Check if allow list overrides this denial
+			if v.isInAllowList(namespace) {
+				return nil
+			}
+
 			return errors.Errorf("namespace %q is denied (matches %q)", namespace, entry)
 		}
 	}
 
 	return nil
+}
+
+func (v *NamespaceValidator) isInAllowList(namespace string) bool {
+	for _, entry := range v.allowList {
+		// If entry ends with hyphen, treat as prefix match only, otherwise use exact match.
+		if strings.HasSuffix(entry, "-") {
+			if strings.HasPrefix(namespace, entry) {
+				return true
+			}
+		} else if namespace == entry {
+			return true
+		}
+	}
+
+	return false
+}
+
+func parseListStr(listStr string) []string {
+	var retList []string
+
+	if listStr != "" {
+		list := strings.Split(listStr, ",")
+		retList = make([]string, 0, len(list))
+
+		// Trim whitespace from each entry
+		for i := range list {
+			s := strings.TrimSpace(list[i])
+			if s != "" {
+				retList = append(retList, s)
+			}
+		}
+	}
+
+	return retList
 }

--- a/pkg/agent/controller/namespace_validator_test.go
+++ b/pkg/agent/controller/namespace_validator_test.go
@@ -54,8 +54,8 @@ var _ = Describe("NamespaceValidator", func() {
 		validator = controller.NewNamespaceValidator(dynClient)
 	})
 
-	Context("with no configured deny list", func() {
-		It("should use the default deny list", func() {
+	Context("with no configured deny and allow lists", func() {
+		It("should use the defaults", func() {
 			Expect(validator.CheckAllowed("kube-system")).NotTo(Succeed())
 			Expect(validator.CheckAllowed("kube-public")).NotTo(Succeed())
 			Expect(validator.CheckAllowed("kube-node-lease")).NotTo(Succeed())
@@ -68,6 +68,7 @@ var _ = Describe("NamespaceValidator", func() {
 			Expect(validator.CheckAllowed("production")).To(Succeed())
 			Expect(validator.CheckAllowed("my-openshift-app")).To(Succeed())
 			Expect(validator.CheckAllowed("test-kube-demo")).To(Succeed())
+			Expect(validator.CheckAllowed("openshift-storage")).To(Succeed())
 		})
 	})
 
@@ -87,6 +88,47 @@ var _ = Describe("NamespaceValidator", func() {
 
 			Expect(validator.CheckAllowed("defaulttest")).To(Succeed())
 			Expect(validator.CheckAllowed("my-system")).To(Succeed())
+		})
+	})
+
+	Context("with allow list overriding deny list", func() {
+		BeforeEach(func() {
+			configMap = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "submariner-lighthouse-agent"},
+				Data: map[string]string{
+					controller.ConfigKeyImportNamespaceDenyList:  "app-,deny-override",
+					controller.ConfigKeyImportNamespaceAllowList: "app-allow,deny-override",
+				},
+			}
+		})
+
+		It("should allow exceptions to the deny list", func() {
+			Expect(validator.CheckAllowed("app-allow")).To(Succeed())
+			Expect(validator.CheckAllowed("app-disallow")).NotTo(Succeed())
+			Expect(validator.CheckAllowed("my-app")).To(Succeed())
+			Expect(validator.CheckAllowed("deny-override")).To(Succeed())
+		})
+	})
+
+	Context("with allow list using prefix matching", func() {
+		BeforeEach(func() {
+			configMap = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "submariner-lighthouse-agent"},
+				Data: map[string]string{
+					controller.ConfigKeyImportNamespaceDenyList:  "kube-, openshift-",
+					controller.ConfigKeyImportNamespaceAllowList: "openshift-storage, kube-public-",
+				},
+			}
+		})
+
+		It("should allow prefixes that override deny list", func() {
+			Expect(validator.CheckAllowed("openshift-storage")).To(Succeed())
+			Expect(validator.CheckAllowed("kube-public-test")).To(Succeed())
+			Expect(validator.CheckAllowed("kube-public-demo")).To(Succeed())
+
+			Expect(validator.CheckAllowed("openshift-console")).NotTo(Succeed())
+			Expect(validator.CheckAllowed("kube-system")).NotTo(Succeed())
+			Expect(validator.CheckAllowed("kube-public")).NotTo(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
Backport of #2282 on release-0.20.

#2282: Add namespace allow list configuration

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.